### PR TITLE
Use the directory of file passed from command line as initdir

### DIFF
--- a/xtherion/main.tcl
+++ b/xtherion/main.tcl
@@ -52,6 +52,13 @@ if {[llength $xth(app,list)] > 2} {
 }
 
 
+foreach idir $xth(idirs) {
+  catch {source [file join $idir xtherion.ini]}
+}
+catch {source xtherion.ini}
+
+set xth(gui,initdir) [file normalize $xth(gui,initdir)]
+
 set th2open 1
 set cfgopen 1
 
@@ -72,10 +79,5 @@ foreach fname $argv {
     xth_te_open_file 0 $fname 0
   }
 }
-
-foreach idir $xth(idirs) {
-  catch {source [file join $idir xtherion.ini]}
-}
-catch {source xtherion.ini}
 
 


### PR DESCRIPTION
When I open a file from explorer Therion uses the open file directory as the default directory