### PR TITLE
Prevent in source CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
+include(cmake/PreventInSourceBuilds.cmake)
 
 project(Therion)
 set(CMAKE_CXX_STANDARD 14)

--- a/cmake/PreventInSourceBuilds.cmake
+++ b/cmake/PreventInSourceBuilds.cmake
@@ -1,0 +1,18 @@
+#
+# This function will prevent in-source builds
+function(AssureOutOfSourceBuilds)
+  # make sure the user doesn't play dirty with symlinks
+  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+  # disallow in-source builds
+  if("${srcdir}" STREQUAL "${bindir}")
+    message("######################################################")
+    message("Warning: in-source builds are disabled")
+    message("Please create a separate build directory and run cmake from there")
+    message("######################################################")
+    message(FATAL_ERROR "Quitting configuration")
+  endif()
+endfunction()
+
+assureoutofsourcebuilds()


### PR DESCRIPTION
Prevents users from mixing source dir and build dir. Taken from https://github.com/lefticus/cpp_starter_project.