### PR TITLE
Fix loading of files with no extension in text editor

### DIFF
--- a/xtherion/te.tcl
+++ b/xtherion/te.tcl
@@ -656,7 +656,7 @@ proc xth_te_open_file {dialogid fname fline} {
   if {$dialogid} {
     set fname [tk_getOpenFile -filetypes $xth(app,te,filetypes) \
       -parent $xth(gui,main) \
-      -initialdir $xth(gui,initdir) -defaultextension $xth(app,te,fileext)]
+      -initialdir $xth(gui,initdir) ]
   }
   
   if {[string length $fname] == 0} {


### PR DESCRIPTION
Wookey applied this patch to the Debian package in 5.3.11-1, back
in 2013.