### PR TITLE
Correct german translation for 'altitude' (in colour legend)

### DIFF
--- a/thlang/texts.txt
+++ b/thlang/texts.txt
@@ -2529,7 +2529,7 @@ zh_CN: 图例
 therion: title color-legend-altitude
 bg: Височинна скала
 cz: Nadmořské výšky
-de: Höhe des Titelfeldes
+de: Höhe
 el: Υψομετρικά
 en: Altitudes
 es: color (altitud)


### PR DESCRIPTION
The current translation is literally "Height of the title field".

Origin: Markus Boldt <markus.boldt@gmx.net> (therion list)