### PR TITLE
Fix noisy Clang warning

### DIFF
--- a/thdataleg.h
+++ b/thdataleg.h
@@ -409,8 +409,8 @@ class thdataleg {
 
   int walls, shape, gridcs;
   
-  class thdb1d_loop * loop; ///< Worst loop leg is a part of.
-  class thdb1d_traverse * traverse; ///< Centreline traverse, leg is a part of.
+  struct thdb1d_loop * loop; ///< Worst loop leg is a part of.
+  struct thdb1d_traverse * traverse; ///< Centreline traverse, leg is a part of.
 
   thobjectname station, from, to;
   class thsurvey * psurvey;  ///< parent survey


### PR DESCRIPTION
Clang 10 reports these warnings multiple times:
```
./thdb1d.h:54:1: warning: 'thdb1d_loop' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
struct thdb1d_loop {
^
./thdataleg.h:412:3: note: did you mean struct here?
  class thdb1d_loop * loop; ///< Worst loop leg is a part of.
  ^~~~~
  struct
  
./thdb1d.h:63:1: warning: 'thdb1d_traverse' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
struct thdb1d_traverse {
^
./thdataleg.h:413:3: note: did you mean struct here?
  class thdb1d_traverse * traverse; ///< Centreline traverse, leg is a part of.
  ^~~~~
  struct
```