### PR TITLE
fix -Warray-bounds

### DIFF
--- a/mpost/genmpost.pl
+++ b/mpost/genmpost.pl
@@ -73,7 +73,7 @@ sub process_symbols {
   print OUT "int thsymsets_count[thsymsets_size];\n\n";
   print OUT "std::map<unsigned, std::string> thsymsets_comment;\n\n";
   print OUT "\n\n\nvoid thsymsets_symbols_init() {\n";
-  print OUT "\tsize_t i, j;\n\tfor(i = 0; i <= thsymbolset_size; i++)\n";
+  print OUT "\tsize_t i, j;\n\tfor(i = 0; i < thsymbolset_size; i++)\n";
   print OUT "\t\tfor(j = 0; j < thsymsets_size; j++) \n\t\t\tthsymsets_symbols[i][j] = 0;\n\t\t\n\t\n";
   foreach $s1 (reverse sort keys %SYMBOLS) {
     if (($s1 eq "p") || ($s1 eq "a") || ($s1 eq "l")) {


### PR DESCRIPTION
GCC 10.1 reports this warning:
```
thsymbolsets.cxx: In function ‘void thsymsets_symbols_init()’:
thsymbolsets.cxx:20:28: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’ forming offset [9324, 9359] is out of the bounds [0, 9324] of object ‘thsymsets_symbols’ with type ‘int [259][9]’ [-Warray-bounds]
   20 |    thsymsets_symbols[i][j] = 0;
      |    ~~~~~~~~~~~~~~~~~~~~~~~~^~~
thsymbolsets.cxx:3:5: note: ‘thsymsets_symbols’ declared here
    3 | int thsymsets_symbols [thsymbolset_size][thsymsets_size];
      |     ^~~~~~~~~~~~~~~~~
```

I have fixed the out of the bounds access to the memory.