### PR TITLE
Fixing raft-cone point being draw as raft

### DIFF
--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -896,7 +896,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
     thpoint_type_export_mp(TT_POINT_TYPE_KARREN,SYMP_KARREN)
     thpoint_type_export_mp(TT_POINT_TYPE_SCALLOP,SYMP_SCALLOP)
     thpoint_type_export_mp(TT_POINT_TYPE_FLUTE,SYMP_FLUTE)
-    thpoint_type_export_mp(TT_POINT_TYPE_RAFT_CONE,SYMP_RAFT)
+    thpoint_type_export_mp(TT_POINT_TYPE_RAFT_CONE,SYMP_RAFTCONE)
     thpoint_type_export_mp(TT_POINT_TYPE_CLAY_TREE,SYMP_CLAYTREE)
 
   


### PR DESCRIPTION
This issue has already been discussed at https://goo.gl/GvHBIw

Summary: raft-cone points are being drawn like raft points.

It's a one line fix at thpoint.cxx file and raft-cone are finally drawn as raft-cones.

