### PR TITLE
Fix -pedantic warnings

### DIFF
--- a/loch/lxAboutDlg.cxx
+++ b/loch/lxAboutDlg.cxx
@@ -19,7 +19,7 @@ public:
   void OnKeyPress(wxKeyEvent&);
   void OnMouseDown(wxMouseEvent&);
 
-  DECLARE_EVENT_TABLE();
+  wxDECLARE_EVENT_TABLE();
 
 };
 

--- a/thexpdb.cxx
+++ b/thexpdb.cxx
@@ -466,7 +466,7 @@ void thexpdb::export_csv_file(class thdatabase * dbp) {
 
       // Export equate links between stations 
       int last_equate = 0;
-      long MAX_LEN = 500;
+      const long MAX_LEN = 500;
       char first_name[MAX_LEN];
       if (!dp->equate_list.empty()) {
         fprintf(out, "# Equated stations\n");

--- a/thtexfonts.cxx
+++ b/thtexfonts.cxx
@@ -90,7 +90,7 @@ int encodings_new::get_enc_pos (int ch) {
   }
 //cout << "==FP== " << m_fon[style][ch] << endl;
   return m_fon[ch];
-};
+}
 
 void encodings_new::write_enc_files() {
   if (NFSS==0) return;


### PR DESCRIPTION
GCC and Clang report these warnings with the flag `-pedantic`:
```
therion/thexpdb.cxx: In member function ‘void thexpdb::export_csv_file(thdatabase*)’:
therion/thexpdb.cxx:470:12: warning: ISO C++ forbids variable length array ‘first_name’ [-Wvla]
  470 |       char first_name[MAX_LEN];
      |            ^~~~~~~~~~

therion/thtexfonts.cxx:93:2: warning: extra ‘;’ [-Wpedantic]
   93 | };
      |  ^

therion/loch/lxAboutDlg.cxx:22:24: warning: extra ‘;’ [-Wpedantic]
   22 |   DECLARE_EVENT_TABLE();
      |                        ^
      |                        -
```