### PR TITLE
Set language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+lxFNT* linguist-generated
+TODO* linguist-documentation

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ xtherion/therion.tcl
 .*
 !.gitignore
 !.github/
+!.gitattributes
 *~
 *.3d
 *.a


### PR DESCRIPTION
Fix the repository to report correct language statistics:
### Before:
```
56.46%  Objective-C
28.91%  C++
8.28%   Tcl
3.46%   TeX
1.02%   C
0.74%   Makefile
0.62%   Perl
0.14%   Roff
0.10%   HTML
0.10%   Assembly
0.08%   Python
0.05%   MATLAB
0.04%   MAXScript
0.01%   Shell
0.00%   SWIG
```
### After:
```
66.68%  C++
19.09%  Tcl
7.97%   TeX
2.36%   C
1.70%   Makefile
1.43%   Perl
0.33%   Roff
0.22%   HTML
0.20%   Python
0.02%   Shell
0.00%   SWIG
```