### PR TITLE
Applying proper collation when sorting.

### DIFF
--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -64,9 +64,28 @@ if {[lsearch -exact $xth(kbencodings) [encoding system]] < 0} {
   lappend xth(kbencodings) [encoding system]
 }
 
-#The collation code used by xtherion takes a map in which collation differences can be listed as 
-# {from to from to...}, sorts the mapped items, and retrieves only the original elements.
-set xth(collations,pt) { á a à a ã a â a é e ê e í i î i ó o ô o õ o ú u ù u û u ç c \
+# The collation aware sort code used by xtherion takes a map in which collation differences can be 
+# listed as {from to from to...}, sorts the mapped items, and retrieves only the original elements.
+#
+# Examples:
+#
+# Portuguese:
+# % lsort {ab ãc ae ãd}
+# ab ae ãc ãd
+# % collatesort {ab ãc ae ãd} {ã a}
+# ab ãc ãd ae
+#
+# Spanish (ll sorts after lz):
+# % collatesort {llano luxación leche} {ll lzz}
+# leche luxación llano
+#
+# German (umlauts sorted as if "ä" was "ae"):
+# % lsort {Bar Bär Bor}
+# Bar Bor Bär
+# % collatesort {Bar Bär Bor} {ä ae}
+# Bär Bar Bor
+#
+set xth(collation-maps,pt) { á a à a ã a â a é e ê e í i î i ó o ô o õ o ú u ù u û u ç c \
   Á A À A Ã A Â A É E Ê E Í I Î I Ó O Ô O Õ O Ú U Û U Ç C }
 
 set xth(length_units) {m cm in ft yd}

--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -64,6 +64,11 @@ if {[lsearch -exact $xth(kbencodings) [encoding system]] < 0} {
   lappend xth(kbencodings) [encoding system]
 }
 
+#The collation code used by xtherion takes a map in which collation differences can be listed as 
+# {from to from to...}, sorts the mapped items, and retrieves only the original elements.
+set xth(collations,pt) { á a à a ã a â a é e ê e í i î i ó o ô o õ o ú u ù u û u ç c \
+  Á A À A Ã A Â A É E Ê E Í I Î I Ó O Ô O Õ O Ú U Û U Ç C }
+
 set xth(length_units) {m cm in ft yd}
 set xth(angle_units) {deg min grad}
 set xth(point_types) {}

--- a/xtherion/init.tcl
+++ b/xtherion/init.tcl
@@ -189,10 +189,21 @@ foreach itm $xth(me,themes) {
 }
 
 proc xth_me_sortxlist {cl} {
-  set cl [lsort -index 0 $cl]
+	global xth
+
+  set lang [string range [::msgcat::mclocale] 0 1]
+  set map [expr {[info exists "xth(collations,$lang)"] ? $xth(collations,$lang) : {}}]
+
+  set l2 {}
+  foreach {sort} $cl {
+    lappend l2 [list [lrange $sort 0 1] [string map $map [lindex $sort 0]]]
+  }
+  set res {}
+  foreach e [lsort -dictionary -index 1 $l2] {lappend res [lindex $e 0]}
+
   set hl {}
   set sl {}
-  foreach xl $cl {
+  foreach xl $res {
     lappend sl [lindex $xl 0]
     lappend hl [lindex $xl 1]
   }

--- a/xtherion/init.tcl
+++ b/xtherion/init.tcl
@@ -192,7 +192,7 @@ proc xth_me_sortxlist {cl} {
 	global xth
 
   set lang [string range [::msgcat::mclocale] 0 1]
-  set map [expr {[info exists "xth(collations,$lang)"] ? $xth(collations,$lang) : {}}]
+  set map [expr {[info exists "xth(collation-maps,$lang)"] ? $xth(collation-maps,$lang) : {}}]
 
   set l2 {}
   foreach {sort} $cl {


### PR DESCRIPTION
Implemented simple collation sorting support so xtherion can sort translated texts properly.

To include support for proper collation for a new language, all that's needed is to create a mapping list { from to from to ...} for the desired language at _global.tcl_: xth(collations,XX) where XX is the language code.

