### PR TITLE
Line point "Edit line" contextual menu fix.

### DIFF
--- a/xtherion/me.tcl
+++ b/xtherion/me.tcl
@@ -1193,7 +1193,6 @@ proc xth_me_bind_image_drag {tagOrId imgx} {
   $xth(me,can) bind $tagOrId <Double-$xth(gui,rmb)> "xth_me_image_start_drag $tagOrId $imgx %x %y"
 }
 
-
 xth_app_create me [mc "Map Editor"]
 
 xth_ctrl_add me cmds [mc "File commands"]
@@ -2099,13 +2098,8 @@ Button $lnc.simpl -text [mc "Simplify line"] -anchor center -font $xth(gui,lfont
   -state disabled -command {xth_me_cmds_line_simplify} -width 10
 xth_status_bar me $lnc.upd [mc "Click this button to apply line changes."]
 
-menu $lnc.lpa.m -tearoff 0 -font $xth(gui,lfont)
-$lnc.lpa.m add command -label [mc "Insert point"] -command {xth_me_cmds_start_linept_insert} -state disabled
-$lnc.lpa.m add command -label [mc "Delete point"] -command {xth_me_cmds_delete_linept {} {}} -state disabled
-$lnc.lpa.m add command -label [mc "Split line"] -command {xth_me_cmds_line_split} -state disabled
-$lnc.lpa.m add command -label [mc "Trace line"] -command {xth_me_cmds_line_trace_start}
-$lnc.lpa.m add command -label [mc "Convert to curve"] -command {xth_me_cmds_line_poly2bezier}
-$lnc.lpa.m add command -label [mc "Simplify line"] -command {xth_me_cmds_line_simplify}
+set tmp $lnc.lpa
+xth_me_create_line_point_edit_menu tmp disabled
 
 #Button $lnc.insp -text "Insert" -anchor center -font $xth(gui,lfont) \
 #  -state disabled -width 10 -command {xth_me_cmds_start_linept_insert}

--- a/xtherion/me_cmds.tcl
+++ b/xtherion/me_cmds.tcl
@@ -2821,6 +2821,18 @@ $xth(me,ctxmenu).cps add checkbutton -label [mc "<<"] -variable xth(ctrl,me,line
 $xth(me,ctxmenu).cps add checkbutton -label [mc "smooth"] -variable xth(ctrl,me,linept,smooth) -command xth_me_cmds_toggle_linept
 $xth(me,ctxmenu).cps add checkbutton -label [mc ">>"] -variable xth(ctrl,me,linept,idn) -command xth_me_cmds_toggle_linept
 
+proc xth_me_create_line_point_edit_menu { lpem_father {state normal} } {
+    upvar $lpem_father f
+    global xth
+    
+    catch {menu $f.m -tearoff 0 -font $xth(gui,lfont)}
+    $f.m add command -label [mc "Insert point"] -command {xth_me_cmds_start_linept_insert} -state $state
+    $f.m add command -label [mc "Delete point"] -command {xth_me_cmds_delete_linept {} {}} -state $state
+    $f.m add command -label [mc "Split line"] -command {xth_me_cmds_line_split} -state $state
+    $f.m add command -label [mc "Trace line"] -command {xth_me_cmds_line_trace_start}
+    $f.m add command -label [mc "Convert to curve"] -command {xth_me_cmds_line_poly2bezier}
+    $f.m add command -label [mc "Simplify line"] -command {xth_me_cmds_line_simplify}    
+}
 
 catch {menu $xth(me,ctxmenu).subtype -tearoff 0}
 catch {menu $xth(me,ctxmenu).segsubtype -tearoff 0}
@@ -2831,6 +2843,7 @@ $xth(me,ctxmenu).altitude add radiobutton -label [mc "auto"] -variable xth(me,ct
 $xth(me,ctxmenu).altitude add command -label [mc "edit"] -command {xth_me_ctx_change_text altitude [mc "Altitude"]}
 
 catch {menu $xth(me,ctxmenu).others -tearoff 0}
+xth_me_create_line_point_edit_menu xth(me,ctxmenu)
 
 # return point option
 proc xth_me_get_option_value {key optkey} {
@@ -3411,7 +3424,7 @@ proc xth_me_show_context_menu {id x y} {
       
   $xth(me,ctxmenu) add separator
   if {$xth(me,cmds,$id,ct) == 3} {
-    $xth(me,ctxmenu) add cascade -label [mc "Edit line"] -menu $xth(ctrl,me,line).lpa.m
+    $xth(me,ctxmenu) add cascade -label [mc "Edit line"] -menu $xth(me,ctxmenu).m
     $xth(me,ctxmenu).others add checkbutton -label [mc "close"] -variable xth(ctrl,me,line,close) -command xth_me_cmds_toggle_line_close
     $xth(me,ctxmenu).others add checkbutton -label [mc "reverse"] -variable xth(ctrl,me,line,reverse) -command xth_me_cmds_toggle_line_reverse
   }


### PR DESCRIPTION
Line point "Edit line" contextual menu wasn't working on Linux as discussed here: https://goo.gl/wHvLta

As per documentation -http://www.tcl.tk/man/tcl8.5/TkCmd/menu.htm#M12 - of Tk _menu_ widget's cascade option:

_The associated menu must be a child of the menu containing the cascade entry (this is needed in order for menu traversal to work correctly)._

This fix consists of stop reusing the "Edit line" menu from the right panel on the contextual menu and start creating a new one just for the contextual menu.

This probably wasn't an issue on Windows and Mac because, as per above documentation also, only Unix depends on Tk posting and unposting support. Windows and Mac have their own methods. 

