### PR TITLE
MP AUT symbol set: new area flowstone

### DIFF
--- a/mpost/uAUT.mp
+++ b/mpost/uAUT.mp
@@ -1,4 +1,5 @@
 % Austrian Symbol Set, author Georg Pacher
+% enhanced 2017 by Benedikt Hallinger
 
 % color (for Austrian symbol-set)
 
@@ -117,6 +118,13 @@ beginpattern(pattern_ice_AUT);
     draw p shifted (0.0u,0.45u) rotated (90);
     patternxstep(.9u);
     patternystep(0.5u);
+endpattern;
+
+beginpattern(pattern_flowstone_AUT);
+    pickup PenC;
+    draw (0.0u, 0.01u)--(0.33u, 0.01u);
+    draw (0.33u, 0.33u)--(0.66u, 0.33u);
+    patternbbox(0u,0u, 0.66u, 0.66u); % definiert Rechteckgroesse des Symbols
 endpattern;
 
 def a_water_AUT (expr Path) =
@@ -272,6 +280,14 @@ def a_blocks_AUT (expr p) =
   drawoptions();
   draw tmp_pic;
 enddef;  
+
+
+def a_flowstone_AUT (expr Path) =
+  T:=identity;
+  thclean Path;
+  thfill Path withpattern pattern_flowstone_AUT ;
+enddef;
+
 
 
 %% lines

--- a/thlang/texts.txt
+++ b/thlang/texts.txt
@@ -2369,7 +2369,19 @@ zh_CN: 绳子
 therion: line rope
 bg: въже
 cz: lano
+de: Seil
+el: σχοινί
 en: rope
+es: cuerda
+fr: corde
+it: corda
+mi: taura
+pl: lina
+pt: corda
+ru: линейная опора
+sk: lano
+sq: litar
+zh_CN: 绳子
 
 therion: point rope-ladder
 bg: пещерна стълба
@@ -2389,7 +2401,21 @@ sq: shkalle litari
 zh_CN: 绳梯
 
 therion: line rope-ladder
+bg: пещерна стълба
 cz: lanový žebřík
+de: Drahtseilleiter
+el: ανεμόσκαλα
+en: rope ladder
+es: escala
+fr: échelle de corde
+it: scala di corda
+mi: arawhata taura
+pl: drabinka linowa
+pt: escada de corda
+ru: гибкая лестница
+sk: lanový rebrík
+sq: shkalle litari
+zh_CN: 绳梯
 
 therion: point fixed-ladder
 bg: стационарна стълба
@@ -2411,7 +2437,19 @@ zh_CN: 固定梯子
 therion: line fixed-ladder
 bg: стационарна стълба
 cz: pevný žebřík
+de: feste Leiter
+el: μόνιμη σκάλα
 en: fixed ladder
+es: escala fija
+fr: échelle fixe
+it: scala fissa
+mi: arawhata
+pl: sztywna drabinka
+pt: escada fixa
+ru: жесткая лестница
+sk: fixný rebrík
+sq: shkalle fikse
+zh_CN: 固定梯子
 
 therion: point steps
 bg: стъпала
@@ -2433,14 +2471,28 @@ zh_CN: 梯坎
 therion: line steps
 bg: стъпала
 cz: schody
+de: Stufen
+el: σκαλοπάτια
 en: steps
+es: escalones
+fr: marches
+it: scalini
+mi: nga tapuae
+pl: schody
+pt: degraus
+ru: ступени
+sk: schody
+sq: shkalle
+zh_CN: 梯坎
 
 therion: point via-ferrata
 bg: виа-ферата
+de: Klettersteig
 en: via-ferrata
 
 therion: line via-ferrata
 bg: виа-ферата
+de: Klettersteig
 en: via-ferrata
 
 therion: point traverse
@@ -2480,11 +2532,13 @@ zh_CN: 桥
 therion: point handrail
 bg: перила
 cz: zábradlí
+de: Geländer
 en: handrail
 
 therion: line handrail
 bg: перила
 cz: zábradlí
+de: Geländer
 en: handrail
 
 therion: point camp


### PR DESCRIPTION
I added an area:flowstone definition.
The definition is according to VÖH "Speläo Merkblatt B43"
http://hoehle.org/downloads/merkblaetter/einzeln/B43%20Hoehlenplansignaturen.pdf

Initially i added this as a user defined symbol, so i am not sure, this addition is enough to let it show up in the symbol set automatically; however i did an extensive grep-session to try to find if i need to add further code anywhere (especially "initsymbol()") without finding anything.

Sorry for the inconvinience - how can i test this locally?