### PR TITLE
Fix loch "make depend"

### DIFF
--- a/loch/Makefile
+++ b/loch/Makefile
@@ -173,7 +173,7 @@ depend:
 	perl makedepend.pl > Makefile.dep
 	perl maketest.pl Makefile.dep
 	perl makefile.pl mv Makefile.dep Makefile
-	$(CXX) -DLXDEPCHECK -DLOCH -MM *.cxx >> Makefile
+	$(CXX) -DLXDEPCHECK -DLOCH -D'wxCHECK_VERSION(X,Y,Z)=1' -MM *.cxx >> Makefile
 	$(CC) -DLXDEPCHECK -DLOCH -MM *.c >> Makefile
 	perl makedepend2.pl
   


### PR DESCRIPTION
Fixes errors such as:

c++ -DLXDEPCHECK -DLOCH -MM *.cxx >> Makefile
lxAboutDlg.cxx:97:20: error: missing binary operator before token "("
 #if wxCHECK_VERSION(3,0,0)