### PR TITLE
Mp new ladder line symbols

### DIFF
--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -1120,13 +1120,80 @@ def l_handrail_SKBB (expr P) =
 enddef;
 
 def l_fixedladder_SKBB (expr P) = 
-  pickup PenD;
-  draw P withcolor red;
+  pair Pp;
+  pair Pd;
+  pair Pv;
+  T:=identity;
+  cas := 0;                          % loop-variable (current iteration through path)
+  dlzka := arclength P;              % base for iterations (the length of the drawn line)
+  mojkrok:=adjust_step(dlzka, 0.3u); % ammount of iterations / count of individual steps (segments)
+
+  % get shift coordinates based on initial angleof path;
+  % this gets us the left and right rail of the ladder.
+  % PLEASE NOTE: this currently only works properly with straight lines.
+  %              for beziers, the tension points must be recalculated / path shortened+lengthened
+  %              based on next angle in the path.
+  %              Maybe play with http://tex.stackexchange.com/questions/309830/draw-a-curve-as-an-outline-to-another-curve
+  pair offsetLeft;
+  pair offsetRight;
+  offsetLeft  := 0.25u * (dir (angle direction 0.0001 of P-90));
+  offsetRight := 0.25u * (dir (angle direction 0.0001 of P+90));
+  thdraw P shifted offsetLeft;
+  thdraw P shifted offsetRight;
+
+   % draw rungs
+   pickup PenC;
+   forever:
+     t  := arctime (cas + mojkrok/2) of P;
+     Pp := (point t of P);         % center of current step
+     Pd := unitvector(thdir(P,t)); % Point in direction of line (x,y)
+     Pv := Pd rotated 90;          % direction of line, rotated 90° to the right
+
+     % draw one rung segment in direction of the path. Absolute Point coordinates are
+     % calculated from the current directions Pd and Pv.
+     thdraw (Pp - 0.25u * Pv) --
+            (Pp + 0.25u * Pv);
+     cas := cas + mojkrok;
+     exitif cas > dlzka - (2*mojkrok/3); % for rounding errors
+   endfor;
 enddef;
 
 def l_ropeladder_SKBB (expr P) = 
-  pickup PenD;
-  draw P withcolor red;
+  pair Pp;
+  pair Pd;
+  pair Pv;
+  T:=identity;
+  cas := 0;                          % loop-variable (current iteration through path)
+  dlzka := arclength P;              % base for iterations (the length of the drawn line)
+  mojkrok:=adjust_step(dlzka, 0.3u); % ammount of iterations / count of individual steps (segments)
+
+  % get shift coordinates based on initial angleof path;
+  % this gets us the left and right rail of the ladder.
+  % PLEASE NOTE: this currently only works properly with straight lines.
+  %              for beziers, the tension points must be recalculated / path shortened+lengthened
+  %              based on next angle in the path.
+  %              Maybe play with http://tex.stackexchange.com/questions/309830/draw-a-curve-as-an-outline-to-another-curve
+  pair offsetLeft;
+  pair offsetRight;
+  offsetLeft  := 0.25u * (dir (angle direction 0.0001 of P-90));
+  offsetRight := 0.25u * (dir (angle direction 0.0001 of P+90));
+  thdraw P shifted offsetLeft;
+  thdraw P shifted offsetRight;
+
+  pickup PenC;
+  forever:
+    t  := arctime (cas + mojkrok/2) of P;
+    Pp := (point t of P);         % center of current step
+    Pd := unitvector(thdir(P,t)); % Point in direction of line
+    Pv := Pd rotated 90;          % direction of line, rotated 90° to the right
+
+    % draw one rung segment in direction of the path. Absolute Point coordinates are
+    % calculated from the current directions Pd and Pv.
+    thdraw (Pp - 0.25u * Pv){down+0.25u*Pd} ..  % rung (".." -> draw curve)
+           (Pp + 0.25u * Pv);
+    cas := cas + mojkrok;
+    exitif cas > dlzka - (2*mojkrok/3); % for rounding errors
+  endfor;
 enddef;
 
 def l_viaferrata_SKBB (expr P) = 


### PR DESCRIPTION
Implemented fixed-ladder and rope-ladder line types for SKBB (replacing the red line todo reminder currently used).

<s>The symbol works like the ceiling-meander, like discussed on the mailing list.

The symbols work with slopes and straight lines, however optimizations could be still made to make the line more smoother and to save on symbols: currently the outer shafts of the ladder is drawn with small sections. It would be better to draw them using just two single curves following the entire line Path with some offset.
Does someone know how this works? The examples are still somewhat confusing to me...</s>

The smbol works good with straight lines; small linear dents are supported too. With bezier curves there are strange effects, bu most ladders i know are straight anyway ;)
The current code draws the ladder-sides in two paths, which should be more efficient and avoids artefacts with the old code.