### PR TITLE
thbook: example command for installing dependencies

### DIFF
--- a/thbook/ch06.tex
+++ b/thbook/ch06.tex
@@ -80,6 +80,32 @@ It's a distribution of GNU utilities with GNU make and GCC.
 
 \subsubchapter Hacker's guide.
 
+{\it Installing dependencies}
+
+Ubuntu 18.04 example command for installing dependencies to compile Therion:
+
+\list
+* |sudo apt-get -y install|
+  |bwidget|
+  |gcc|
+  |ghostscript|
+  |imagemagick|
+  |lcdf-typetools|
+  |libfreetype6-dev|
+  |libjpeg-dev|
+  |libpng-dev|
+  |libproj-dev|
+  |libtk-img-dev|
+  |libtk-img|
+  |libvtk6-dev|
+  |libvtk6.3|
+  |libwxgtk3.0-dev|
+  |tcl-dev|
+  |texlive-latex-base|
+  |zlib1g-dev|
+  |zlib1g|
+\endlist
+
 {\it Make parameters}
 
 Therion's {\it makefile} may take some optional parameters.


### PR DESCRIPTION
Included an example on how to install all dependencies to compile Therion (for Ubuntu 18.04).