### PR TITLE
thbook: update 'freetype-config' requirement to 'pkg-config freetype2'

### DIFF
--- a/thbook/ch06.tex
+++ b/thbook/ch06.tex
@@ -42,8 +42,8 @@ If you want to compile Therion from source code and run it, you need
 To compile Loch, you need
 
 \list
-* freetype 2 and newer; freetype-config must work
-* wxWidgets 2.6 and newer; wx-config must work
+* freetype 2 and newer; 'pkg-config freetype2' must work
+* wxWidgets 2.6 and newer; 'wx-config' must work
 * VTK 5.0 and newer
 * libjpeg, libpng, zlib
 \endlist


### PR DESCRIPTION
freetype config requirement needs updating from 'freetype-config' to 'pkg-config freetype2' in Therion Book.