### PR TITLE
make DESTDIR= PREFIX= SYSCONFDIR= install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ CROSS =
 EXT =
 
 # Prefix to install to (override like so: make PREFIX=/usr)
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 # Directory to install config files in (override like so: make SYSCONFDIR=/etc)
-SYSCONFDIR = $(PREFIX)/etc
+SYSCONFDIR ?= $(PREFIX)/etc
 
 # PLATFORM CONFIG
 
@@ -192,7 +192,7 @@ init:
 	./therion --print-init-file > therion.ini
 
 install: all
-	tclsh makeinstall.tcl $(THPLATFORM) $(PREFIX) $(SYSCONFDIR)
+	tclsh makeinstall.tcl $(THPLATFORM) $(DESTDIR)$(PREFIX) $(DESTDIR)$(SYSCONFDIR)
 
 minor-release:
 	perl makerelease.pl

--- a/makeinstall.tcl
+++ b/makeinstall.tcl
@@ -17,6 +17,7 @@ if {$argc > 2} {
 }
 
 proc copyfile {force src dst} {
+  file mkdir [file dirname $dst]
   if {$force} {
     if {[catch { 
       file copy -force -- $src $dst


### PR DESCRIPTION
For `make install`:

- Add support for `DESTDIR`
- Pick up `PREFIX` and `SYSCONFDIR` from arguments or environment

This makes packaging easier. E.g.:
```bash
make DESTDIR=${pkgdir} PREFIX=/usr SYSCONFDIR=/etc install
```