### PR TITLE
Updating URL for 'Metapost A user's manual' to a working one

### DIFF
--- a/thbook/ch05.tex
+++ b/thbook/ch05.tex
@@ -390,7 +390,7 @@ visualization. It's described in
 
 \list
   Hobby, J. D.: {\it A User's Manual for MetaPost}, available at \hfil\break
-     \www{http://cm.bell-labs.com/cm/cs/cstr/162.ps.gz}
+     \www{https://www.tug.org/docs/metapost/mpman.pdf}
 \endlist
 
 The user may also benefit from comprehensive reference to the {\manfnt METAFONT} 


### PR DESCRIPTION
The URL for Hobby's "A User's Manual for MetaPost" in Therion's Book doesn't work: domain error.

I changed it for a working one.