### PR TITLE
Make metapost output reproducible

### DIFF
--- a/mpost/therion.mp
+++ b/mpost/therion.mp
@@ -41,6 +41,10 @@
 tracingstats:=1;
 prologues:=0;
 
+% Set the random seed to a fixed value so therion reproducibly produces the
+% same output for a given input.
+randomseed:=42;
+
 if known Background: background:=Background fi;
 %TrueScale:=Scale;
 


### PR DESCRIPTION
Set the mpost randomseed so that the same input gives the same output.
The particular motivation is to make the Debian package build
reproducible, and currently it fails to be for the samples.

This seems more widely desirable though - as a user it seems weird
that things like generated rocks change shape each time you generate
a PDF.