### PR TITLE
Regularise indentation to use spaces

### DIFF
--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -673,7 +673,7 @@ void lxFrame::OnAll(wxCommandEvent& event)
           } else {
             this->m_fileName = dialog.GetPath();
             this->m_fileDir  = dialog.GetDirectory();
-						this->m_fileType = 0;
+            this->m_fileType = 0;
             this->DetectFileType();
             this->ReloadData();
             this->setup->ResetCamera();

--- a/thdataleg.h
+++ b/thdataleg.h
@@ -449,11 +449,11 @@ class thdataleg {
   void calc_total_stds();
 
 
-	/**
-	 * Export station attributes to metapost.
-	 */
+  /**
+   * Export station attributes to metapost.
+   */
 
-	void export_mp_flags(FILE * out);
+  void export_mp_flags(FILE * out);
 
   
 };

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -73,7 +73,7 @@ thdb1d::thdb1d()
 
 void thdb1ds::export_mp_flags(FILE * out)
 {
-	fprintf(out, "ATTR__stationflag_splay := %s;\n", (this->is_temporary() ? "true" : "false"));
+  fprintf(out, "ATTR__stationflag_splay := %s;\n", (this->is_temporary() ? "true" : "false"));
 }
 
 void thdb1ds::set_temporary(const char * name)
@@ -123,7 +123,7 @@ void thdb1d::scan_data()
   int lastleggridmccs = TTCS_LOCAL;
   thdata * dp;
   unsigned used_declination = 0;
-	unsigned long prevlsid;
+  unsigned long prevlsid;
   double dcc, sindecl, cosdecl, tmpx, tmpy;
   thdb1ds * tsp1, * tsp2;  // Temporary stations.
   this->min_year = thnan;
@@ -428,7 +428,7 @@ void thdb1d::scan_data()
     obi++;
   }
 
-	// process equates separately
+  // process equates separately
   obi = this->db->object_list.begin();
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
@@ -437,10 +437,10 @@ void thdb1d::scan_data()
       eqi = dp->equate_list.begin();
       try {
         while(eqi != dp->equate_list.end()) {
-					prevlsid = this->lsid;
+          prevlsid = this->lsid;
           eqi->station.id = this->insert_station(eqi->station, eqi->psurvey, dp, 1);
-					if ((prevlsid < eqi->station.id) && (eqi->station.survey != NULL))
-						thwarning(("%s [%d] -- equate used to define new station (%s@%s)", eqi->srcf.name, eqi->srcf.line, eqi->station.name, eqi->station.survey));
+          if ((prevlsid < eqi->station.id) && (eqi->station.survey != NULL))
+            thwarning(("%s [%d] -- equate used to define new station (%s@%s)", eqi->srcf.name, eqi->srcf.line, eqi->station.name, eqi->station.survey));
           eqi++;
         }
       }

--- a/thdb1d.h
+++ b/thdb1d.h
@@ -198,11 +198,11 @@ class thdb1ds {
    */
   void set_temporary(const char * name);
 
-	/**
-	 * Export station attributes to metapost.
-	 */
+  /**
+   * Export station attributes to metapost.
+   */
 
-	void export_mp_flags(FILE * out);
+  void export_mp_flags(FILE * out);
   
 };
 

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -2725,7 +2725,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
           commentstr += " etex";
         }
         this->db->db1d.m_station_attr.export_mp_object_begin(out->file, slp->station_name.id);
