### PR TITLE
Remove redundant NULL checks

### DIFF
--- a/loch/lxData.cxx
+++ b/loch/lxData.cxx
@@ -178,10 +178,10 @@ bool lxDataTexture::InitCalibNormal(double idx, double idy, double ixx, double i
 void lxDataTexture::ClearTexImages()
 {
 #define lxDataTextureClear(i) \
-  if (this->i != NULL) { \
+  do { \
     delete [] this->i; \
     this->i = NULL; \
-  }
+  } while (false)
   lxDataTextureClear(texS);
   lxDataTextureClear(texSbw);
   lxDataTextureClear(texO);

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -386,10 +386,8 @@ lxRenderFile::~lxRenderFile()
 {
   if (m_file != NULL)
     fclose(m_file);
-  if (this->m_imgBuffLine != NULL)
-    delete [] this->m_imgBuffLine;
-  if (this->m_imgBuffRow != NULL)
-    delete [] this->m_imgBuffRow;
+  delete [] this->m_imgBuffLine;
+  delete [] this->m_imgBuffRow;
   this->m_glc->TRCDestroy();
   this->m_glc->m_renderData = NULL;
   this->m_glc->ForceRefresh();
@@ -658,9 +656,7 @@ void lxRenderFile::Render() {
   m_glc->setup->cam_width = tmpcw;
   //pngtst;
 
-  if (dialog != NULL) {
-    delete dialog;
-  }
+  delete dialog;
 
   switch (this->m_pData->m_imgFileType) {
     case 0:

--- a/tharea.cxx
+++ b/tharea.cxx
@@ -44,8 +44,7 @@ tharea::tharea()
 
 tharea::~tharea()
 {
-  if (this->m_outline_line != NULL)
-    delete this->m_outline_line;
+  delete this->m_outline_line;
 }
 
 

--- a/thbezier.cxx
+++ b/thbezier.cxx
@@ -79,7 +79,7 @@
 #define g_return_val_if_fail(C,V) if (!(C)) return (V);
 #define g_return_if_fail(C) if (!(C)) return;
 #define g_new(T,L) new T [L];
-#define g_free(V) if (V != NULL) delete [] V
+#define g_free(V) delete [] V
 #define g_assert(X) assert(X)
 
 /* You might try changing the above to <cmath> if you have problems.

--- a/thbuffer.cxx
+++ b/thbuffer.cxx
@@ -38,8 +38,7 @@ thbuffer::thbuffer()
 
 thbuffer::~thbuffer()
 {
-  if (this->buff)
-    delete [] this->buff;
+  delete [] this->buff;
 }
 
 

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -94,12 +94,9 @@ void thdb1ds::set_temporary(const char * name)
 
 thdb1d::~thdb1d()
 {
-  if (this->tree_legs != NULL)
-    delete [] this->tree_legs;
-  if (this->tree_arrows != NULL)
-    delete [] this->tree_arrows;
-  if (this->tree_nodes != NULL)
-    delete [] this->tree_nodes;
+  delete [] this->tree_legs;
+  delete [] this->tree_arrows;
+  delete [] this->tree_nodes;
 }
 
 
@@ -2034,14 +2031,10 @@ void thdb1d::find_loops()
   
   LC_COORD_CALC:
   
-  if (crossst != NULL)
-    delete [] crossst;
-  if (lclegs != NULL)
-    delete [] lclegs;
-  if (lccrosses != NULL)
-    delete [] lccrosses;
-  if (lccrossarrows != NULL)
-    delete [] lccrossarrows;
+  delete [] crossst;
+  delete [] lclegs;
+  delete [] lccrosses;
+  delete [] lccrossarrows;
 
 #ifdef THDEBUG    
   thprintf("\nEND OF LOOP CLOSURE DEBUG\n");

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -3647,7 +3647,7 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
     }
   }
 
-  if (cln != NULL) delete cln;
+  delete cln;
 
   chdir(wdir.get_buffer());
 

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -1746,8 +1746,7 @@ void thexpmodel::export_lox_file(class thdatabase * dbp) {
     
   } // WALLS  
   
-  if (stnum != NULL)
-    delete [] stnum;
+  delete [] stnum;
 
   expf.ExportLOX(fnm);
 

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -58,8 +58,7 @@ thinput::ifile::ifile(ifile * fp)
 thinput::ifile::~ifile()
 {
   this->close();
-  if (this->next_ptr != NULL)
-    delete this->next_ptr;
+  delete this->next_ptr;
 }
 
 

--- a/thmbuffer.cxx
+++ b/thmbuffer.cxx
@@ -40,10 +40,8 @@ thmbuffer::mblock::mblock(size_t min_size, size_t last_size)
 
 thmbuffer::mblock::~mblock()
 {
-  if (this->data)
-    delete [] this->data;
-  if (this->next_ptr != NULL)
-    delete this->next_ptr;
+  delete [] this->data;
+  delete this->next_ptr;
 }
 
 
@@ -61,10 +59,8 @@ thmbuffer::thmbuffer()
 
 thmbuffer::~thmbuffer()
 {
-  if (this->buf)
-    delete [] this->buf;
-  if (this->first_ptr)
-    delete this->first_ptr;
+  delete [] this->buf;
+  delete this->first_ptr;
 }
 
 

--- a/thpic.cxx
+++ b/thpic.cxx
@@ -238,10 +238,8 @@ void thpic::rgba_load()
 
 void thpic::rgba_free()
 {
-  if (this->rgba != NULL) {
-    delete [] this->rgba;
-    this->rgba = NULL;
-  }
+  delete [] this->rgba;
+  this->rgba = NULL;
 }
 
 

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -63,8 +63,7 @@ thpoint::~thpoint()
 {
   if (this->type == TT_POINT_TYPE_DATE) {
     thdate * dp = (thdate *) this->text;
-    if (dp != NULL)
-      delete dp;
+    delete dp;
     this->text = NULL;
   }
 }

--- a/thscrapis.cxx
+++ b/thscrapis.cxx
@@ -84,8 +84,7 @@ thscrapis::thscrapis(class thscrap * scrap) {
 
 
 thscrapis::~thscrapis() {
-  if (this->tri_triangles != NULL)
-    delete [] this->tri_triangles;
+  delete [] this->tri_triangles;
 }
 
 

--- a/thsurface.cxx
+++ b/thsurface.cxx
@@ -104,8 +104,7 @@ thsurface::thsurface()
 
 thsurface::~thsurface()
 {
-  if (this->grid != NULL)
-    delete [] this->grid;
+  delete [] this->grid;
 }
 
 

--- a/thwarp.cxx
+++ b/thwarp.cxx
@@ -263,7 +263,7 @@ thpic * thwarplin::morph(thsketch * sketch, double scale)
           thprintf(" [%.0f%%]", double(counter) / double(mw * mh) * 100.0);
       }
     }
-    if (ss != NULL) delete [] ss;
+    delete [] ss;
 
   } else {
 
@@ -383,7 +383,7 @@ thpic * thwarplin::morph(thsketch * sketch, double scale)
     //  }
     //}
 
-    if (ss != NULL) delete [] ss;
+    delete [] ss;
   }
 
 


### PR DESCRIPTION
delete on a NULL pointer is valid (and a no-op), so the explicit checks
serve no useful purpose, and make the source less clear.