### PR TITLE
Revert "fix travis osx environment"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then   sudo apt-get install -y texlive-binaries texlive-metapost libwxgtk3.0-dev libvtk6-dev survex imagemagick      ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then   sudo apt-get install -y mxe-i686-w64-mingw32.static-binutils mxe-i686-w64-mingw32.static-bzip2 mxe-i686-w64-mingw32.static-expat mxe-i686-w64-mingw32.static-freetype-bootstrap mxe-i686-w64-mingw32.static-gcc mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-glib mxe-i686-w64-mingw32.static-harfbuzz mxe-i686-w64-mingw32.static-jpeg mxe-i686-w64-mingw32.static-libiconv mxe-i686-w64-mingw32.static-libpng mxe-i686-w64-mingw32.static-tiff mxe-i686-w64-mingw32.static-vtk mxe-i686-w64-mingw32.static-wxwidgets mxe-i686-w64-mingw32.static-xz mxe-i686-w64-mingw32.static-zlib      ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then   brew update                     ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then   brew upgrade python             ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then   brew tap homebrew/core          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then   brew cask uninstall oclint; fi  # conflicting files workaround
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then   brew install freetype wxmac vtk ; fi


### PR DESCRIPTION
Travis seems to have now upgraded to a more recent homebrew where
"brew upgrade python" is not required and now causes the build to
fail.  (Kudos to James Aylett who solved the same issue in
Xapian's .travis.yml).

This reverts commit c961919a2f878a2a77beb97fe166782187b503fb.