### PR TITLE
Allow building against system libproj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CMNOBJECTS = thdate.o extern/shpopen.o extern/dbfopen.o \
   extern/lxMath.o extern/lxFile.o thdb3d.o thsurface.o thimport.o thsvg.o thepsparse.o \
   thtrans.o thwarpp.o thwarppt.o thwarppme.o thwarp.o thexpshp.o thattr.o thtex.o \
   extern/poly2tri/common/shapes.o extern/poly2tri/sweep/advancing_front.o extern/poly2tri/sweep/sweep.o extern/poly2tri/sweep/cdt.o extern/poly2tri/sweep/sweep_context.o \
-  therion.o extern/proj4/libproj.a extern/quickhull/QuickHull.o
+  therion.o extern/quickhull/QuickHull.o
 
 CROSS =
 EXT =
@@ -117,6 +117,18 @@ LDBFLAGS = $(LDPFLAGS)
 
 # BUILD ENDCONFIG
 
+# PROJ CONFIG
+
+# PROJ BUNDLED
+CMNOBJECTS += extern/proj4/libproj.a
+PROJ_LIBS =
+PROJ_API_H = extern/proj4/proj_api.h
+
+# PROJ SYSTEM
+##PROJ_LIBS = $(shell pkg-config proj --libs)
+##PROJ_API_H = $(shell pkg-config proj --variable=includedir)/proj_api.h
+
+# PROJ ENDCONFIG
 
 # compiler settings
 CXXFLAGS = -Wall $(CXXPFLAGS) $(CXXBFLAGS) -std=c++11
@@ -125,7 +137,7 @@ OBJECTS = $(addprefix $(OUTDIR)/,$(POBJECTS)) $(addprefix $(OUTDIR)/,$(CMNOBJECT
 
 
 # linker settings
-LIBS =
+LIBS = $(PROJ_LIBS)
 LDFLAGS = $(LDBFLAGS)
 
 
@@ -144,7 +156,6 @@ $(OUTDIR)/%.o : %.c
 all: version outdirs $(OUTDIR)/therion doc xtherion/xtherion $(LOCHEXE)
 
 outdirs:
-	mkdir -p $(OUTDIR)/extern/proj4
 	mkdir -p $(OUTDIR)/extern/poly2tri/sweep/
 	mkdir -p $(OUTDIR)/extern/poly2tri/common/
 	mkdir -p $(OUTDIR)/extern/quickhull
@@ -157,6 +168,7 @@ version:
 
 
 $(OUTDIR)/extern/proj4/libproj.a: extern/proj4/*.c extern/proj4/*.h
+	mkdir -p $(OUTDIR)/extern/proj4
 	$(MAKE) -C ./extern/proj4
 
 $(OUTDIR)/therion: version $(OBJECTS)
@@ -393,7 +405,7 @@ $(OUTDIR)/thconfig.o: thconfig.cxx thconfig.h thbuffer.h thmbuffer.h thinput.h \
 $(OUTDIR)/thconvert.o: thconvert.cxx thpdfdbg.h thexception.h therion.h thbuffer.h \
  thpdfdata.h thepsparse.h thtexfonts.h
 $(OUTDIR)/thcs.o: thcs.cxx thcs.h thcsdata.h thparse.h thbuffer.h thmbuffer.h \
- thexception.h therion.h extern/proj4/proj_api.h thdatabase.h \
+ thexception.h therion.h $(PROJ_API_H) thdatabase.h \
  thdataobject.h thperson.h thdate.h thdataleg.h thobjectname.h \
  thobjectsrc.h thinfnan.h thlayoutclr.h thdb1d.h thobjectid.h thdb3d.h \
  loch/lxMath.h thattr.h thchenc.h thchencdata.h thdb2d.h thdb2dprj.h \
@@ -837,7 +849,7 @@ $(OUTDIR)/thpoint.o: thpoint.cxx thpoint.h th2ddataobject.h thdataobject.h \
  thsymbolsetlist.h thlocale.h thlang.h thlangdata.h thtflength.h thtf.h \
  thtexfonts.h thscrap.h thsketch.h thpic.h thtrans.h
 $(OUTDIR)/thproj.o: thproj.cxx thexception.h therion.h thbuffer.h \
- extern/proj4/proj_api.h
+ $(PROJ_API_H)
 $(OUTDIR)/thscrap.o: thscrap.cxx thscrap.h thdataobject.h thdatabase.h thmbuffer.h \
  thbuffer.h thdb1d.h thobjectid.h thinfnan.h thdataleg.h thparse.h \
  thobjectname.h therion.h thobjectsrc.h thdb3d.h loch/lxMath.h thattr.h \


### PR DESCRIPTION
Linux distros dislike use of bundled code copies because it means a lot
more work for security fixes to the bundled code.  The Debian package
of therion currently has a special patch to make it build with the
system libproj.

This change provides a simple way to switch the build use to use the
system libproj instead of the bundled version:

perl ./makeconfig.pl PROJ SYSTEM

And to switch back to using the bundled code copy:

perl ./makeconfig.pl PROJ BUNDLED