### PR TITLE
Sync divergent docs of therion command line

### DIFF
--- a/man/therion.1
+++ b/man/therion.1
@@ -1,17 +1,23 @@
-.TH "THERION" "1" "2003/07/15"
+.TH "THERION" "1" "2017/01/25"
 .SH "NAME" 
 Therion \(em program to draw cave surveys 
 .SH "SYNOPSIS" 
 .PP 
-\fBtherion\fP [\fB-q\fP] [\fB-L\fP] [\fB-l \fIlog-file\fR]  
-        [\fB-s \fIsource file\fR] [\fB-p \fIsearch path\fR]  
-        [\fB-g\fP|\fB-u\fP] [\fB-i\fP] [\fB-d\fP] [\fB-x\fP] [config-file]
+\fBtherion\fP [\fB-q\fP] [\fB-L\fP] [\fB-l \fIlog-file\fR]
+        [\fB-s \fIsource-file\fR] [\fB-p \fIsearch-path\fR]
+        [\fB-b\fP|\fB--bezier\fP] [\fB--use-extern-libs\fP]
+        [\fB-g\fP|\fB-u\fP] [\fB-i\fP]
+        [\fB-d\fP] [\fB-x\fP] [\fB--use-extern-libs\fP] [config-file]
 .PP
 \fBtherion\fP [\fB-h\fP|\fB--help\fP]
         [\fB-v\fP|\fB--version\fP]
-        [\fB--print-encodings\fP]  
-        [\fB--print-tex-encodings\fP]  
-        [\fB--print-init-file\fP]  
+        [\fB--print-encodings\fP]
+        [\fB--print-environment\fP]
+        [\fB--print-init-file\fP]
+        [\fB--print-library-src\fP]
+        [\fB--print-symbols\fP]
+        [\fB--print-tex-encodings\fP]
+        [\fB--print-xtherion-src\fP]
 .SH "DESCRIPTION" 
 .PP 
 This manual page briefly documents \fBTherion\fP and provides an overview of 

--- a/thbook/ch03.tex
+++ b/thbook/ch03.tex
@@ -635,6 +635,7 @@ The full syntax is
 
 |therion [-q] [-L] [-l <log-file>]
         [-s <source-file>] [-p <search-path>]
+        [-b/--bezier]
         [-d] [-x] [--use-extern-libs] [<cfg-file>]|
 
 or
@@ -642,10 +643,12 @@ or
 |therion [-h/--help]
         [-v/--version]
         [--print-encodings]
-        [--print-tex-encodings]
-        [--print-init-file]
         [--print-environment]
-        [--print-symbols]|
+        [--print-init-file]
+        [--print-library-src]
+        [--print-symbols]
+        [--print-tex-encodings]
+        [--print-xtherion-src]|
 
 \penalty-200
 \arguments

--- a/thcmdline.cxx
+++ b/thcmdline.cxx
@@ -142,9 +142,9 @@ void thcmdline::process(int argc, char * argv[])
       //  thcfg.set_file_state(THCFG_UPDATE);
       //  break;
         
-      case 'i':
-        thcfg.comments_skip_on();
-        break;
+      //case 'i':
+      //  thcfg.comments_skip_on();
+      //  break;
         
       case 's':     
         thcfg.append_source(optarg);

--- a/therion.cxx
+++ b/therion.cxx
@@ -67,14 +67,17 @@ char * thexecute_cmd = NULL;
 const char * thhelp_text =
       "\ntherion [-q] [-L] [-l log-file]\n"
       "\t[-s source-file] [-p search-path]\n"
+      "\t[-b|--bezier]\n"
       "\t[-d] [-x] [cfg-file]\n\n"
       "therion [-h|--help]\n"
       "        [-v|--version]\n"
       "        [--print-encodings]\n"
-      "        [--print-init-file]\n"
-      "        [--print-tex-encodings]\n"
       "        [--print-environment]\n"
-      "        [--print-symbols]\n\n";
+      "        [--print-init-file]\n"
+      "        [--print-library-src]\n"
+      "        [--print-symbols]\n"
+      "        [--print-tex-encodings]\n"
+      "        [--print-xtherion-src]\n\n";
 
 const char * thversion_text = THVERSION;
 const char * thversion_format = "therion %s";


### PR DESCRIPTION
Make the man page, --help output, and text in thbook agree with
reality.

Also comment out handling of '-i' to match the other removed
options '-g' and '-u'.