### PR TITLE
Clean compiled help files

### DIFF
--- a/loch/Makefile
+++ b/loch/Makefile
@@ -224,6 +224,7 @@ clean:
 	perl makefile.pl rm -q *.zip
 	perl makefile.pl rm -q *.pdf
 	perl makefile.pl rm -q *.png
+	$(MAKE) -C help clean
 
 
 

--- a/loch/help/Makefile
+++ b/loch/help/Makefile
@@ -1,3 +1,7 @@
 all:
 	$(MAKE) -i -C ./en
 	$(MAKE) -i -C ./sk
+
+clean:
+	$(MAKE) -C ./en clean
+	$(MAKE) -C ./sk clean

--- a/loch/help/en/Makefile
+++ b/loch/help/en/Makefile
@@ -7,4 +7,4 @@ loch.htb: loch.hhp loch.hhc loch.hhk loch.htm
 	zip loch.htb loch.hhp loch.hhc loch.hhk loch.htm
 
 clean:
-	$(RM) loch.chm loch.htb
+	perl ../../../makefile.pl rm -q loch.chm loch.htb

--- a/loch/help/en/Makefile
+++ b/loch/help/en/Makefile
@@ -6,3 +6,5 @@ loch.chm: loch.hhp loch.hhc loch.hhk loch.htm
 loch.htb: loch.hhp loch.hhc loch.hhk loch.htm
 	zip loch.htb loch.hhp loch.hhc loch.hhk loch.htm
 
+clean:
+	$(RM) loch.chm loch.htb

--- a/loch/help/sk/Makefile
+++ b/loch/help/sk/Makefile
@@ -7,4 +7,4 @@ loch.htb: loch.hhp loch.hhc loch.hhk loch.htm
 	zip loch.htb loch.hhp loch.hhc loch.hhk loch.htm
 
 clean:
-	$(RM) loch.chm loch.htb
+	perl ../../../makefile.pl rm -q loch.chm loch.htb

--- a/loch/help/sk/Makefile
+++ b/loch/help/sk/Makefile
@@ -6,3 +6,5 @@ loch.chm: loch.hhp loch.hhc loch.hhk loch.htm
 loch.htb: loch.hhp loch.hhc loch.hhk loch.htm
 	zip loch.htb loch.hhp loch.hhc loch.hhk loch.htm
 
+clean:
+	$(RM) loch.chm loch.htb


### PR DESCRIPTION
This is a patch by Wookey from the Debian packaging, plus a tweak from me to make it use `makefile.pl rm` instead of `$(RM)` (not sure why therion eschews `$(RM)` but it seems better to be consistent).