### PR TITLE
Whitespace clean-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CMNOBJECTS = thdate.o extern/shpopen.o extern/dbfopen.o \
   extern/lxMath.o extern/lxFile.o thdb3d.o thsurface.o thimport.o thsvg.o thepsparse.o \
   thtrans.o thwarpp.o thwarppt.o thwarppme.o thwarp.o thexpshp.o thattr.o thtex.o \
   extern/poly2tri/common/shapes.o extern/poly2tri/sweep/advancing_front.o extern/poly2tri/sweep/sweep.o extern/poly2tri/sweep/cdt.o extern/poly2tri/sweep/sweep_context.o \
-  therion.o extern/proj4/libproj.a 
+  therion.o extern/proj4/libproj.a
 
 CROSS =
 EXT =
@@ -55,7 +55,7 @@ THXTHMKCMD = ./therion
 # PLATFORM WIN32
 ##CXX = c++
 ##CC = gcc
-##POBJECTS = extern/getopt.o extern/getopt1.o therion.res extern/getline.o 
+##POBJECTS = extern/getopt.o extern/getopt1.o therion.res extern/getline.o
 ##LOCHEXE = loch/loch
 ##CXXPFLAGS = -DTHWIN32
 ##CCPFLAGS = -DTHWIN32
@@ -70,7 +70,7 @@ THXTHMKCMD = ./therion
 ##CXX = $(CROSS)c++
 ##export CC = $(CROSS)gcc
 ##export AR = $(CROSS)ar
-##POBJECTS = extern/getopt.o extern/getopt1.o therion.res extern/getline.o 
+##POBJECTS = extern/getopt.o extern/getopt1.o therion.res extern/getline.o
 ##LOCHEXE = loch/loch
 ##CXXPFLAGS = -DTHWIN32
 ##CCPFLAGS = -DTHWIN32
@@ -106,14 +106,14 @@ CXXBFLAGS = -O2
 LDBFLAGS = $(LDPFLAGS)
 
 # BUILD RELEASE
-##CCBFLAGS = 
-##CXXBFLAGS = 
+##CCBFLAGS =
+##CXXBFLAGS =
 ##LDBFLAGS = $(LDPFLAGS)
 
 # BUILD DEBUG
 ##CCBFLAGS = -ggdb
 ##CXXBFLAGS = -ggdb -DTHDEBUG
-##LDBFLAGS = 
+##LDBFLAGS =
 
 # BUILD ENDCONFIG
 
