### PR TITLE
Update texts.txt

### DIFF
--- a/thlang/texts.txt
+++ b/thlang/texts.txt
@@ -1470,7 +1470,7 @@ en: altar
 pt: altar
 
 therion: point archeo-excavation
-en: archeo-excavation
+en: archaeological excavation
 pt: escavação arqueológica
 
 therion: point audio

--- a/thlang/texts.txt
+++ b/thlang/texts.txt
@@ -3333,7 +3333,9 @@ sl: Datum merjenja
 
 therion: title color-legend-default
 ca: Llegenda de colors
-en: Color legend
+en: Colour legend
+en_GB: Colour legend
+en_US: Color legend
 es: Leyenda de colores
 fr: Légende colorée
 pt: Cores

--- a/thlang/texts.txt
+++ b/thlang/texts.txt
@@ -480,6 +480,7 @@ cz: vstupní propast
 de: Eingangsschacht
 en: entrance pit
 en_GB: entrance pitch
+en_US: entrance pit
 es: pozo de entrada
 fr: mur-puits
 it: parete:pozzo
@@ -1080,6 +1081,7 @@ ca: pou
 cz: propast
 de: Schacht
 el: πηγάδι
+en: pit
 en_GB: pitch
 en_US: pit
 es: pozo


### PR DESCRIPTION
Rationalise English Translations for Pit - Pitch

Make the en, en_GB and en_US translations for pit/pitch consistent with
each other.

* Include an explicit translation for en, so that it is clear that this
  will be used in case a variant other than GB or US is specified by a
  user
* It is assumed that generic en usage would be 'pit' and that only 'GB'
  uses 'pitch'