### PR TITLE
Fixing xtherion/lang/process.pl greddyness.

### DIFF
--- a/xtherion/lang/process.pl
+++ b/xtherion/lang/process.pl
@@ -189,7 +189,7 @@ sub update_todo_list {
     @lines = split(/\n/,$ln);
     foreach $ln (@lines) {
       $i++;
-      if ($ln =~ /^\[mc\ \"(.*)\"/) {
+      if ($ln =~ /^\[mc\ \"(.*?)\"/) {
         $hr{$1}{therion} = $i;
       }
     }


### PR DESCRIPTION
_xtherion/lang/process.pl_ was using a greddy regex to identify the texts that need to me translated. This resulted in a few texts being selected with some unwanted neighbour code in _xtherion/lang/xtexts.txt_. Example:

`therion: on"] -variable xth(me,ctrl,ctx,clip) -value "on`

when the correct selection would be

`therion: on`

The solution was just to remove regex greddyness from the extraction of translatable texts.