### PR TITLE
Last updated Loch Translation not incorpored in executable file

### DIFF
--- a/loch/locale/es/loch.po
+++ b/loch/locale/es/loch.po
@@ -866,7 +866,7 @@ msgstr "&Importar...\tCtrl+I"
 # c:/cave/loch/loch/lxGUI.cxx:264
 #: lxGUI.cxx:264
 msgid "&Export...\tCtrl+X"
-msgstr ""&Exportar...\tCtrl+X"
+msgstr "&Exportar...\tCtrl+X"
 
 # c:/cave/loch/loch/lxGUI.cxx:313
 #: lxGUI.cxx:313


### PR DESCRIPTION
The last updated spanish Loch translation is not incorporated in the executable file. I thinks is because the "/es/loch.mo" is not updated with the changes. The "/es/loch.po" file is 9 days ago and "/es/loch.mo" is 26 days ago.

Checking the file I have found a minor error.