### PR TITLE
find no-suffix VTK installation

### DIFF
--- a/loch/Makefile
+++ b/loch/Makefile
@@ -19,12 +19,23 @@ CMNOBJECTS = \
 CROSS =
 EXT =
 
+WX_CONFIG = wx-config
+
+VTKSUFFIX = $(shell tclsh ./getvtkver.tcl suffix)
 VTKVERSION = $(shell tclsh ./getvtkver.tcl version)
 VTKPATH = $(shell tclsh ./getvtkver.tcl incpath)
 VTKLIBPATH = $(shell tclsh ./getvtkver.tcl libpath)
 VTKV6 = $(shell tclsh ./getvtkver.tcl version6)
 ifeq ($(VTKV6),1)
-VTKLIBS = -lvtkCommonExecutionModel-$(VTKVERSION) -lvtkCommonDataModel-$(VTKVERSION) -lvtkCommonCore-$(VTKVERSION) -lvtkFiltersCore-$(VTKVERSION) -lvtkFiltersHybrid-$(VTKVERSION) -lvtkIOLegacy-$(VTKVERSION) -lfreetype -lpng -ljpeg
+VTKLIBS = \
+    -lvtkCommonExecutionModel$(VTKSUFFIX) \
+    -lvtkCommonDataModel$(VTKSUFFIX) \
+    -lvtkCommonCore$(VTKSUFFIX) \
+    -lvtkFiltersCore$(VTKSUFFIX) \
+    -lvtkFiltersHybrid$(VTKSUFFIX) \
+    -lvtkIOLegacy$(VTKSUFFIX) \
+    $(shell pkg-config --libs freetype2) \
+    -lpng -ljpeg
 else
 VTKLIBS = -lvtkHybrid -lvtkImaging -lvtkIO -lvtkGraphics -lvtkFiltering -lvtkCommon -lvtkjpeg -lvtkpng -lvtkzlib -lvtksys -lfreetype
 endif
@@ -54,17 +65,27 @@ STRIPFLAG = -s
 # PLATFORM DEBIAN
 CXX = c++
 CC = gcc
-POBJECTS = lxR2P.o
 ifeq ($(VTKV6),1)
-VTKLIBS = -lvtkCommonExecutionModel-$(VTKVERSION) -lvtkCommonDataModel-$(VTKVERSION) -lvtkCommonCore-$(VTKVERSION) -lvtkFiltersCore-$(VTKVERSION) -lvtkFiltersHybrid-$(VTKVERSION) -lvtkIOLegacy-$(VTKVERSION) -lfreetype -lpng -ljpeg
 else
 VTKLIBS = -lvtkHybrid -lvtkImaging -lvtkIO -lvtkGraphics -lvtkFiltering -lvtkCommon -lfreetype
 endif
-CXXPFLAGS = -DLXLINUX -std=c++11 $(shell wx-config --cxxflags) -Wno-deprecated $(shell pkg-config freetype2 --cflags) -I$(VTKPATH)
-CCPFLAGS = -DLXLINUX  $(shell wx-config --cflags)
+CXXPFLAGS = \
+    -std=c++11 \
+    -Wno-deprecated \
+    $(shell $(WX_CONFIG) --cxxflags) \
+    $(shell pkg-config freetype2 --cflags) \
+    -I$(VTKPATH)
+CCPFLAGS = $(shell $(WX_CONFIG) --cflags)
 LXLIBDIR = linux
 PLIBS = $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS) -lGLU -lGL -lpthread -lX11 -lz
 LXPLATFORM = LINUX
+
+# LXLINUX doesn't work with Arch Linux
+ifneq ($(shell lsb_release -si),Arch)
+  POBJECTS = lxR2P.o
+  CXXPFLAGS += -DLXLINUX
+  CCPFLAGS += -DLXLINUX
+endif
 
 # PLATFORM WIN32
 ##CXX = c++
@@ -139,8 +160,8 @@ LDBFLAGS = $(STRIPFLAG)
 
 
 # compiler settings
-CXXFLAGS = -Wall -D_GNU_SOURCE -DLOCH $(CXXPFLAGS) $(CXXBFLAGS)
-CCFLAGS = -Wall -D_GNU_SOURCE -DLOCH $(CCPFLAGS) $(CCBFLAGS)
+CXXFLAGS := -Wall -D_GNU_SOURCE -DLOCH $(CXXPFLAGS) $(CXXBFLAGS)
+CCFLAGS := -Wall -D_GNU_SOURCE -DLOCH $(CCPFLAGS) $(CCBFLAGS)
 OBJECTS = $(addprefix $(LOUTDIR)/,$(POBJECTS)) $(addprefix $(LOUTDIR)/,$(CMNOBJECTS))
 
 

--- a/loch/getvtkver.tcl
+++ b/loch/getvtkver.tcl
@@ -1,4 +1,5 @@
 set ver 5.4
+set suffix -$ver
 set incpath "/usr/local/include/vtk-$ver"
 set libpath "/usr/local/lib/vtk-$ver"
 set vv1 0
@@ -12,9 +13,27 @@ foreach d {/usr /usr/local} {
 		set vv1 $v1
 		set vv2 $v2
 		set ver $vv1.$vv2
+		set suffix -$ver
 		set incpath "$d/include/vtk-$vv1.$vv2"
 		set libpath "$d/lib/vtk-$vv1.$vv2"
 	    }
+	} elseif {[regexp {vtk$} $l]} {
+	    if [catch {set fp [open $l/vtkVersionMacros.h]}] {
+		set ver "unknown"
+	    } else {
+		while {[gets $fp line] >= 0} {
+		    if {[regexp {VTK_MAJOR_VERSION (\d+)} $line dum v1]} {
+			set vv1 $v1
+		    } elseif {[regexp {VTK_MINOR_VERSION (\d+)} $line dum v2]} {
+			set vv2 $v2
+		    }
+		}
+		close $fp
+		set ver $vv1.$vv2
+	    }
+	    set suffix ""
+	    set incpath "$d/include/vtk"
+	    set libpath "$d/lib"
 	}
     }
 }
@@ -28,6 +47,9 @@ switch [lindex $argv 0] {
     }
     version6 {
         puts [expr $vv1 >= 6]
+    }
+    suffix {
+	puts $suffix
     }
     default {
 	puts $ver


### PR DESCRIPTION
Don't require VTK headers and libraries to have `-X.Y` version suffix.