### PR TITLE
Fix block/indent mismatch

### DIFF
--- a/thparse.cxx
+++ b/thparse.cxx
@@ -368,11 +368,11 @@ void thsplit_args(thmbuffer * dest, const char * src)
         dest->appendn("",0);
       break;
     case 3:
-      if (idx > (idx0 + 1))
+      if (idx > (idx0 + 1)) {
         postp_ptr = dest->appendn((char *) s1 + 1, idx - idx0 - 1);
         if (postp_quotes)
           thsplit_args_postp_quotes(postp_ptr);
-      else
+      } else
         dest->appendn("",0);
       break;
   }


### PR DESCRIPTION
Discovered thanks to warning from GCC 6.3.

The patch here makes the block match the indent, which looks more correct to me (the alternative would be to outdent lines 373-374 one level to reflect the actual block structure).

But I don't really follow this code, beyond that it seems to be for splitting up args when there's an unterminated "["..."]", so please review to make sure this is actually an appropriate change.
