### PR TITLE
Fix compilation error on Linux with gcc.

### DIFF
--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -29,8 +29,8 @@
 #endif  
 //LXDEPCHECK - standard libraries
 
-#include "lxGUI.h"
 #include "lxData.h"
+#include "lxGUI.h"
 #include "lxSetup.h"
 #include "lxRender.h"
 #include "lxOptDlg.h"


### PR DESCRIPTION
Didn't compile on my machine (OpenSUSE Leap x64, gcc 10.1.1) with the following error:
```

In file included from /usr/include/GL/glx.h:31,
                 from /usr/include/wx-3.0/wx/unix/glx11.h:13,
                 from /usr/include/wx-3.0/wx/gtk/glcanvas.h:14,
                 from /usr/include/wx-3.0/wx/glcanvas.h:195,
                 from lxGLC.h:34,
                 from lxGUI.h:43,
                 from lxGUI.cxx:32:
/usr/include/vtk-9.0/vtkDataArray.h:602:8: error: expected identifier before numeric constant
```

It happens because xutil.h (one of X11 headers) defines
`#define AllValues         0x000F`
before `struct AllValues` from vtkDataArray.h.

Swapping "lxGUI.h" and "lxData.h" in oxGUI.cxx fixed the problem.
