### PR TITLE
Xtherion: add thconfig* to selectable config file list; unified lists

### DIFF
--- a/threpair-files
+++ b/threpair-files
@@ -13,7 +13,7 @@ proc repair_file {fnm} {
 
 proc scan_directory {dnm} {
   puts "scanning directory $dnm"
-  set files [glob -nocomplain -directory $dnm *.th *.th2 *.th3 *.thcfg thconfig*]
+  set files [glob -nocomplain -directory $dnm *.th *.th2 *.th3 *.thcfg thconfig* *.thconfig]
   set dirs [glob -nocomplain -directory $dnm -type d *]
   foreach sfl $files {
     repair_file $sfl

--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -107,8 +107,7 @@ set xth(app,me,filetypes) {
 }
 
 set xth(app,cp,filetypes) {    
-  {{Therion config files}       {thconfig*}}    
-  {{Therion config files }       {.thcfg .thconfig}}    
+  {{Therion config files }       {.thcfg .thconfig thconfig*}}    
   {{All files}       {*}}    
 }
 


### PR DESCRIPTION
There were two select lists for file formats in xtherion. This PR unifies them, allowing (already supported) files with naming scheme "xyz.thconfig" to be showed in the open-file dialogue list without the need to switch to the second data filter.

Now, enhanced usability:
![grafik](https://user-images.githubusercontent.com/13608602/70802241-38591300-1db1-11ea-89da-be5fbd2beae2.png)


Prevoius, one needs to switch:
![grafik](https://user-images.githubusercontent.com/13608602/70802298-5fafe000-1db1-11ea-9cf1-68315863a037.png)
![grafik](https://user-images.githubusercontent.com/13608602/70802337-82da8f80-1db1-11ea-9b35-8792138014e7.png)
