### PR TITLE
Fix memory leak in thscrapis

### DIFF
--- a/thscrapis.cxx
+++ b/thscrapis.cxx
@@ -1151,7 +1151,8 @@ void thscrapis::outline_scan(class thscraplo * outln) {
 
   // TRIANGULACIA PO NOVOM
   if (numpts > 2) {
-    p2t::CDT * cdt = NULL;
+    std::vector<std::unique_ptr<p2t::Point>> points_holder;
+    std::unique_ptr<p2t::CDT> cdt;
     std::vector<p2t::Point *> polyline;
     pt2d2olptmap ptmap;
     bool mult_outer = false;
@@ -1171,12 +1172,14 @@ void thscrapis::outline_scan(class thscraplo * outln) {
     			}
     			ptmap[pt2d(xx, yy)] = olineln;
     			//fprintf(f,"%.6f\t%.6f\n", xx, yy);
-    			polyline.push_back(new p2t::Point(xx, yy));
+          auto new_point = std::make_unique<p2t::Point>(xx, yy);
+    			polyline.push_back(new_point.get());
+          points_holder.push_back(std::move(new_point)); // owner of all the allocated points
     			olineln = olineln->next;
     			numpts++;
     		}
-    		if (cdt == NULL) {
-    			cdt = new p2t::CDT(polyline);
+    		if (!cdt) {
+    			cdt = std::make_unique<p2t::CDT>(polyline);
     			polyline.clear();
     		} else {
     			if (oline->outer) {
@@ -1256,8 +1259,6 @@ void thscrapis::outline_scan(class thscraplo * outln) {
     } else {
       this->tri_triangles = NULL;
     }
-
-    delete cdt;
   }
 
 #ifdef THSCRAPIS_NEW3D


### PR DESCRIPTION
Memory leak found by Address Sanitizer:
```
==203694==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8400 byte(s) in 210 object(s) allocated from:
    #0 0x7fbcafaf8f41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x56372789f6d2 in thscrapis::outline_scan(thscraplo*) /home/afforix/Dropbox/Devel/C++/therion/thscrapis.cxx:1174
    #2 0x56372789754d in thscrap::process_3d() /home/afforix/Dropbox/Devel/C++/therion/thscrap.cxx:1147
    #3 0x563727899e55 in thscrap::get_3d_outline() /home/afforix/Dropbox/Devel/C++/therion/thscrap.cxx:1450
    #4 0x563727ade5e1 in thexpmodel::export_lox_file(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexpmodel.cxx:1722
    #5 0x563727ace90a in thexpmodel::process_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexpmodel.cxx:166
    #6 0x56372771760a in thexporter::export_db(thdatabase*) /home/afforix/Dropbox/Devel/C++/therion/thexporter.cxx:164
    #7 0x5637275d8753 in thconfig::export_data() /home/afforix/Dropbox/Devel/C++/therion/thconfig.cxx:874
    #8 0x5637275c4635 in main /home/afforix/Dropbox/Devel/C++/therion/therion-main.cxx:217
    #9 0x7fbcaf25e151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)
```