### PR TITLE
Correct spelling of "assistent" in code

### DIFF
--- a/thdataleg.h
+++ b/thdataleg.h
@@ -88,7 +88,7 @@ enum {
  
 static const thstok thtt_dataleg_comp[] = {
   {"altitude", TT_DATALEG_ALTITUDE},
-  {"assistent", TT_DATALEG_ASSISTANT},
+  {"assistant", TT_DATALEG_ASSISTANT},
   {"backbearing", TT_DATALEG_BACKBEARING},
   {"backclino", TT_DATALEG_BACKGRADIENT},
   {"backcompass", TT_DATALEG_BACKBEARING},


### PR DESCRIPTION
The documentation has the correct spelling "assistant" , but actually
that doesn't work (only the incorrect spelling "assistent" and the
alias "dog" do).

Fix the code to match the documentation, but recognise the incorrect
spelling in case it has made its way into user data files.

---

Or perhaps it's better to just fix the recognised spelling and not try to be
backwardly compatible?

The incorrect spelling is not documented to work, and looking at the git
history, it seems the documentation has always given the correct spelling.
So user files with "assistent" would have to be from either looking at the
source code, or from coincidentally misspelling it.

Your call.  I'm happy to update this PR to drop the backward compatibility.