### PR TITLE
fix memory management issues in thinput

### DIFF
--- a/thinput.cxx
+++ b/thinput.cxx
@@ -105,7 +105,7 @@ thinput::thinput()
 thinput::~thinput()
 {
   delete this->first_ptr;
-  delete this->lnbuffer;
+  delete[] this->lnbuffer;
 }
 
 

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -51,16 +51,7 @@ thinput::ifile::ifile(ifile * fp)
   this->lnumber = 0;
   this->encoding = TT_UTF_8;
   this->prev_ptr = fp;
-  this->next_ptr = NULL;
 }
-
-
-thinput::ifile::~ifile()
-{
-  this->close();
-  delete this->next_ptr;
-}
-
 
 void thinput::ifile::close()
 {
@@ -92,22 +83,14 @@ thinput::thinput()
   this->cmd_sensitivity = true;
   this->input_sensitivity = true;
   this->scan_search_path = false;
-  this->first_ptr = new ifile(NULL);
-  this->last_ptr = this->first_ptr;
-  this->lnbuffer = new char [thinput::max_line_size];
+  this->first_ptr = std::unique_ptr<ifile>(new ifile(nullptr));
+  this->last_ptr = this->first_ptr.get();
+  this->lnbuffer = std::unique_ptr<char[]>(new char [thinput::max_line_size]);
   this->pifo = false;
   this->pifoid = NULL;
   this->pifoproc = NULL;
   this->report_missing = false;
 }
-
-
-thinput::~thinput()
-{
-  delete this->first_ptr;
-  delete[] this->lnbuffer;
-}
-
 
 void thinput::set_cmd_sensitivity(bool cs)
 {
@@ -202,10 +185,10 @@ void thinput::open_file(char * fname)
   ifile * ifptr;
   ifptr = this->last_ptr;
   while (ifptr->sh.is_open() && (ifptr->next_ptr != NULL))
-    ifptr = ifptr->next_ptr;
+    ifptr = ifptr->next_ptr.get();
   if (ifptr->sh.is_open() && (ifptr->next_ptr == NULL)) {
-    ifptr->next_ptr = new ifile(ifptr);
-    ifptr = ifptr->next_ptr;
+    ifptr->next_ptr = std::unique_ptr<ifile>(new ifile(ifptr));
+    ifptr = ifptr->next_ptr.get();
   }
   
   // now, let's open the file
@@ -342,14 +325,14 @@ void thinput::close_file()
 void thinput::reset()
 {
   // first, let's close all open files
-  ifile * iptr = this->first_ptr;
+  ifile * iptr = this->first_ptr.get();
   while(iptr != NULL) {
     iptr->close();
-    iptr = iptr->next_ptr;
+    iptr = iptr->next_ptr.get();
   }
   
   // set pointer to the first ifile
-  this->last_ptr = this->first_ptr;
+  this->last_ptr = this->first_ptr.get();
   this->open_file(this->file_name);  
 }
 
@@ -376,7 +359,7 @@ char * thinput::read_line()
     }
 
     // OK, we can read the line
-    this->last_ptr->sh.getline(this->lnbuffer, thinput::max_line_size);
+    this->last_ptr->sh.getline(this->lnbuffer.get(), thinput::max_line_size);
     this->last_ptr->lnumber++;
 
     // Check, if reading was OK.
@@ -387,8 +370,8 @@ char * thinput::read_line()
     }
     
     // now let's find last non white character
