### PR TITLE
Fixed temporary string

### DIFF
--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -406,7 +406,7 @@ void thlookup::export_color_legend(thlayout * layout) {
     COLORLEGENDLIST.clear();
     thlookup_table_list::iterator tli;
     colorlegendrecord clrec;
-    const char * title;
+    std::string title;
     for(tli = this->m_table.begin(); tli != this->m_table.end(); tli++) {
       clrec.R = tli->m_color.R;
       clrec.G = tli->m_color.G;
@@ -421,8 +421,8 @@ void thlookup::export_color_legend(thlayout * layout) {
           case TT_LAYOUT_CCRIT_SCRAP:
           case TT_LAYOUT_CCRIT_SURVEY:
         	if (tli->m_ref) {
-        		title = ths2txt(tli->m_ref->title, layout->lang).c_str();
-				if (strlen(title) == 0)
+        		title = ths2txt(tli->m_ref->title, layout->lang);
+				if (title.empty())
 				  title = tli->m_ref->name;
 				else
 				  title = tli->m_ref->title;


### PR DESCRIPTION
Bug where a pointer to a destructed string has been used. Found by `clang-tidy` static analysis:
```
therion/thlookup.cxx:423:9: warning: Inner pointer of container used after re/deallocation [clang-analyzer-cplusplus.InnerPointer]
                                if (strlen(title) == 0)
                                    ^
therion/thlookup.cxx:405:7: note: Assuming field 'color_legend' is equal to TT_TRUE
  if (layout->color_legend == TT_TRUE) {
      ^
therion/thlookup.cxx:405:3: note: Taking true branch
  if (layout->color_legend == TT_TRUE) {
  ^
therion/thlookup.cxx:410:5: note: Loop condition is true.  Entering loop body
    for(tli = this->m_table.begin(); tli != this->m_table.end(); tli++) {
    ^
therion/thlookup.cxx:412:11: note: Assuming the condition is false
      if (strlen(tli->m_label) > 0) {
          ^
therion/thlookup.cxx:412:7: note: Taking false branch
      if (strlen(tli->m_label) > 0) {
      ^
therion/thlookup.cxx:417:9: note: Control jumps to 'case TT_LAYOUT_CCRIT_SURVEY:'  at line 420
        switch (this->m_type) {
        ^
therion/thlookup.cxx:421:14: note: Assuming field 'm_ref' is non-null
                if (tli->m_ref) {
                    ^
therion/thlookup.cxx:421:10: note: Taking true branch
                if (tli->m_ref) {
                ^
therion/thlookup.cxx:422:19: note: Pointer to inner buffer of 'std::string' obtained here
                        title = ths2txt(tli->m_ref->title, layout->lang).c_str();
                                ^
therion/thlookup.cxx:422:58: note: Inner buffer of 'std::string' deallocated by call to destructor
                        title = ths2txt(tli->m_ref->title, layout->lang).c_str();
                                                                       ^
therion/thlookup.cxx:423:9: note: Inner pointer of container used after re/deallocation
                                if (strlen(title) == 0)
                                    ^
```