### PR TITLE
Fix problems with selection/copy/paste for text editors

### DIFF
--- a/xtherion/cp.tcl
+++ b/xtherion/cp.tcl
@@ -81,26 +81,7 @@ grid rowconf $txb 0 -weight 1
 grid $txb.txt -column 0 -row 0 -sticky news
 grid $txb.sv -column 1 -row 0 -sticky news
 grid $txb.sh -column 0 -row 1 -sticky news
-bind $txb.txt <$xth(kb_control)-Key-x> "tk_textCut $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-c> "tk_textCopy $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-v> "tk_textPaste $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-z> "catch {$txb.txt edit undo}"
-bind $txb.txt <$xth(kb_control)-Key-y> "catch {$txb.txt edit redo}"
-
-if {$xth(gui,bindinsdel)} {
-  bind $txb.txt <Delete> {
-    %W delete insert
-    %W see insert
-  }
-  bind $txb.txt <Shift-Key-Delete> "tk_textCut $txb.txt"
-  bind $txb.txt <$xth(kb_control)-Key-Insert> "tk_textCopy $txb.txt"
-  bind $txb.txt <Shift-Key-Insert> "tk_textPaste $txb.txt"
-#  catch {
-#    bind $txb.txt <Shift-Key-KP_Decimal> "tk_textCut $txb.txt"
-#    bind $txb.txt <$xth(kb_control)-Key-KP_Insert> "tk_textCopy $txb.txt"
-#    bind $txb.txt <Shift-Key-KP_0> "tk_textPaste $txb.txt"
-#  }
-}
+xth_app_text_copy_paste_binds $txb.txt
 
 # nechame tab, return originalny
 if {[info exists xth(gui,te)]} {
@@ -136,24 +117,7 @@ grid rowconf $txb 0 -weight 1
 grid $txb.txt -column 0 -row 0 -sticky news
 grid $txb.sv -column 1 -row 0 -sticky news
 grid $txb.sh -column 0 -row 1 -sticky news
-bind $txb.txt <$xth(kb_control)-Key-x> "tk_textCut $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-c> "tk_textCopy $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-v> "tk_textPaste $txb.txt"
-
-if {$xth(gui,bindinsdel)} {
-  bind $txb.txt <Delete> {
-    %W delete insert
-    %W see insert
-  }
-  bind $txb.txt <Shift-Key-Delete> "tk_textCut $txb.txt"
-  bind $txb.txt <$xth(kb_control)-Key-Insert> "tk_textCopy $txb.txt"
-  bind $txb.txt <Shift-Key-Insert> "tk_textPaste $txb.txt"
-#  catch {
-#    bind $txb.txt <Shift-Key-KP_Decimal> "tk_textCut $txb.txt"
-#    bind $txb.txt <$xth(kb_control)-Key-KP_Insert> "tk_textCopy $txb.txt"
-#    bind $txb.txt <Shift-Key-KP_0> "tk_textPaste $txb.txt"
-#  }
-}
+xth_app_text_copy_paste_binds $txb.txt
 
 xth_status_bar cp $txb.txt "Therion log file."
 
@@ -282,24 +246,7 @@ grid $txb.txt -column 0 -row 0 -sticky news
 grid $txb.sv -column 1 -row 0 -sticky news
 grid $txb.sh -column 0 -row 1 -sticky news
 xth_status_bar me $txb.txt [mc "Survey informations."]
-bind $txb.txt <$xth(kb_control)-Key-x> "tk_textCut $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-c> "tk_textCopy $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-v> "tk_textPaste $txb.txt"
-
-if {$xth(gui,bindinsdel)} {
-  bind $txb.txt <Delete> {
-    %W delete insert
-    %W see insert
-  }
-  bind $txb.txt <Shift-Key-Delete> "tk_textCut $txb.txt"
-  bind $txb.txt <$xth(kb_control)-Key-Insert> "tk_textCopy $txb.txt"
-  bind $txb.txt <Shift-Key-Insert> "tk_textPaste $txb.txt"
-#  catch {
-#    bind $txb.txt <Shift-Key-KP_Decimal> "tk_textCut $txb.txt"
-#    bind $txb.txt <$xth(kb_control)-Key-KP_Insert> "tk_textCopy $txb.txt"
-#    bind $txb.txt <Shift-Key-KP_0> "tk_textPaste $txb.txt"
-#  }
-}
+xth_app_text_copy_paste_binds $txb.txt
 
 
 

--- a/xtherion/init.tcl
+++ b/xtherion/init.tcl
@@ -93,30 +93,42 @@ bind $xth(gui,main) <Configure> {
 set xth(gui,clock) "00:00"
 
 # redefine some public key bindigs
+bind Text <$xth(kb_control)-Key-c> "#"
+bind Text <$xth(kb_control)-Key-v> "#"
+bind Text <$xth(kb_control)-Key-x> "#"
+bind Text <$xth(kb_control)-Key-z> "#"
+bind Text <$xth(kb_control)-Key-y> "#"
+
 if {$xth(gui,bindinsdel)} {
-  bind Text <Delete> { }
+  bind Text <Delete>                      "#"
+  bind Text <Shift-Key-Delete>            "#"
+  bind Text <$xth(kb_control)-Key-Insert> "#"
+  bind Text <Shift-Key-Insert>            "#"
 }
+
 bind Text <$xth(kb_control)-Key-o> "#"
 bind Text <$xth(kb_control)-Key-a> "#"
 bind Text <$xth(kb_control)-Key-i> "#"
 bind Text <$xth(kb_control)-Key-s> "#"
 bind Text <$xth(kb_control)-Key-w> "#"
 bind Text <$xth(kb_control)-Key-q> "#"
-bind Text <$xth(kb_control)-Key-x> "#"
 bind Text <$xth(kb_control)-Key-n> "#"
 bind Text <$xth(kb_control)-Key-p> "#"
-bind Text <$xth(kb_control)-Key-c> "#"
-bind Text <$xth(kb_control)-Key-v> "#"
 bind Text <$xth(kb_control)-Key-f> "#"
 bind Text <$xth(kb_control)-Key-h> "#"
-bind Text <$xth(kb_control)-Key-z> "#"
-bind Text <$xth(kb_control)-Key-y> "#"
 bind Text <$xth(kb_control)-Key-d> "#"
 bind Text <$xth(kb_control)-Key-k> "#"
 bind Text <$xth(kb_control)-Key-r> "#"
 
 bind Entry <$xth(kb_control)-Key-d> "#"
 bind Entry <$xth(kb_control)-Key-k> "#"
+bind Entry <$xth(kb_control)-Key-v> "tk_entryPaste %W"
+if {$xth(gui,bindinsdel)} {
+  bind Entry <Delete>                      "tk_entryDelete %W"
+  bind Entry <Shift-Key-Delete>            "tk_textCut %W"
+  bind Entry <$xth(kb_control)-Key-Insert> "tk_textCopy %W"
+  bind Entry <Shift-Key-Insert>            "tk_entryPaste %W"
+}
 
 set xth(gui,bind,text_tab) [bind Text <Tab>]
 set xth(gui,bind,text_return) [bind Text <Return>]

--- a/xtherion/me.tcl
+++ b/xtherion/me.tcl
@@ -1597,24 +1597,7 @@ grid $txb.sv -column 1 -row 0 -sticky news
 grid $txb.sh -column 0 -row 1 -sticky news
 grid $txb.upd -column 0 -row 2 -columnspan 2 -sticky news
 xth_status_bar me $txb.txt [mc "Editor for free text in therion 2D file."]
-bind $txb.txt <$xth(kb_control)-Key-x> "tk_textCut $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-c> "tk_textCopy $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-v> "tk_textPaste $txb.txt"
-
-if {$xth(gui,bindinsdel)} {
-  bind $txb.txt <Delete> {
-    %W delete insert
-    %W see insert
-  }
-  bind $txb.txt <Shift-Key-Delete> "tk_textCut $txb.txt"
-  bind $txb.txt <$xth(kb_control)-Key-Insert> "tk_textCopy $txb.txt"
-  bind $txb.txt <Shift-Key-Insert> "tk_textPaste $txb.txt"
-#  catch {
-#    bind $txb.txt <Shift-Key-KP_Decimal> "tk_textCut $txb.txt"
-#    bind $txb.txt <$xth(kb_control)-Key-KP_Insert> "tk_textCopy $txb.txt"
-#    bind $txb.txt <Shift-Key-KP_0> "tk_textPaste $txb.txt"
-#  }
-}
+xth_app_text_copy_paste_binds $txb.txt
 
 if {[info exists xth(gui,te)]} {
 #  bind $txb.txt <$xth(kb_control)-Key-a> "xth_te_text_select_all %W"
@@ -2287,24 +2270,7 @@ grid $txb.txt -column 0 -row 0 -sticky news
 grid $txb.sv -column 1 -row 0 -sticky news
 grid $txb.sh -column 0 -row 1 -sticky news
 xth_status_bar me $txb [mc "Editor for line point options."]
-bind $txb.txt <$xth(kb_control)-Key-x> "tk_textCut $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-c> "tk_textCopy $txb.txt"
-bind $txb.txt <$xth(kb_control)-Key-v> "tk_textPaste $txb.txt"
-
-if {$xth(gui,bindinsdel)} {
-  bind $txb.txt <Delete> {
-    %W delete insert
-    %W see insert
-  }
-  bind $txb.txt <Shift-Key-Delete> "tk_textCut $txb.txt"
-  bind $txb.txt <$xth(kb_control)-Key-Insert> "tk_textCopy $txb.txt"
-  bind $txb.txt <Shift-Key-Insert> "tk_textPaste $txb.txt"
-#  catch {
-#    bind $txb.txt <Shift-Key-KP_Decimal> "tk_textCut $txb.txt"
-#    bind $txb.txt <$xth(kb_control)-Key-KP_Insert> "tk_textCopy $txb.txt"
-#    bind $txb.txt <Shift-Key-KP_0> "tk_textPaste $txb.txt"
-#  }
-}
+xth_app_text_copy_paste_binds $txb.txt
 
 if {[info exists xth(gui,te)]} {
   bind $txb.txt <Tab> $xth(te,bind,text_tab)

--- a/xtherion/te.tcl
+++ b/xtherion/te.tcl
@@ -488,28 +488,9 @@ proc xth_te_create_file {} {
   bind $cfr.txt <$xth(kb_control)-Key-i> "$iac {xth_te_auto_indent}"
   bind $cfr.txt <$xth(kb_control)-Key-s> "$iac {xth_te_save_file 0 $cfid}"
   bind $cfr.txt <Destroy> "xth_te_before_close_file $cfid yesno"  
-#  if {$xth(gui,bindclip) == 1} {
-    bind $cfr.txt <$xth(kb_control)-Key-x> "$iac {tk_textCut $cfr.txt}"
-    bind $cfr.txt <$xth(kb_control)-Key-c> "$iac {tk_textCopy $cfr.txt}"
-    bind $cfr.txt <$xth(kb_control)-Key-v> "$iac {tk_textPaste $cfr.txt}"
-    bind $cfr.txt <$xth(kb_control)-Key-z> "$iac {catch {$cfr.txt edit undo}}"
-    bind $cfr.txt <$xth(kb_control)-Key-y> "$iac {catch {$cfr.txt edit redo}}"
-  if {$xth(gui,bindinsdel)} {
-    bind $cfr.txt <Delete> {
-      %W delete insert
-      %W see insert
-    }
-    bind $cfr.txt <Shift-Key-Delete> "$iac {tk_textCut $cfr.txt}"
-    bind $cfr.txt <$xth(kb_control)-Key-Insert> "$iac {tk_textCopy $cfr.txt}"
-    bind $cfr.txt <Shift-Key-Insert> "$iac {tk_textPaste $cfr.txt}"
-#    catch {
-#      bind $cfr.txt <Shift-Key-KP_Decimal> "$iac {tk_textCut $cfr.txt}"
-#      bind $cfr.txt <$xth(kb_control)-Key-KP_Insert> "$iac {tk_textCopy $cfr.txt}"
-#      bind $cfr.txt <Shift-Key-KP_0> "$iac {tk_textPaste $cfr.txt}"
-#    }
-  }
-#  }
-    
+
+  xth_app_text_copy_paste_binds $cfr.txt $iac
+
   grid columnconf $cfr 0 -weight 1
   grid rowconf $cfr 0 -weight 1
   grid $cfr.txt -column 0 -row 0 -sticky news


### PR DESCRIPTION
1) added removal of selected text for Paste/Del
2) fixed doubled paste with Ctrl+Ins
3) enabled Ctrl+Ins/Shift+Ins for single line text editors