### PR TITLE
Fix memory leaks in thmapstat

### DIFF
--- a/thmapstat.cxx
+++ b/thmapstat.cxx
@@ -262,7 +262,7 @@ int thmapstat_person_data_compar(const void * d1, const void * d2) {
 
 #define thmapstat_print_team(team_map, team_name, max_items, alphasort, teamstr) \
     fprintf(f,"\\" team_name "={"); \
-    pd = new thmapstat_person_data [team_map.size()]; \
+    pd.reset(new thmapstat_person_data [team_map.size()]); \
     i = 0; \
     for (pi = team_map.begin(); \
           pi != team_map.end(); pi++) { \
@@ -273,7 +273,7 @@ int thmapstat_person_data_compar(const void * d1, const void * d2) {
         pd[i].crit = pi->second.crit; \
       i++; \
     } \
-    qsort(pd,cnt,sizeof(thmapstat_person_data),thmapstat_person_data_compar); \
+    qsort(pd.get(),cnt,sizeof(thmapstat_person_data),thmapstat_person_data_compar); \
     if (max_items >= 0) \
       tcnt = (unsigned long)(max_items); \
     else \
@@ -355,7 +355,7 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
   thmapstat_personmap::iterator pi;
   thmapstat_copyrightmap::iterator ci;
   thmapstat_datamap::iterator ii;
-  thmapstat_person_data * pd;
+  std::unique_ptr<thmapstat_person_data[]> pd;
   bool show_lengths, z_any = false;
   double clen = 0.0, z_top = 0.0, z_bot = 0.0;
   c.guarantee(256);


### PR DESCRIPTION
There are memory leaks in the method `thmapstat::export_pdftex()`. My solution is just a straightforward fix with minimal diff, proper C++ solution would be to replace the array with a vector, but since `thmapstat_print_team` is just a macro it is harder to do larger changes.

Obligatory report from Address Sanitizer:
```
==163386==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 448 byte(s) in 1 object(s) allocated from:
    #0 0x7fafed90d0c1 in operator new[](unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x55ab44d5bb42 in thmapstat::export_pdftex(_IO_FILE*, thlayout*, legenddata*) /home/afforix/Dropbox/Devel/C++/therion/thmapstat.cxx:458
    #2 0x55ab44c407d1 in thexpmap::export_pdf(thdb2dxm*, thdb2dprj*) /home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx:2155
    #3 0x55ab44c2554f in thexpmap::process_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx:346
    #4 0x55ab44b2b0e6 in thexporter::export_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexporter.cxx:160
    #5 0x55ab44a077bf in thconfig::export_data() /home/afforix/Dropbox/Devel/C++/therion/thconfig.cxx:866
    #6 0x55ab449d4d0d in main /home/afforix/Dropbox/Devel/C++/therion/therion-main.cxx:209
    #7 0x7fafed08a001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)

Direct leak of 384 byte(s) in 1 object(s) allocated from:
    #0 0x7fafed90d0c1 in operator new[](unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x55ab44d5c5b9 in thmapstat::export_pdftex(_IO_FILE*, thlayout*, legenddata*) /home/afforix/Dropbox/Devel/C++/therion/thmapstat.cxx:487
    #2 0x55ab44c407d1 in thexpmap::export_pdf(thdb2dxm*, thdb2dprj*) /home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx:2155
    #3 0x55ab44c2554f in thexpmap::process_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx:346
    #4 0x55ab44b2b0e6 in thexporter::export_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexporter.cxx:160
    #5 0x55ab44a077bf in thconfig::export_data() /home/afforix/Dropbox/Devel/C++/therion/thconfig.cxx:866
    #6 0x55ab449d4d0d in main /home/afforix/Dropbox/Devel/C++/therion/therion-main.cxx:209
    #7 0x7fafed08a001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x7fafed90d0c1 in operator new[](unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x55ab44d5cfde in thmapstat::export_pdftex(_IO_FILE*, thlayout*, legenddata*) /home/afforix/Dropbox/Devel/C++/therion/thmapstat.cxx:515
    #2 0x55ab44c407d1 in thexpmap::export_pdf(thdb2dxm*, thdb2dprj*) /home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx:2155
    #3 0x55ab44c2554f in thexpmap::process_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx:346
    #4 0x55ab44b2b0e6 in thexporter::export_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexporter.cxx:160
    #5 0x55ab44a077bf in thconfig::export_data() /home/afforix/Dropbox/Devel/C++/therion/thconfig.cxx:866
    #6 0x55ab449d4d0d in main /home/afforix/Dropbox/Devel/C++/therion/therion-main.cxx:209
    #7 0x7fafed08a001 in __libc_start_main (/usr/lib/libc.so.6+0x27001)

SUMMARY: AddressSanitizer: 960 byte(s) leaked in 3 allocation(s).
```