### PR TITLE
Including missing translatable texts with comments.

### DIFF
--- a/xtherion/me_cmds.tcl
+++ b/xtherion/me_cmds.tcl
@@ -3135,38 +3135,49 @@ proc xth_me_show_context_menu {id x y} {
     	# set variable
     	switch -nocase [lindex $optalign 0] {
     	  t - top {
+          #DON'T REMOVE - for translation. [mc "top"]
     	    set xth(me,ctrl,ctx,align) "top"
     	  }
     	  tr - top-right {
+          #DON'T REMOVE - for translation. [mc "top-right"]
     	    set xth(me,ctrl,ctx,align) "top-right"
     	  }
     	  tl - top-left {
+          #DON'T REMOVE - for translation. [mc "top-left"]
     	    set xth(me,ctrl,ctx,align) "top-left"
     	  }
     	  b - bottom {
+          #DON'T REMOVE - for translation. [mc "bottom"]
     	    set xth(me,ctrl,ctx,align) "bottom"
     	  }
     	  br - bottom-right {
+          #DON'T REMOVE - for translation. [mc "bottom-right"]
     	    set xth(me,ctrl,ctx,align) "bottom-right"
     	  }
     	  bl - bottom-left {
+          #DON'T REMOVE - for translation. [mc "bottom-left"]
     	    set xth(me,ctrl,ctx,align) "bottom-left"
     	  }
     	  c - centre - center {
+          #DON'T REMOVE - for translation. [mc "center"]
     	    set xth(me,ctrl,ctx,align) "center"
     	  }
     	  r - right {
+          #DON'T REMOVE - for translation. [mc "right"]
     	    set xth(me,ctrl,ctx,align) "right"
     	  }
     	  l - left {
+          #DON'T REMOVE - for translation. [mc "left"]
     	    set xth(me,ctrl,ctx,align) "left"
     	  }
     	  default {
+          #DON'T REMOVE - for translation. [mc "auto"]
     	    set xth(me,ctrl,ctx,align) "auto"
     	  }
     	}
     	# set options
-    	set xth(me,ctrl,ctxopt,align) [lindex $optalign 1] 
+      set xth(me,ctrl,ctxopt,align) [lindex $optalign 1]
+      #DON'T REMOVE - for translation. [mc "align"]
       $xth(me,ctxmenu) add cascade -label [xth_me_optlabel align] -menu $xth(me,ctxmenu).align
     }
 	  	  
@@ -3175,6 +3186,7 @@ proc xth_me_show_context_menu {id x y} {
       set optname [xth_me_get_option_value "name" $opts]
       set xth(me,ctrl,ctx,name) [lindex $optname 0]
       set xth(me,ctrl,ctxopt,name) [lindex $optname 1] 
+      #DON'T REMOVE - for translation. [mc "name"]
       $xth(me,ctxmenu) add command -label [xth_me_optlabel name] -command {xth_me_ctx_change_text name [mc "Station name"]}
     }
     # scrap
@@ -3196,6 +3208,7 @@ proc xth_me_show_context_menu {id x y} {
       set optvalue [xth_me_get_option_value "value" $opts]
       set xth(me,ctrl,ctx,value) [lindex $optvalue 0]
       set xth(me,ctrl,ctxopt,value) [lindex $optvalue 1] 
+      #DON'T REMOVE - for translation. [mc "value"]
       $xth(me,ctxmenu) add command -label [xth_me_optlabel value] -command {xth_me_ctx_change_text value}
     }
     # toggle orientation
@@ -3251,6 +3264,7 @@ proc xth_me_show_context_menu {id x y} {
         }
       }
       set xth(me,ctrl,ctxopt,subtype) [lindex $optsubtype 1] 
+      #DON'T REMOVE - for translation. [mc "subtype"]
       $xth(me,ctxmenu) add cascade -label [xth_me_optlabel subtype] -menu $xth(me,ctxmenu).subtype
     }    
 
@@ -3308,6 +3322,7 @@ proc xth_me_show_context_menu {id x y} {
     }
     # set options
     set xth(me,ctrl,ctxopt,outline) [lindex $optoutline 1] 
+    #DON'T REMOVE - for translation. [mc "outline"]
     $xth(me,ctxmenu).others add cascade -label [xth_me_optlabel outline] -menu $xth(me,ctxmenu).outline
       
     # text for label
@@ -3315,6 +3330,7 @@ proc xth_me_show_context_menu {id x y} {
       set opttext [xth_me_get_option_value "text" $opts]
       set xth(me,ctrl,ctx,text) [lindex $opttext 0]
       set xth(me,ctrl,ctxopt,text) [lindex $opttext 1]
+      #DON'T REMOVE - for translation. [mc "text"]
       $xth(me,ctxmenu) add command -label [xth_me_optlabel text] -command {xth_me_ctx_change_text text}
     }
   }
@@ -3339,6 +3355,7 @@ proc xth_me_show_context_menu {id x y} {
   }
   # set options
   set xth(me,ctrl,ctxopt,clip) [lindex $optclip 1] 
+  #DON'T REMOVE - for translation. [mc "clip"]
   $xth(me,ctxmenu).others add cascade -label [xth_me_optlabel clip] -menu $xth(me,ctxmenu).clip
 
   $xth(me,ctxmenu) add cascade -label [mc "other options"] -menu $xth(me,ctxmenu).others


### PR DESCRIPTION
Several subtype keys and values weren't being included in _xtherion/lang/xtexts.txt_ because there wasn't an explicit call to _[mc ... ]_ with them, just calls through variables which aren't recognized by _perl xtherion/lang/process.pl update_

Created a series of comments that mimick _[mc ... ]_ calls for all missings texts.