### PR TITLE
More drawing object sizes: 2XS<XS<S<M<L<XL<2XL<3XL<4XL

### DIFF
--- a/mpost/therion.mp
+++ b/mpost/therion.mp
@@ -224,7 +224,11 @@ def fonts_setup (expr t,s,m,l,h) =
         "\def\thsmallsize{\size[" & decimal max(optical_zoom*s,0) & "]}" & 
         "\def\thnormalsize{\size[" & decimal max(optical_zoom*m,0) & "]}" & 
         "\def\thlargesize{\size[" & decimal max(optical_zoom*l,0) & "]}" & 
-        "\def\thhugesize{\size[" & decimal max(optical_zoom*h,0) & "]}" 
+        "\def\thhugesize{\size[" & decimal max(optical_zoom*h,0) & "]}" & 
+        "\def\thtinysizexxs{\size[" & decimal max(optical_zoom*t*0.6,0) & "]}" & 
+        "\def\thhugesizexxl{\size[" & decimal max(optical_zoom*h*1.5,0) & "]}" & 
+        "\def\thhugesizexxxl{\size[" & decimal max(optical_zoom*h*1.5*1.5,0) & "]}" & 
+        "\def\thhugesizexxxxl{\size[" & decimal max(optical_zoom*h*1.5*1.5*1.5,0) & "]}" 
   to "mptexpre.tex";
   write EOF to "mptexpre.tex";
 enddef;

--- a/th2ddataobject.h
+++ b/th2ddataobject.h
@@ -38,11 +38,15 @@
 
 enum {
   TT_2DOBJ_SCALE_UNKNOWN,
+  TT_2DOBJ_SCALE_2XS,
   TT_2DOBJ_SCALE_XS,
   TT_2DOBJ_SCALE_S,
   TT_2DOBJ_SCALE_M,
   TT_2DOBJ_SCALE_L,
   TT_2DOBJ_SCALE_XL,
+  TT_2DOBJ_SCALE_2XL,
+  TT_2DOBJ_SCALE_3XL,
+  TT_2DOBJ_SCALE_4XL,
 };
 
 