@@ -125,7 +125,7 @@ OBJECTS = $(addprefix $(OUTDIR)/,$(POBJECTS)) $(addprefix $(OUTDIR)/,$(CMNOBJECT
 
 
 # linker settings
-LIBS = 
+LIBS =
 LDFLAGS = $(LDBFLAGS)
 
 
@@ -152,7 +152,7 @@ $(OUTDIR)/extern/proj4/libproj.a: extern/proj4/*.c extern/proj4/*.h
 	make -C ./extern/proj4
 
 $(OUTDIR)/therion:	$(OBJECTS)
-	$(CXX) -Wall -o $(OUTDIR)/therion$(EXT) $(OBJECTS) $(LDFLAGS) $(LIBS) 
+	$(CXX) -Wall -o $(OUTDIR)/therion$(EXT) $(OBJECTS) $(LDFLAGS) $(LIBS)
 
 
 $(OUTDIR)/therion.res: therion.rc
@@ -176,7 +176,7 @@ release: clean
 
 binary: all doc
 	perl makebinary.pl $(THPLATFORM)
-  
+
 depend:
 	perl makedepend.pl > Makefile.dep
 	perl maketest.pl Makefile.dep
@@ -209,11 +209,11 @@ samples: $(OUTDIR)/samples.doc/index.tex
 $(OUTDIR)/samples.doc/index.tex:
 	make -C samples
 	touch thbook/version.tex
-	make -C thbook    
+	make -C thbook
 
 $(OUTDIR)/thbook/thbook.pdf: thbook/*.tex
 	make -C thbook
-  
+
 clean:
 	make -C ./xtherion clean
 	make -C ./loch clean
@@ -244,7 +244,7 @@ thmpost.cxx: mpost/*.mp
 
 thsymbolsetlist.h: thsymbolsetlist.pl mpost/thTrans.mp
 	perl thsymbolsetlist.pl
-  
+
 thtex.h: tex/*.tex
 	make -C ./tex
 
@@ -256,20 +256,20 @@ thchencdata.h: thchencdata/*.TXT
 
 thcsdata.h: thcsdata.tcl
 	tclsh thcsdata.tcl
-  
+
 update:
 	make -C ./thlang update
 
 unixify: clean
 	tclsh makeunixify.tcl
-  
+
 thlangdata.h: thlang/texts.txt
 	make -C ./thlang
 
 config-debug:
 	perl makeconfig.pl BUILD DEBUG
 	make -C ./loch config-debug
-  
+
 config-release:
 	perl makeconfig.pl BUILD RELEASE
 	make -C ./loch config-release
@@ -277,7 +277,7 @@ config-release:
 config-oxygen:
 	perl makeconfig.pl BUILD OXYGEN
 	make -C ./loch config-oxygen
-  
+
 config-ozone:
 	perl makeconfig.pl BUILD OZONE
 	make -C ./loch config-ozone
@@ -285,11 +285,11 @@ config-ozone:
 config-debian:
 	perl makeconfig.pl PLATFORM DEBIAN
 	make -C ./loch config-debian
-  
+
 config-linux:
 	perl makeconfig.pl PLATFORM LINUX
 	make -C ./loch config-linux
-  
+
 config-win32:
 	perl makeconfig.pl PLATFORM WIN32
 	make -C ./loch config-win32
@@ -297,7 +297,7 @@ config-win32:
 config-win32cross:
 	perl makeconfig.pl PLATFORM WIN32CROSS
 	make -C ./loch config-win32cross
-  
+
 config-macosx:
 	perl makeconfig.pl PLATFORM MACOSX
 	make -C ./loch config-macosx
@@ -305,7 +305,7 @@ config-macosx:
 # external sources
 $(OUTDIR)/extern/lxMath.o: loch/lxMath.h loch/lxMath.cxx
 	$(CXX) -c $(CXXFLAGS) -o $(OUTDIR)/extern/lxMath.o loch/lxMath.cxx
-    
+
 $(OUTDIR)/extern/lxFile.o: loch/lxFile.h loch/lxFile.cxx
 	$(CXX) -c $(CXXFLAGS) -o $(OUTDIR)/extern/lxFile.o loch/lxFile.cxx
 

--- a/loch/Makefile
+++ b/loch/Makefile
@@ -48,7 +48,7 @@ STRIPFLAG = -s
 ##CXXPFLAGS = -DLXLINUX $(shell wx-config --cxxflags) -Wno-deprecated $(shell freetype-config --cflags) -I$(VTKPATH)
 ##CCPFLAGS = -DLXLINUX  $(shell wx-config --cflags)
 ##LXLIBDIR = linux
-##PLIBS = $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS) -lGLU -lGL -lpthread -lX11 -lz 
+##PLIBS = $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS) -lGLU -lGL -lpthread -lX11 -lz
 ##LXPLATFORM = LINUX
 
 # PLATFORM DEBIAN
@@ -63,7 +63,7 @@ endif
 CXXPFLAGS = -DLXLINUX $(shell wx-config --cxxflags) -Wno-deprecated $(shell freetype-config --cflags) -I$(VTKPATH)
 CCPFLAGS = -DLXLINUX  $(shell wx-config --cflags)
 LXLIBDIR = linux
-PLIBS = $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS) -lGLU -lGL -lpthread -lX11 -lz 
+PLIBS = $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS) -lGLU -lGL -lpthread -lX11 -lz
 LXPLATFORM = LINUX
 
 # PLATFORM WIN32
@@ -88,7 +88,7 @@ LXPLATFORM = LINUX
 ##POBJECTS = loch.res lxR2D.o getline.o
 ##CXXPFLAGS = -W -Wall -std=gnu++11 -DLXWIN32 $(shell $(CROSS)wx-config --static --cxxflags) $(shell $(CROSS)freetype-config --cflags) -I$(VTKPATH) -Wno-deprecated
 ##CCPFLAGS = -W -Wall -DLXWIN32 $(shell $(CROSS)wx-config --static --cflags)
-##LXLIBDIR = 
+##LXLIBDIR =
 ##PLIBS = $(shell $(CROSS)freetype-config --libs) $(shell $(CROSS)wx-config --static --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS)
 ##LXPLATFORM = WIN32
 ##STRIPFLAG = -static-libgcc -static -s
@@ -96,10 +96,10 @@ LXPLATFORM = LINUX
 # PLATFORM MACOSX
 ##CXX = c++
 ##CC = cc
-##POBJECTS = 
+##POBJECTS =
 ##CXXPFLAGS = -W -Wall -DLXMACOSX $(shell wx-config --cxxflags) $(shell freetype-config --cflags) -I$(VTKPATH) -Wno-deprecated -I/usr/X11R6/include -I/usr/X11R6/include/freetype2
 ##CCPFLAGS = -W -Wall -DLXMACOSX $(shell wx-config --cflags) -I/usr/X11R6/include
-##LXLIBDIR = 
+##LXLIBDIR =
 ##PLIBS = -lz -L/usr/X11R6/lib $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS)
 ##POSTMAKE = cp -f ./loch ./loch.app/Contents/MacOS
 ##STRIPFLAG =
@@ -120,14 +120,14 @@ CXXBFLAGS = -O2
 LDBFLAGS = $(STRIPFLAG)
 
 # BUILD RELEASE
-##CCBFLAGS = 
-##CXXBFLAGS = 
+##CCBFLAGS =
+##CXXBFLAGS =
 ##LDBFLAGS = $(STRIPFLAG)
 
 # BUILD DEBUG
 ##CCBFLAGS = -ggdb
 ##CXXBFLAGS = -ggdb -DLXDEBUG
-##LDBFLAGS = 
+##LDBFLAGS =
 
 # BUILD ENDCONFIG
 
@@ -165,7 +165,7 @@ $(LOUTDIR)/loch: $(OBJECTS)
 $(LOUTDIR)/loch.res: loch.rc loch.ico
 	$(CROSS)windres -i loch.rc $(shell $(CROSS)wx-config --cflags | tr ' ' '\n' | grep "^-I" | tr '\n' ' ') -J rc -o $(LOUTDIR)/loch.res -O coff
 
-graphs: 
+graphs:
 	dot -Tps graph-vispipe.dot -o graph-vispipe.ps
 
 
@@ -176,40 +176,40 @@ depend:
 	$(CXX) -DLXDEPCHECK -DLOCH -MM *.cxx >> Makefile
 	$(CC) -DLXDEPCHECK -DLOCH -MM *.c >> Makefile
 	perl makedepend2.pl
-  
+
 
 config-debug:
 	perl makeconfig.pl BUILD DEBUG
 
 test-release:
 	zip -9 loch.zip loch.exe test.th test.jpg thconfig
-  
+
 config-release:
 	perl makeconfig.pl BUILD RELEASE
 
 config-oxygen:
 	perl makeconfig.pl BUILD OXYGEN
-  
+
 config-ozone:
 	perl makeconfig.pl BUILD OZONE
-  
+
 config-linux:
 	perl makeconfig.pl PLATFORM LINUX
 
 config-debian:
 	perl makeconfig.pl PLATFORM DEBIAN
-  
+
 config-win32:
 	perl makeconfig.pl PLATFORM WIN32
 
 config-win32cross:
 	perl makeconfig.pl PLATFORM WIN32CROSS
-  
+
 config-macosx:
 	perl makeconfig.pl PLATFORM MACOSX
 
 clean:
-	perl makefile.pl rm -q *~     
+	perl makefile.pl rm -q *~
 	perl makefile.pl rm -q help/*/*~
 	perl makefile.pl rm -q loch.exe
 	perl makefile.pl rm -q loch
@@ -223,7 +223,7 @@ clean:
 	perl makefile.pl rm -q *.zip
 	perl makefile.pl rm -q *.pdf
 	perl makefile.pl rm -q *.png
-  
+
 
 
 # DEPENDENCIES


### PR DESCRIPTION
Removes trailing whitespace from makefiles.

Split out of patch from Wookey in Debian packaging
(debian/patches/*therion-5.3.12-whitespace.patch).