-				slp->station->export_mp_flags(out->file);
+        slp->station->export_mp_flags(out->file);
         out->symset->export_mp_symbol_options(out->file, macroid);
         fprintf(out->file,"p_station((%.2f,%.2f),%d,%s,\"\"",
           thxmmxst(out, slp->stx, slp->sty),
@@ -2816,19 +2816,19 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
             if (expstation) {
               if (obj->export_mp(noout)) {
                 thexpmap_export_mp_bgif;
-								if (ptp->station_name.id != 0) {
+                if (ptp->station_name.id != 0) {
                   tmps = &(thdb.db1d.station_vec[ptp->station_name.id - 1]);
-									tmps->export_mp_flags(out->file);
-					        this->db->db1d.m_station_attr.export_mp_object_begin(out->file, ptp->station_name.id);
-								} else
-									tmps = NULL;
+                  tmps->export_mp_flags(out->file);
+                  this->db->db1d.m_station_attr.export_mp_object_begin(out->file, ptp->station_name.id);
+                } else
+                  tmps = NULL;
                 obj->export_mp(out);
-								if (tmps != NULL) {
-					        this->db->db1d.m_station_attr.export_mp_object_end(out->file, ptp->station_name.id);
-								}
+                if (tmps != NULL) {
+                  this->db->db1d.m_station_attr.export_mp_object_end(out->file, ptp->station_name.id);
+                }
                 if (out->layout->is_debug_stationnames() && (tmps != NULL)) {
-					  out->symset->export_mp_symbol_options(&dbg_stnms, SYMP_STATIONNAME);
-					  dbg_stnms.appspf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, 7);\n",
+                      out->symset->export_mp_symbol_options(&dbg_stnms, SYMP_STATIONNAME);
+                      dbg_stnms.appspf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, 7);\n",
                       (const char *) utf2tex(thobjectname__print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
                       thxmmxst(out, ptp->point->xt, ptp->point->yt));
                 }

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -479,7 +479,7 @@ void thexpmodel::export_thm_file(class thdatabase * dbp)
   thdb_object_list_type::iterator obi;
   thdb3ddata * pgn = dbp->db1d.get_3d(), 
     * surf_pgn = dbp->db1d.get_3d_surface(),
-		* splay_pgn = dbp->db1d.get_3d_splay(),
+    * splay_pgn = dbp->db1d.get_3d_splay(),
     * tmp3d;
   thdb3dlim pgnlimits, finlim;
   switch (this->items & TT_EXPMODEL_ITEM_CENTERLINE) {
@@ -654,7 +654,7 @@ void thexpmodel::export_vrml_file(class thdatabase * dbp) {
   thdb_object_list_type::iterator obi;
   thdb3ddata * pgn = dbp->db1d.get_3d(), 
     * surf_pgn = dbp->db1d.get_3d_surface(),
-		* splay_pgn = dbp->db1d.get_3d_splay(),
+    * splay_pgn = dbp->db1d.get_3d_splay(),
     * tmp3d;
   thdb3dlim pgnlimits, finlim;
   switch (this->items & TT_EXPMODEL_ITEM_CENTERLINE) {
@@ -668,8 +668,8 @@ void thexpmodel::export_vrml_file(class thdatabase * dbp) {
     default:    
       pgnlimits.update(&(pgn->limits));
   }
-	if ((this->items & TT_EXPMODEL_ITEM_SPLAYSHOTS) != 0)
-		pgnlimits.update(&(splay_pgn->limits));
+  if ((this->items & TT_EXPMODEL_ITEM_SPLAYSHOTS) != 0)
+    pgnlimits.update(&(splay_pgn->limits));
 
   finlim.update(&(pgnlimits));
   // now let's print header
@@ -908,7 +908,7 @@ void thexpmodel::export_3dmf_file(class thdatabase * dbp) {
   thdb_object_list_type::iterator obi;
   thdb3ddata * pgn = dbp->db1d.get_3d(), 
     * surf_pgn = dbp->db1d.get_3d_surface(),
-		* splay_pgn = dbp->db1d.get_3d_splay(),
+    * splay_pgn = dbp->db1d.get_3d_splay(),
     * tmp3d;
   thdb3dlim pgnlimits, finlim;
   switch (this->items & TT_EXPMODEL_ITEM_CENTERLINE) {
@@ -922,8 +922,8 @@ void thexpmodel::export_3dmf_file(class thdatabase * dbp) {
     default:    
       pgnlimits.update(&(pgn->limits));
   }
-	if ((this->items & TT_EXPMODEL_ITEM_SPLAYSHOTS) != 0)
-		pgnlimits.update(&(splay_pgn->limits));
+  if ((this->items & TT_EXPMODEL_ITEM_SPLAYSHOTS) != 0)
+    pgnlimits.update(&(splay_pgn->limits));
   finlim.update(&(pgnlimits));
   avx = (pgnlimits.minx + pgnlimits.maxx) / 2.0;
   avy = (pgnlimits.miny + pgnlimits.maxy) / 2.0;
@@ -1128,8 +1128,8 @@ void thexpmodel::export_dxf_file(class thdatabase * dbp) {
     default:    
       pgnlimits.update(&(pgn->limits));
   }
-	if ((this->items & TT_EXPMODEL_ITEM_SPLAYSHOTS) != 0)
-		pgnlimits.update(&(splay_pgn->limits));
+  if ((this->items & TT_EXPMODEL_ITEM_SPLAYSHOTS) != 0)
+    pgnlimits.update(&(splay_pgn->limits));
   finlim.update(&(pgnlimits));
   avx = 0.0;
   avy = 0.0;

--- a/thscrap.cxx
+++ b/thscrap.cxx
@@ -872,12 +872,12 @@ void thscrap::calc_z()
 {
   thdb2dcp * cp = this->fcpp;
   this->z = 0.0;
-	this->a = 0.0;
+  this->a = 0.0;
   unsigned long numcp = 0;
   while(cp != NULL) {
     if (cp->st != NULL) {
       this->z += cp->tz;
-			this->a += cp->ta;
+      this->a += cp->ta;
       numcp++;
     }
     cp = cp->nextcp;


### PR DESCRIPTION
Currently some tabs seem to be meant to be 2 spaces wide, while other
tabs (sometimes even in the same file, e.g. thexpmap.cxx) seem to be
meant to be 4 spaces wide.

Space-only indentation seems to be dominant in the code, and
standardising on that makes the source easier to work with without
having to set a non-standard tab width in editors.

This patch doesn't eliminate all tab indentation - it's split out of
a "miscellaneous whitespace" patch Wookey has in the Debian packaging
(debian/patches/*therion-5.3.12-whitespace.patch).