@@ -51,6 +55,14 @@ enum {
  */
  
 static const thstok thtt_2dobj_scales[] = {
+  {"2XL", TT_2DOBJ_SCALE_2XL},
+  {"2XS", TT_2DOBJ_SCALE_2XS},
+  {"2xl", TT_2DOBJ_SCALE_2XL},
+  {"2xs", TT_2DOBJ_SCALE_2XS},
+  {"3XL", TT_2DOBJ_SCALE_3XL},
+  {"3xl", TT_2DOBJ_SCALE_3XL},
+  {"4XL", TT_2DOBJ_SCALE_4XL},
+  {"4xl", TT_2DOBJ_SCALE_4XL},
   {"L", TT_2DOBJ_SCALE_L},
   {"M", TT_2DOBJ_SCALE_M},
   {"S", TT_2DOBJ_SCALE_S},

--- a/thline.cxx
+++ b/thline.cxx
@@ -762,6 +762,15 @@ bool thline::export_mp(class thexpmapmpxs * out)
       out->symset->export_mp_symbol_options(out->file, omacroid);
       fprintf(out->file,"l_label(btex ");
       switch (this->scale) {
+        case TT_2DOBJ_SCALE_4XL:
+          fprintf(out->file,"\\thhugesizexxxxl ");
+          break;
+        case TT_2DOBJ_SCALE_3XL:
+          fprintf(out->file,"\\thhugesizexxxl ");
+          break;
+        case TT_2DOBJ_SCALE_2XL:
+          fprintf(out->file,"\\thhugesizexxl ");
+          break;
         case TT_2DOBJ_SCALE_XL:
           fprintf(out->file,"\\thhugesize ");
           break;
@@ -773,6 +782,9 @@ bool thline::export_mp(class thexpmapmpxs * out)
           break;
         case TT_2DOBJ_SCALE_XS:
           fprintf(out->file,"\\thtinysize ");
+          break;
+        case TT_2DOBJ_SCALE_2XS:
+          fprintf(out->file,"\\thtinysizexxs ");
           break;
         default:
           fprintf(out->file,"\\thnormalsize ");

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -448,6 +448,15 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
             break;
         }
         switch (this->scale) {
+          case TT_2DOBJ_SCALE_4XL:
+            fprintf(out->file,"\\thhugesizexxxxl ");
+            break;
+          case TT_2DOBJ_SCALE_3XL:
+            fprintf(out->file,"\\thhugesizexxxl ");
+            break;
+          case TT_2DOBJ_SCALE_2XL:
+            fprintf(out->file,"\\thhugesizexxl ");
+            break;
           case TT_2DOBJ_SCALE_XL:
             fprintf(out->file,"\\thhugesize ");
             break;
@@ -459,6 +468,9 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
             break;
           case TT_2DOBJ_SCALE_XS:
             fprintf(out->file,"\\thtinysize ");
+            break;
+          case TT_2DOBJ_SCALE_2XS:
+            fprintf(out->file,"\\thtinysizexxs ");
             break;
           default:
             fprintf(out->file,"\\thnormalsize ");
@@ -577,6 +589,15 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         fprintf(out->file,"p_label%s(btex \\thaltitude ",
 					thpoint_export_mp_align2mp(thdb2d_rotate_align(this->align, xrr)));
         switch (this->scale) {
+          case TT_2DOBJ_SCALE_4XL:
+            fprintf(out->file,"\\thhugesizexxxxl ");
+            break;
+          case TT_2DOBJ_SCALE_3XL:
+            fprintf(out->file,"\\thhugesizexxxl ");
+            break;
+          case TT_2DOBJ_SCALE_2XL:
+            fprintf(out->file,"\\thhugesizexxl ");
+            break;
           case TT_2DOBJ_SCALE_XL:
             fprintf(out->file,"\\thhugesize ");
             break;
@@ -589,6 +610,11 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
           case TT_2DOBJ_SCALE_XS:
             fprintf(out->file,"\\thtinysize ");
             break;
+          case TT_2DOBJ_SCALE_2XS:
+            fprintf(out->file,"\\thtinysizexxs ");
+            break;
+          default:
+            fprintf(out->file,"\\thnormalsize ");
         }
         fprintf(out->file,"%s etex,",
 					utf2tex(out->layout->units.format_length(this->xsize - out->layout->goz)));
@@ -629,6 +655,15 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         fprintf(out->file,"p_label%s(btex \\thheight ",thpoint_export_mp_align2mp(thdb2d_rotate_align(this->align, xrr)));
 
         switch (this->scale) {
+          case TT_2DOBJ_SCALE_4XL:
+            fprintf(out->file,"\\thhugesizexxxxl ");
+            break;
+          case TT_2DOBJ_SCALE_3XL:
+            fprintf(out->file,"\\thhugesizexxxl ");
+            break;
+          case TT_2DOBJ_SCALE_2XL:
+            fprintf(out->file,"\\thhugesizexxl ");
+            break;
           case TT_2DOBJ_SCALE_XL:
             fprintf(out->file,"\\thhugesize ");
             break;
@@ -641,6 +676,11 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
           case TT_2DOBJ_SCALE_XS:
             fprintf(out->file,"\\thtinysize ");
             break;
+          case TT_2DOBJ_SCALE_2XS:
+            fprintf(out->file,"\\thtinysizexxs ");
+            break;
+          default:
+            fprintf(out->file,"\\thnormalsize ");
         }
 
         if ((this->tags & TT_POINT_TAG_HEIGHT_P) != 0)
@@ -681,6 +721,15 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         fprintf(out->file,"p_label%s(btex \\thdate ",
             thpoint_export_mp_align2mp(thdb2d_rotate_align(this->align, xrr)));
         switch (this->scale) {
+          case TT_2DOBJ_SCALE_4XL:
+            fprintf(out->file,"\\thhugesizexxxxl ");
+            break;
+          case TT_2DOBJ_SCALE_3XL:
+            fprintf(out->file,"\\thhugesizexxxl ");
+            break;
+          case TT_2DOBJ_SCALE_2XL:
+            fprintf(out->file,"\\thhugesizexxl ");
+            break;
           case TT_2DOBJ_SCALE_XL:
             fprintf(out->file,"\\thhugesize ");
             break;
@@ -693,6 +742,11 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
           case TT_2DOBJ_SCALE_XS:
             fprintf(out->file,"\\thtinysize ");
             break;
+          case TT_2DOBJ_SCALE_2XS:
+            fprintf(out->file,"\\thtinysizexxs ");
+            break;
+          default:
+            fprintf(out->file,"\\thnormalsize ");
         }
         fprintf(out->file,"%s etex,",
             utf2tex(((thdate *)this->text)->get_str(TT_DATE_FMT_LOCALE)));
@@ -756,6 +810,15 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         if (!thisnan(this->xsize)) {
           fprintf(out->file,"{");
           switch (this->scale) {
+            case TT_2DOBJ_SCALE_4XL:
+              fprintf(out->file,"\\thhugesizexxxxl ");
+              break;
+            case TT_2DOBJ_SCALE_3XL:
+              fprintf(out->file,"\\thhugesizexxxl ");
+              break;
+            case TT_2DOBJ_SCALE_2XL:
+              fprintf(out->file,"\\thhugesizexxl ");
+              break;
             case TT_2DOBJ_SCALE_XL:
               fprintf(out->file,"\\thhugesize ");
               break;
@@ -768,6 +831,11 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
             case TT_2DOBJ_SCALE_XS:
               fprintf(out->file,"\\thtinysize ");
               break;
+            case TT_2DOBJ_SCALE_2XS:
+              fprintf(out->file,"\\thtinysizexxs ");
+              break;
+            default:
+              fprintf(out->file,"\\thnormalsize ");
           }
           fprintf(out->file,"%s}", utf2tex(out->layout->units.format_human_length(this->xsize)));
         }
@@ -775,6 +843,15 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         if (!thisnan(this->ysize)) {
           fprintf(out->file,"{");
           switch (this->scale) {
+            case TT_2DOBJ_SCALE_4XL:
+              fprintf(out->file,"\\thhugesizexxxxl ");
+              break;
+            case TT_2DOBJ_SCALE_3XL:
+              fprintf(out->file,"\\thhugesizexxxl ");
+              break;
+            case TT_2DOBJ_SCALE_2XL:
+              fprintf(out->file,"\\thhugesizexxl ");
+              break;
             case TT_2DOBJ_SCALE_XL:
               fprintf(out->file,"\\thhugesize ");
               break;
@@ -786,6 +863,9 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
               break;
             case TT_2DOBJ_SCALE_XS:
               fprintf(out->file,"\\thtinysize ");
+              break;
+            case TT_2DOBJ_SCALE_2XS:
+              fprintf(out->file,"\\thtinysizexxs ");
               break;
           }
           fprintf(out->file,"%s}", utf2tex(out->layout->units.format_human_length(this->ysize)));
@@ -959,17 +1039,29 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
     this->point->export_mp(out);
     double scl = 1.0;
     switch (this->scale) {
-      case TT_2DOBJ_SCALE_L:
-        scl = 1.414;
+      case TT_2DOBJ_SCALE_4XL:
+        scl = 6.75;
+        break;
+      case TT_2DOBJ_SCALE_3XL:
+        scl = 4.5;
+        break;
+      case TT_2DOBJ_SCALE_2XL:
+        scl = 3.0;
         break;
       case TT_2DOBJ_SCALE_XL:
         scl = 2.0;
+        break;
+      case TT_2DOBJ_SCALE_L:
+        scl = 1.414;
         break;
       case TT_2DOBJ_SCALE_S:
         scl = 0.707;
         break;
       case TT_2DOBJ_SCALE_XS:
         scl = 0.5;
+        break;
+      case TT_2DOBJ_SCALE_2XS:
+        scl = 0.3;
         break;
     }
     const char * al = "(0,0)";

--- a/xtherion/me_cmds.tcl
+++ b/xtherion/me_cmds.tcl
@@ -2803,11 +2803,15 @@ $xth(me,ctxmenu).align add radiobutton -hidemargin 1 -image align-br.gif -select
 
 catch {menu $xth(me,ctxmenu).scale -tearoff 0}
 $xth(me,ctxmenu).scale delete 0 end
+$xth(me,ctxmenu).scale add radiobutton -label [mc "tiny (2xs)"] -variable xth(me,ctrl,ctx,scale) -value "2xs" -command {xth_me_set_option_value scale}
 $xth(me,ctxmenu).scale add radiobutton -label [mc "tiny (xs)"] -variable xth(me,ctrl,ctx,scale) -value "xs" -command {xth_me_set_option_value scale}
 $xth(me,ctxmenu).scale add radiobutton -label [mc "small (s)"] -variable xth(me,ctrl,ctx,scale) -value "s" -command {xth_me_set_option_value scale}
 $xth(me,ctxmenu).scale add radiobutton -label [mc "normal (m)"] -variable xth(me,ctrl,ctx,scale) -value "m" -command {xth_me_set_option_value scale}
 $xth(me,ctxmenu).scale add radiobutton -label [mc "large (l)"] -variable xth(me,ctrl,ctx,scale) -value "l" -command {xth_me_set_option_value scale}
 $xth(me,ctxmenu).scale add radiobutton -label [mc "huge (xl)"] -variable xth(me,ctrl,ctx,scale) -value "xl" -command {xth_me_set_option_value scale}
+$xth(me,ctxmenu).scale add radiobutton -label [mc "huge (2xl)"] -variable xth(me,ctrl,ctx,scale) -value "2xl" -command {xth_me_set_option_value scale}
+$xth(me,ctxmenu).scale add radiobutton -label [mc "huge (3xl)"] -variable xth(me,ctrl,ctx,scale) -value "3xl" -command {xth_me_set_option_value scale}
+$xth(me,ctxmenu).scale add radiobutton -label [mc "huge (4xl)"] -variable xth(me,ctrl,ctx,scale) -value "4xl" -command {xth_me_set_option_value scale}
 
 catch {menu $xth(me,ctxmenu).outline -tearoff 0}
 $xth(me,ctxmenu).outline delete 0 end
@@ -3367,6 +3371,9 @@ proc xth_me_show_context_menu {id x y} {
   set optscale [xth_me_get_option_value "scale" $opts]
   # set variable
   switch -nocase [lindex $optscale 0] {
+    2xs - tiny {
+      set xth(me,ctrl,ctx,scale) "2xs"
+    }
     xs - tiny {
       set xth(me,ctrl,ctx,scale) "xs"
     }
@@ -3381,6 +3388,18 @@ proc xth_me_show_context_menu {id x y} {
     }
     xl - huge {
       set xth(me,ctrl,ctx,scale) "xl"
+    }
+    xxl - huge {
+      set xth(me,ctrl,ctx,scale) "xl"
+    }
+    xl - huge {
+      set xth(me,ctrl,ctx,scale) "xl"
+    }
+    2xl - huge {
+      set xth(me,ctrl,ctx,scale) "2xl"
+    }
+    3xl - huge {
+      set xth(me,ctrl,ctx,scale) "3xl"
     }
     default {
       set xth(me,ctrl,ctx,scale) "auto"


### PR DESCRIPTION
Added more drawing object sizes: 2XS<XS<S<M<L<XL<2XL<3XL<4XL. Each is approx 50% larger than the previous.
This is based on the existing code for the object sizes. It will be much more flexible if the size can be defined with a floating point value. E.g. 1.0 is the M size and any smaller or larger value would scale the symbol accordingly. However, this will mean a change in the TH2 file format and I also don't know if such a change can easily be done in the TEX commands. 