-    lnlen = (long)strlen(this->lnbuffer);
-    idxptr = this->lnbuffer + lnlen - 1;
+    lnlen = (long)strlen(this->lnbuffer.get());
+    idxptr = this->lnbuffer.get() + lnlen - 1;
     while ((lnlen > 0) && (*idxptr < 33)) {
       idxptr--;
       lnlen--;
@@ -401,19 +384,19 @@ char * thinput::read_line()
     // join backslash ended lines together
     if (*idxptr == '\\') {
       if (mline) {
-        this->linebf.strncat(this->lnbuffer, lnlen - 1);
+        this->linebf.strncat(this->lnbuffer.get(), lnlen - 1);
       }
       else {
-        this->linebf.strncpy(this->lnbuffer, lnlen - 1);
+        this->linebf.strncpy(this->lnbuffer.get(), lnlen - 1);
         mline = true;
       }
       continue;
     }
     else {
       if (mline)
-        this->linebf.strncat(this->lnbuffer, lnlen);
+        this->linebf.strncat(this->lnbuffer.get(), lnlen);
       else
-        this->linebf.strncpy(this->lnbuffer, lnlen);
+        this->linebf.strncpy(this->lnbuffer.get(), lnlen);
     }
     
     mline = false;

--- a/thinput.h
+++ b/thinput.h
@@ -38,6 +38,7 @@
 #include "thmbuffer.h"
 #include "thparse.h"
 #include <fstream>
+#include <memory>
 
 
 /**
@@ -67,7 +68,7 @@ class thinput {
     valuebf;  ///< Value buffer.
     
   static const long max_line_size;
-  char * lnbuffer;
+  std::unique_ptr<char[]> lnbuffer;
   
 
   /**
@@ -82,8 +83,8 @@ class thinput {
       path;  ///< Input file path buffer.
     unsigned long lnumber;  /// Position at the file.
     int encoding;  /// Current file encoding.
-    ifile * prev_ptr,  /// Pointer to the upper file.
-      * next_ptr;  /// Pointer to the lower file.
+    ifile * prev_ptr;  /// Pointer to the upper file.
+    std::unique_ptr<ifile> next_ptr;  /// Pointer to the lower file.
 #ifdef THMSVC
     struct _stat st;
 #else
@@ -96,16 +97,6 @@ class thinput {
      */
     
     ifile(ifile * fp);
-    
-    
-    /**
-     * Standard destructor.
-     *
-     * Also release next files.
-     */
-    
-    ~ifile();
-    
     
     /**
      * Close file if it's open.
@@ -129,8 +120,8 @@ struct stat
   };
   
   
-  ifile * first_ptr,  ///< Pointer to the first file.
-    * last_ptr;  ///< Pointer to the last file.
+  std::unique_ptr<ifile> first_ptr;  ///< Pointer to the first file.
+  ifile * last_ptr;  ///< Pointer to the last file.
 
 
   bool is_first_file();
@@ -157,15 +148,7 @@ struct stat
    */
   
   thinput();
-  
-  
-  /**
-   * Destructor.
-   */
-  
-  ~thinput();
-  
-  
+
   /**
    * Set command sensitivity state.
    */


### PR DESCRIPTION
If you compile therion with Address Sanitizer, then the following build step fails with this report:
```
./therion --print-library-src thlibrarydata.thcfg > thlibrarydata.log
=================================================================
==117922==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x63100003c800
    #0 0x7f6b6167cab9 in operator delete(void*) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:160
    #1 0x559d707d7884 in thinput::~thinput() /home/afforix/Dropbox/Devel/C++/therion/thinput.cxx:108
    #2 0x559d7087adfc in thinit::~thinit() /home/afforix/Dropbox/Devel/C++/therion/thinit.cxx:94
    #3 0x7f6b60e10c56 in __run_exit_handlers (/usr/lib/libc.so.6+0x3ec56)
    #4 0x7f6b60e10dfd in __GI_exit (/usr/lib/libc.so.6+0x3edfd)
    #5 0x559d70cb2c5c in thexit(int) /home/afforix/Dropbox/Devel/C++/therion/therion.cxx:193
    #6 0x559d707a1c16 in main (/home/afforix/Dropbox/Devel/C++/therion/therion+0x59cc16)
    #7 0x7f6b60df9001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)
    #8 0x559d707a145d in _start (/home/afforix/Dropbox/Devel/C++/therion/therion+0x59c45d)

0x63100003c800 is located 0 bytes inside of 65535-byte region [0x63100003c800,0x63100004c7ff)
allocated by thread T0 here:
    #0 0x7f6b6167c0c1 in operator new[](unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x559d707d7615 in thinput::thinput() /home/afforix/Dropbox/Devel/C++/therion/thinput.cxx:97
    #2 0x559d7087ab16 in thinit::thinit() /home/afforix/Dropbox/Devel/C++/therion/thinit.cxx:84
    #3 0x559d7087ea3e in __static_initialization_and_destruction_0 /home/afforix/Dropbox/Devel/C++/therion/thinit.cxx:789
    #4 0x559d7087ea73 in _GLOBAL__sub_I_THCCC_INIT_FILE /home/afforix/Dropbox/Devel/C++/therion/thinit.cxx:789
    #5 0x559d70cbf51c in __libc_csu_init (/home/afforix/Dropbox/Devel/C++/therion/therion+0xaba51c)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:160 in operator delete(void*)
```
I have fixed the `delete[]` operator.