### PR TITLE
Memory management

### DIFF
--- a/cclass.pl
+++ b/cclass.pl
@@ -179,15 +179,6 @@ class $thclass : public $thfather {
 
 
   /**
-   * Delete this object.
-   *
-   * \@warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    
@@ -310,11 +301,6 @@ void $thclass\::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lo
   }
 }
 
-
-void $thclass\::self_delete()
-{
-  delete this;
-}
 
 void $thclass\::self_print_properties(FILE * outf)
 {

--- a/tharea.cxx
+++ b/tharea.cxx
@@ -150,12 +150,6 @@ void tharea::parse_subtype(char * ststr)
     ththrow(("invalid type - subtype combination"))
 }
 
-
-void tharea::self_delete()
-{
-  delete this;
-}
-
 void tharea::self_print_properties(FILE * outf)
 {
   th2ddataobject::self_print_properties(outf);

--- a/tharea.h
+++ b/tharea.h
@@ -206,15 +206,6 @@ class tharea : public th2ddataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
 

--- a/thcomment.cxx
+++ b/thcomment.cxx
@@ -94,11 +94,6 @@ void thcomment::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lo
 }
 
 
-void thcomment::self_delete()
-{
-  delete this;
-}
-
 void thcomment::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thcomment.h
+++ b/thcomment.h
@@ -135,15 +135,6 @@ class thcomment : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -654,7 +654,6 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
   // vlozi ho do databazy
   // kazdy riadok prida do prikazov na ulozenie
 
-  thdataobject * objptr;  // pointer to the newly created object
   thcmd_option_desc optd;  // option descriptor
   char * ln, * opt;
   char ** opts;
@@ -673,12 +672,12 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
     dbptr->csrc.name = osrc.name;
 
 
-    objptr = dbptr->create(this->cfg_file.get_cmd(), osrc);
+    auto objptr = dbptr->create(this->cfg_file.get_cmd(), osrc);
     if (objptr == NULL)
       ththrow(("unknown command -- %s", this->cfg_file.get_cmd()));
 
     if (objptr->get_class_id() == TT_LAYOUT_CMD) {
-      ((thlayout*)objptr)->m_pconfig = this;
+      ((thlayout*)objptr.get())->m_pconfig = this;
     }
 
     thencode(&this->bf1, this->cfg_file.get_line(), this->cfg_file.get_cif_encoding());  
@@ -774,7 +773,7 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
     }
     
     // vlozi objekt do databazy
-    dbptr->insert(objptr);
+    dbptr->insert(std::move(objptr));
   }
     
   // put everything into try block and throw exception, if error

--- a/thdata.cxx
+++ b/thdata.cxx
@@ -560,12 +560,6 @@ void thdata::self_print_properties(FILE * outf)
 }
 
 
-void thdata::self_delete()
-{
-  delete this;
-}
-
-
 void thdata::set_data_calibration(int nargs, char ** args)
 {
   static int items[THDATA_MAX_ITEMS];
@@ -2847,7 +2841,7 @@ void thdata::end_group() {
     this->cgroup->dims_list.insert(this->cgroup->dims_list.end(), (*di));
   }
   
-  tmp->self_delete();
+  delete tmp;
 }
 
 

--- a/thdata.h
+++ b/thdata.h
@@ -328,15 +328,6 @@ class thdata : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-    
-  /**
    * Return class name.
    */
    

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -71,6 +71,7 @@ const char * thlibrarydata_init_text =
 const char * thlibrarydata_grades_text =
   "void thlibrary_init_grades()\n"
   "{\n"
+  "\tstd::unique_ptr<thdataobject> unique_grade;\n"
   "\tthgrade * pgrade;\n"
   "\tthbuffer oname;\n";
 
@@ -78,6 +79,7 @@ const char * thlibrarydata_grades_text =
 const char * thlibrarydata_layouts_text =
   "void thlibrary_init_layouts()\n"
   "{\n"
+  "\tstd::unique_ptr<thdataobject> unique_layout;\n"
   "\tthlayout * playout;\n"
   "\tthbuffer oname;\n";
 
@@ -134,12 +136,7 @@ thdatabase::~thdatabase()
 void thdatabase::clear()
 {
 
-  // let's delete all objects and clear object list
-  thdb_object_list_type::iterator oli = this->object_list.begin();
-  while (oli != this->object_list.end()) {
-    (*oli)->self_delete();
-    oli++;
-  }
+  // delete all objects
   this->object_list.clear();
   
   // clear search hashes
@@ -150,9 +147,9 @@ void thdatabase::clear()
   this->reset_context();
 
   // create top level survey
-  thsurvey * top = (thsurvey*) this->create("survey",thobjectsrc("error",0));
-  top->name = "";
-  this->insert(top);
+  auto top = this->create("survey",thobjectsrc("error",0));
+  dynamic_cast<thsurvey*>(top.get())->name = "";
+  this->insert(std::move(top));
 
 }
 
@@ -179,7 +176,7 @@ void thdatabase::check_context(class thdataobject * optr) {
   }
 }
 
-void thdatabase::insert(thdataobject * optr)
+void thdatabase::insert(std::unique_ptr<thdataobject> unique_optr)
 {
 
   thsurvey * survey_optr;
@@ -188,7 +185,8 @@ void thdatabase::insert(thdataobject * optr)
   const char * optr_name;
   int optr_class_id;
   unsigned long csurvey_id = (this->csurveyptr == NULL) ? 0 : csurveyptr->get_nss()->id;
-
+  auto* optr = unique_optr.get();
+  
   
   // Call start_insert object method.
   optr->start_insert();
@@ -198,15 +196,15 @@ void thdatabase::insert(thdataobject * optr)
   bool is_special_o = false;
   switch (optr->get_class_id()) {
     case TT_GRADE_CMD:
-      this->insert_grade((thgrade *) optr);
+      this->insert_grade(std::move(unique_optr));
       is_special_o = true;
       break;
     case TT_LAYOUT_CMD:
-      this->insert_layout((thlayout *) optr);
+      this->insert_layout(std::move(unique_optr));
       is_special_o = true;
       break;
     case TT_LOOKUP_CMD:
-      this->insert_lookup((thlookup *) optr);
+      this->insert_lookup(std::move(unique_optr));
       is_special_o = true;
       break;  }
   if (is_special_o)
@@ -221,7 +219,6 @@ void thdatabase::insert(thdataobject * optr)
     if (this->object_map.find(thobjectid(optr->name,csurvey_id)) !=
         this->object_map.end()) {
       optr_name = optr->get_name();  
-      optr->self_delete();
       ththrow(("duplicate object name -- %s", optr_name));
     }
   }
@@ -239,7 +236,6 @@ void thdatabase::insert(thdataobject * optr)
       }
 
       if ((optr->get_class_id() == TT_ENDSURVEY_CMD) && (this->fsurveyptr->id == this->csurveyptr->id)) {
-        optr->self_delete();
         ththrow(("missing survey before endsurvey command"));
       }
 
@@ -254,7 +250,6 @@ void thdatabase::insert(thdataobject * optr)
         this->lcsobjectptr = csurveyptr->loptr;
       //}
       this->csurveylevel--;
-      optr->self_delete();
       this->csrc.context = csurveyptr;
       break;
       
@@ -269,7 +264,6 @@ void thdatabase::insert(thdataobject * optr)
       this->ccontext = THCTX_SURVEY;
       this->cscrapptr = NULL;
       this->lcscrapoptr = NULL;
-      optr->self_delete();
       this->csrc.context = csurveyptr;
       break;
   
@@ -279,7 +273,7 @@ void thdatabase::insert(thdataobject * optr)
       this->csrc.context = optr;
 
       // let's insert object into database
-      this->object_list.push_back(optr);
+      this->object_list.push_back(std::move(unique_optr));
       this->object_map[thobjectid(optr->name, csurvey_id)] = optr;
       
       if (this->lcsobjectptr != NULL) {
@@ -358,7 +352,7 @@ void thdatabase::insert(thdataobject * optr)
   // insert sub-objects
   switch(optr_class_id) {
     case TT_SURVEY_CMD:
-      this->insert(((thsurvey*)(optr))->data);
+      this->insert(std::move(((thsurvey*)(optr))->tmp_data_holder));
       break;
   }
   
@@ -471,89 +465,85 @@ bool thdatabase::insert_datastation(thobjectname on, thsurvey * ps)
 }  // end of datastation inserion
 
 
-class thdataobject * thdatabase::create(const char * oclass, 
+std::unique_ptr<thdataobject> thdatabase::create(const char * oclass, 
   thobjectsrc osrc)
 {
   int tclass = thmatch_token(oclass, thtt_commands);
-  thdataobject * ret;
-  thdata * retdata;
-  retdata = NULL;
+  std::unique_ptr<thdataobject> ret;
+  std::unique_ptr<thdata> retdata;
   switch (tclass) {
   
     case TT_SURVEY_CMD:
-      ret = new thsurvey;
-      retdata = new thdata;
+      ret = std::make_unique<thsurvey>();
+      retdata = std::make_unique<thdata>();
       break;
       
     case TT_ENDSURVEY_CMD:
-      ret = new thendsurvey;
+      ret = std::make_unique<thendsurvey>();
       break;
       
     case TT_SCRAP_CMD:
-      ret = new thscrap;
+      ret = std::make_unique<thscrap>();
       break;
       
     case TT_ENDSCRAP_CMD:
-      ret = new thendscrap;
+      ret = std::make_unique<thendscrap>();
       break;
       
     case TT_DATA_CMD:
-      ret = new thdata;
+      ret = std::make_unique<thdata>();
       break;
       
     case TT_COMMENT_CMD:
-      ret = new thcomment;
+      ret = std::make_unique<thcomment>();
       break;
       
     case TT_GRADE_CMD:
-      ret = new thgrade;
+      ret = std::make_unique<thgrade>();
       break;
       
     case TT_LAYOUT_CMD:
-      ret = new thlayout;
+      ret = std::make_unique<thlayout>();
       break;
       
     case TT_LOOKUP_CMD:
-      ret = new thlookup;
+      ret = std::make_unique<thlookup>();
       break;
 
     case TT_POINT_CMD:
-      ret = new thpoint;
+      ret = std::make_unique<thpoint>();
       break;
       
     case TT_LINE_CMD:
-      ret = new thline;
+      ret = std::make_unique<thline>();
       break;
       
     case TT_AREA_CMD:
-      ret = new tharea;
+      ret = std::make_unique<tharea>();
       break;
       
     case TT_JOIN_CMD:
-      ret = new thjoin;
+      ret = std::make_unique<thjoin>();
       break;
       
     case TT_MAP_CMD:
-      ret = new thmap;
+      ret = std::make_unique<thmap>();
       break;
       
     case TT_IMPORT_CMD:
-      ret = new thimport;
+      ret = std::make_unique<thimport>();
       break;
       
     case TT_SURFACE_CMD:
-      ret = new thsurface;
+      ret = std::make_unique<thsurface>();
       break;
-      
-    default:
-      ret = NULL;
   }
   
   if (ret != NULL) {
     ret->assigndb(this);
     // set object id and mark revision
     ret->id = ++this->objid;
-    this->attr.insert_object((void *) ret, (long) ret->id);
+    this->attr.insert_object((void *) ret.get(), (long) ret->id);
 		ret->source = osrc;
     this->revision_set.insert(threvision(ret->id, 0, osrc));
   }
@@ -568,7 +558,9 @@ class thdataobject * thdatabase::create(const char * oclass,
 
   switch (tclass) {
     case TT_SURVEY_CMD:
-      ((thsurvey*)(ret))->data = retdata;
+      auto* survey = dynamic_cast<thsurvey*>(ret.get());
+      survey->data = retdata.get();
+      survey->tmp_data_holder = std::move(retdata);
       break;
   }
   
@@ -681,7 +673,7 @@ class thscrap * thdatabase::get_current_scrap()
 }
 
 
-void thdatabase::insert_grade(class thgrade * optr)
+void thdatabase::insert_grade(std::unique_ptr<thdataobject> optr)
 {
 //  thdb_grade_map_type::iterator gi = 
 //    this->grade_map.find(thsurveyname(optr->get_name()));
@@ -689,8 +681,8 @@ void thdatabase::insert_grade(class thgrade * optr)
 //  if ((gi == this->grade_map.end()) || 
 //      (thcmdln.get_print_state() == THPS_LIB_SRC)) {
     // insert grade
-    this->object_list.push_back(optr);
-    this->grade_map[thsurveyname(optr->get_name())] = optr;
+    this->grade_map[thsurveyname(optr->get_name())] = optr.get();
+    this->object_list.push_back(std::move(optr));
 //  }
 //  else
 //    ththrow(("survey grade already exists -- %s",optr->get_name()))
@@ -698,7 +690,7 @@ void thdatabase::insert_grade(class thgrade * optr)
 }
  
  
-void thdatabase::insert_layout(class thlayout * optr)
+void thdatabase::insert_layout(std::unique_ptr<thdataobject> optr)
 {
 //  thdb_layout_map_type::iterator gi = 
 //    this->layout_map.find(thsurveyname(optr->get_name()));
@@ -706,15 +698,15 @@ void thdatabase::insert_layout(class thlayout * optr)
 //  if ((gi == this->layout_map.end()) || 
 //      (thcmdln.get_print_state() == THPS_LIB_SRC)) {
     // insert grade
-    this->object_list.push_back(optr);
-    this->layout_map[thsurveyname(optr->get_name())] = optr;
+    this->layout_map[thsurveyname(optr->get_name())] = optr.get();
+    this->object_list.push_back(std::move(optr));
 //  }
 //  else
 //    ththrow(("map layout already exists -- %s",optr->get_name()))
   
 }
 
-void thdatabase::insert_lookup(class thlookup * optr)
+void thdatabase::insert_lookup(std::unique_ptr<thdataobject> optr)
 {
 //  thdb_layout_map_type::iterator gi = 
 //    this->layout_map.find(thsurveyname(optr->get_name()));
@@ -722,8 +714,8 @@ void thdatabase::insert_lookup(class thlookup * optr)
 //  if ((gi == this->layout_map.end()) || 
 //      (thcmdln.get_print_state() == THPS_LIB_SRC)) {
     // insert grade
-    this->object_list.push_back(optr);
-    this->lookup_map[thsurveyname(optr->get_name())] = optr;
+    this->lookup_map[thsurveyname(optr->get_name())] = optr.get();
+    this->object_list.push_back(std::move(optr));
 //  }
 //  else
 //    ththrow(("map layout already exists -- %s",optr->get_name()))
@@ -772,10 +764,11 @@ void thdatabase::self_print_library()
   thprintf(thlibrarydata_grades_text);
   thdb_grade_map_type::iterator gi = this->grade_map.begin();
   while (gi != this->grade_map.end()) {
-    thprintf("\n\tpgrade = (thgrade *) thdb.create(\"grade\", thobjectsrc(\"therion\",0));\n");
+    thprintf("\n\tunique_grade = thdb.create(\"grade\", thobjectsrc(\"therion\",0));\n");
+    thprintf("\tpgrade = dynamic_cast<thgrade*>(unique_grade.get());\n");
     ((thgrade *)(gi->second))->self_print_library();
     gi++;
-    thprintf("\tthdb.insert(pgrade);\n");
+    thprintf("\tthdb.insert(std::move(unique_grade));\n");
   }
   thprintf("}\n\n");
 
@@ -783,10 +776,11 @@ void thdatabase::self_print_library()
   thprintf(thlibrarydata_layouts_text);
   thdb_layout_map_type::iterator li = this->layout_map.begin();
   while (li != this->layout_map.end()) {
-    thprintf("\n\tplayout = (thlayout *) thdb.create(\"layout\", thobjectsrc(\"therion\",0));\n");
+    thprintf("\n\tunique_layout = thdb.create(\"layout\", thobjectsrc(\"therion\",0));\n");
+    thprintf("\tplayout = dynamic_cast<thlayout*>(unique_layout.get());\n");
     ((thlayout *)(li->second))->self_print_library();
     li++;
-    thprintf("\tthdb.insert(playout);\n");
+    thprintf("\tthdb.insert(std::move(unique_layout));\n");
   }
   thprintf("}\n\n");
   
@@ -877,7 +871,7 @@ void thdatabase::preprocess() {
     try {
       switch ((*obi)->get_class_id()) {
         case TT_IMPORT_CMD:
-          ((thimport*)(*obi))->import_file();
+          ((thimport*)(*obi).get())->import_file();
           break;
       }
     } catch (...) {

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -171,7 +171,6 @@ void thdatabase::check_context(class thdataobject * optr) {
         misscmd = "scrap";
         break;
     }
-    optr->self_delete();
     ththrow(("missing %s before %s command", misscmd, cmdname));
   }
 }

--- a/thdatabase.h
+++ b/thdatabase.h
@@ -32,6 +32,7 @@
 #include <map>
 #include <list>
 #include <set>
+#include <memory>
 
 #include "thdataobject.h"
 #include "thmbuffer.h"
@@ -145,7 +146,7 @@ typedef std::map < thobjectid, class thdataobject * > thdb_object_map_type;  ///
 typedef std::map < thsurveyname, class thsurvey * > thdb_survey_map_type;   ///< Survey map  
 typedef std::map < thsurveyname, class thdataobject * > thdb_grade_map_type;   ///< Grade map  
 typedef thdb_grade_map_type thdb_layout_map_type;   ///< Layout map  
-typedef std::list < class thdataobject * > thdb_object_list_type;   ///< Object list
+typedef std::list < std::unique_ptr<thdataobject> > thdb_object_list_type;   ///< Object list
 
   
 /**
@@ -221,7 +222,7 @@ class thdatabase {
    * Create an data object linked to the database.
    */
    
-  class thdataobject * create(const char * oclass, thobjectsrc osrc);
+  std::unique_ptr<thdataobject> create(const char * oclass, thobjectsrc osrc);
   
   
   /**
@@ -256,27 +257,27 @@ class thdatabase {
    * Insert data object into database.
    */
    
-  void insert(class thdataobject * optr);
+  void insert(std::unique_ptr<thdataobject> unique_optr);
   
   
   /**
    * Insert survey grade object into database.
    */
    
-  void insert_grade(class thgrade * optr);
+  void insert_grade(std::unique_ptr<thdataobject> optr);
 
 
   /**
    * Insert map layout object into database.
    */
    
-  void insert_layout(class thlayout * optr);
+  void insert_layout(std::unique_ptr<thdataobject> optr);
 
   /**
    * Insert lookup object into database.
    */
    
-  void insert_lookup(class thlookup * optr);
+  void insert_lookup(std::unique_ptr<thdataobject> optr);
   
   
   /**

--- a/thdataobject.cxx
+++ b/thdataobject.cxx
@@ -292,12 +292,6 @@ int thdataobject::get_id()
 }
 
 
-void thdataobject::self_delete()
-{
-  delete this;
-}
-
-
 int thdataobject::get_context()
 {
   return THCTX_SURVEY;

--- a/thdataobject.h
+++ b/thdataobject.h
@@ -397,15 +397,6 @@ class thdataobject {
   
   
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-  
-  
-  /**
    * Get context for object.
    */
    

--- a/thdatareader.cxx
+++ b/thdatareader.cxx
@@ -49,7 +49,7 @@ unsigned long thdatareader__get_opos(bool inlineid, bool cfgid)
 
 void thdatareader::read(const char * ifname, long lnstart, long lnend, const char * spath, thdatabase * dbptr)
 {
-
+  std::unique_ptr<thdataobject> unique_objptr;
   thdataobject * objptr = NULL;  // pointer to the newly created object
   thcmd_option_desc optd;  // option descriptor
   bool inside_cmd = false;
@@ -107,7 +107,7 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
           inside_cmd = false;
           //this->inp.cmd_sensitivity_on();
           if (!configure_cmd)
-            dbptr->insert(objptr);
+            dbptr->insert(std::move(unique_objptr));
           else {
             objptr->start_insert();
             configure_cmd = false;
@@ -156,7 +156,8 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
           continue;
         } 
         else {
-          objptr = dbptr->create(this->inp.get_cmd(), osrc);
+          unique_objptr = dbptr->create(this->inp.get_cmd(), osrc);
+          objptr = unique_objptr.get();
           if (objptr == NULL)
             ththrow(("unknown command -- %s", this->inp.get_cmd()))
           else
@@ -221,7 +222,7 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
         // else insert object into database
         if ((endlnopt = objptr->get_cmd_end()) == NULL)
           if (!configure_cmd)
-            dbptr->insert(objptr);
+            dbptr->insert(std::move(unique_objptr));
           else {
             objptr->start_insert();
             configure_cmd = false;

--- a/thdatastation.cxx
+++ b/thdatastation.cxx
@@ -42,9 +42,3 @@ bool thdatastation::is(int class_id)
   else
     return thdataobject::is(class_id);
 }
-
-void thdatastation::self_delete()
-{
-  delete this;
-}
-

--- a/thdatastation.h
+++ b/thdatastation.h
@@ -61,17 +61,6 @@ class thdatastation : public thdataobject {
    */
   
   virtual bool is(int class_id);
-  
-  
-  /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
 };
 
 

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -133,7 +133,7 @@ void thdb1d::scan_data()
   obi = this->db->object_list.begin();
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
       if (dp->date.is_defined()) {
         double syear, eyear;
         syear = dp->date.get_start_year();
@@ -166,7 +166,7 @@ void thdb1d::scan_data()
   obi = this->db->object_list.begin();
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
       bool dpdeclindef;
       double dpdeclin;
 
@@ -452,7 +452,7 @@ void thdb1d::scan_data()
   obi = this->db->object_list.begin();
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
       // scan data equates
       eqi = dp->equate_list.begin();
       try {
@@ -476,7 +476,7 @@ void thdb1d::scan_data()
   while (obi != this->db->object_list.end()) {
 
     if ((*obi)->get_class_id() == TT_SURVEY_CMD) {
-      thsurvey * srv = (thsurvey *) (*obi);
+      thsurvey * srv = (thsurvey *) (*obi).get();
       if (!srv->entrance.is_empty()) {
         srv->entrance.id = this->get_station_id(srv->entrance, srv);
         if (srv->entrance.id == 0) {
@@ -497,7 +497,7 @@ void thdb1d::scan_data()
 
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
 
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
 
       // scan data stations
       ssi = dp->ss_list.begin();
@@ -868,7 +868,7 @@ void thdb1d::process_tree()
   int last_eq = -1;
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
       eqi = dp->equate_list.begin();
       last_eq = -1;
       while(eqi != dp->equate_list.end()) {
@@ -1277,7 +1277,7 @@ void thdb1d::process_survey_stat() {
   thpoint * pt;
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_POINT_CMD) {
-      pt = (thpoint *)(*obi);
+      pt = (thpoint *)(*obi).get();
       ss = pt->fsptr;
       if ((pt->type == TT_POINT_TYPE_CONTINUATION) && (!thisnan(pt->xsize))) {
         while (ss != NULL) {
@@ -2122,7 +2122,7 @@ void thdb1d::close_loops()
   double avg_error = 0.0, avg_error_sum = 0.0;
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
       fii = dp->fix_list.begin();
       while(fii != dp->fix_list.end()) {
         tmps = &(this->station_vec[fii->station.id - 1]);
@@ -2957,7 +2957,7 @@ void thdb1d::postprocess_objects()
   while (obi != this->db->object_list.end()) {
     switch ((*obi)->get_class_id()) {
       case TT_SURFACE_CMD:
-        ((thsurface*)(*obi))->check_stations();
+        ((thsurface*)(*obi).get())->check_stations();
         break;
     }
     obi++;
@@ -3024,7 +3024,7 @@ void thdb1d::process_xelev()
     switch ((*obi)->get_class_id()) {
       case TT_DATA_CMD:
         try {
-          dp = (thdata *)(*obi);
+          dp = (thdata *)(*obi).get();
           xi = dp->extend_list.begin();
           while(xi != dp->extend_list.end()) {
             if (!xi->to.is_empty()) {

--- a/thdb2d00.cxx
+++ b/thdb2d00.cxx
@@ -337,17 +337,17 @@ thdb2dxm * thdb2d::select_projection(thdb2dprj * prj)
     while (obi != this->db->object_list.end()) {
       if (((*obi)->get_class_id() == TT_MAP_CMD) &&
 		  thcfg.use_maps &&
-          (((thmap*)(*obi))->projection_id == prj->id) &&
-          (((thmap*)(*obi))->is_basic) &&
-          (((thmap*)(*obi))->fsptr != NULL) &&
-          (((thmap*)(*obi))->fsptr->is_selected())) {
-        prj->stat.scanmap((thmap*)(*obi));  
-        prj->stat.addstat(&(((thmap*)(*obi))->stat));
+          (((thmap*)(*obi).get())->projection_id == prj->id) &&
+          (((thmap*)(*obi).get())->is_basic) &&
+          (((thmap*)(*obi).get())->fsptr != NULL) &&
+          (((thmap*)(*obi).get())->fsptr->is_selected())) {
+        prj->stat.scanmap((thmap*)(*obi).get());  
+        prj->stat.addstat(&(((thmap*)(*obi).get())->stat));
         cxm = this->insert_xm();
-        cxm->selection_color = ((thmap*)(*obi))->fsptr->selected_color;
+        cxm->selection_color = ((thmap*)(*obi).get())->fsptr->selected_color;
         cxm->title = false;
         cxm->expand = true;
-        cxm->map = (thmap*)(*obi);
+        cxm->map = (thmap*)(*obi).get();
         cxm->map->calc_z();
         nmaps++;
         if (selection == NULL) {
@@ -418,30 +418,36 @@ thdb2dxm * thdb2d::select_projection(thdb2dprj * prj)
       obi = this->db->object_list.begin();
       while (obi != this->db->object_list.end()) {
         if (((*obi)->get_class_id() == TT_SCRAP_CMD) &&
-            (((thscrap*)(*obi))->proj->id == prj->id) &&
-            (((thscrap*)(*obi))->fsptr != NULL) &&
-            (((thscrap*)(*obi))->fsptr->is_selected())) {
+            (((thscrap*)(*obi).get())->proj->id == prj->id) &&
+            (((thscrap*)(*obi).get())->fsptr != NULL) &&
+            (((thscrap*)(*obi).get())->fsptr->is_selected())) {
           nscraps++;
         }
         obi++;
       }  
 
-      mapp = new thmap;
-      mapp->id = ++this->db->objid;
-      mapp->projection_id = prj->id;
-      mapp->db = &(thdb);
-      mapp->fsptr = NULL;
-      thdb.object_list.push_back(mapp);
+      {
+        auto unique_mapp = std::make_unique<thmap>();
+        mapp = unique_mapp.get();
+        mapp->id = ++this->db->objid;
+        mapp->projection_id = prj->id;
+        mapp->db = &(thdb);
+        mapp->fsptr = NULL;
+        thdb.object_list.push_back(std::move(unique_mapp));
+      }
 
       // ak nemame ani jeden scrap, vytvorime mapu z centerlajnu
       if (nscraps == 0) {
 
-        scrapp = new thscrap;
-        scrapp->centerline_io = true;
-        scrapp->fsptr = NULL;
-        scrapp->db = &(thdb);
-        scrapp->proj = prj;
-        thdb.object_list.push_back(scrapp);
+        {
+          auto unique_scrapp = std::make_unique<thscrap>();
+          scrapp = unique_scrapp.get();
+          scrapp->centerline_io = true;
+          scrapp->fsptr = NULL;
+          scrapp->db = &(thdb);
+          scrapp->proj = prj;
+          thdb.object_list.push_back(std::move(unique_scrapp));
+        }
 
         xcitem = thdb.db2d.insert_map_item();
         xcitem->itm_level = mapp->last_level;
@@ -462,9 +468,9 @@ thdb2dxm * thdb2d::select_projection(thdb2dprj * prj)
       obi = this->db->object_list.begin();
       while (obi != this->db->object_list.end()) {
         if (((*obi)->get_class_id() == TT_SCRAP_CMD) &&
-            (((thscrap*)(*obi))->proj->id == prj->id) &&
-            (((thscrap*)(*obi))->fsptr != NULL) &&
-            (((thscrap*)(*obi))->fsptr->is_selected())) {
+            (((thscrap*)(*obi).get())->proj->id == prj->id) &&
+            (((thscrap*)(*obi).get())->fsptr != NULL) &&
+            (((thscrap*)(*obi).get())->fsptr->is_selected())) {
           xcitem = thdb.db2d.insert_map_item();          
           if (mapp->first_item == NULL) {
             mapp->first_item = xcitem;
@@ -478,7 +484,7 @@ thdb2dxm * thdb2d::select_projection(thdb2dprj * prj)
           xcitem->source = thdb.csrc;
           xcitem->psurvey = NULL;
           xcitem->type = TT_MAPITEM_NORMAL;
-          xcitem->object = (thscrap*)(*obi);
+          xcitem->object = (thscrap*)(*obi).get();
           nscraps++;
         }
         obi++;
@@ -602,7 +608,7 @@ void thdb2d::reset_selection() {
   while (obi != this->db->object_list.end()) {
     switch ((*obi)->get_class_id()) {
       case TT_MAP_CMD:
-        ((thmap *)(*obi))->selection_mode = TT_MAPITEM_UNKNOWN;
+        ((thmap *)(*obi).get())->selection_mode = TT_MAPITEM_UNKNOWN;
         break;
 //      case TT_SCRAP_CMD:
 //        ((thscrap *)(*obi))->selection_mode = TT_MAPITEM_UNKNOWN;
@@ -701,7 +707,7 @@ const char * thdb2d::get_projection_title(thdb2dprj * prj) {
   thdb_object_list_type::iterator obi = this->db->object_list.begin(), obi2;
   while (obi != this->db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_SURVEY_CMD) {
-      ((thsurvey*)(*obi))->num1 = 0;
+      ((thsurvey*)(*obi).get())->num1 = 0;
     }
     obi++;
   }
@@ -709,18 +715,18 @@ const char * thdb2d::get_projection_title(thdb2dprj * prj) {
   obi = this->db->object_list.begin();
   while (obi != this->db->object_list.end()) {
     if (((*obi)->get_class_id() == TT_SCRAP_CMD) &&
-        (((thscrap*)(*obi))->proj->id == prj->id) && 
-        (((thscrap*)(*obi))->exported)) {
-      if (((thscrap*)(*obi))->fsptr != NULL) {
-        ((thscrap*)(*obi))->fsptr->num1++;
-      } else if (((thscrap*)(*obi))->centerline_survey != NULL) {
-        ((thscrap*)(*obi))->centerline_survey->num1++;
+        (((thscrap*)(*obi).get())->proj->id == prj->id) && 
+        (((thscrap*)(*obi).get())->exported)) {
+      if (((thscrap*)(*obi).get())->fsptr != NULL) {
+        ((thscrap*)(*obi).get())->fsptr->num1++;
+      } else if (((thscrap*)(*obi).get())->centerline_survey != NULL) {
+        ((thscrap*)(*obi).get())->centerline_survey->num1++;
       } else {
         // prejde vsetky oznacene a da im num1 = 1
         obi2 = this->db->object_list.begin();
         while (obi2 != this->db->object_list.end()) {
           if (((*obi2)->get_class_id() == TT_SURVEY_CMD) && ((*obi2)->selected)) {
-            ((thsurvey*)(*obi2))->num1 = 1;
+            ((thsurvey*)(*obi2).get())->num1 = 1;
           }
           obi2++;
         }

--- a/thendscrap.cxx
+++ b/thendscrap.cxx
@@ -98,11 +98,6 @@ void thendscrap::set(thcmd_option_desc cod, char ** args, int argenc, unsigned l
 }
 
 
-void thendscrap::self_delete()
-{
-  delete this;
-}
-
 void thendscrap::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thendscrap.h
+++ b/thendscrap.h
@@ -133,15 +133,6 @@ class thendscrap : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thendsurvey.cxx
+++ b/thendsurvey.cxx
@@ -105,12 +105,6 @@ void thendsurvey::self_print_properties(FILE * outf)
 }
 
 
-void thendsurvey::self_delete()
-{
-  delete this;
-}
-
-
 int thendsurvey::get_context()
 {
   return THCTX_SURVEY;

--- a/thendsurvey.h
+++ b/thendsurvey.h
@@ -108,15 +108,6 @@ class thendsurvey : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
- 
-  
-  /**
    * Get context for object.
    */
    

--- a/thexpdb.cxx
+++ b/thexpdb.cxx
@@ -249,7 +249,7 @@ void thexpdb::export_sql_file(class thdatabase * dbp)
       switch ((*oi)->get_class_id()) {
 
         case TT_SURVEY_CMD:
-          sp = (thsurvey *)(*oi);
+          sp = (thsurvey *)(*oi).get();
           ENCODESTR(sp->title);
           IF_PRINTING {
             fprintf(sqlf,"insert into SURVEY values "
@@ -265,7 +265,7 @@ void thexpdb::export_sql_file(class thdatabase * dbp)
           break;  // SURVEY
 
 		case TT_SCRAP_CMD:
-			scrapp = (thscrap *)(*oi);
+			scrapp = (thscrap *)(*oi).get();
 			IF_PRINTING {
 				fprintf(sqlf,"insert into SCRAPS values "
 				  "(%ld, %ld, '%s', %d, %.5lf, %.5lf);\n ",
@@ -277,7 +277,7 @@ void thexpdb::export_sql_file(class thdatabase * dbp)
 			break;
 
 		case TT_MAP_CMD:
-			mapp = (thmap *)(*oi);
+			mapp = (thmap *)(*oi).get();
 			mapp->stat.scanmap(mapp);
 			ENCODESTR(mapp->title);
 			IF_PRINTING {
@@ -300,7 +300,7 @@ void thexpdb::export_sql_file(class thdatabase * dbp)
 			break;
           
         case TT_DATA_CMD:
-          dp = (thdata *)(*oi);
+          dp = (thdata *)(*oi).get();
           ENCODESTR(dp->title);
           IF_PRINTING {
             fprintf(sqlf,"insert into CENTRELINE values "
@@ -449,7 +449,7 @@ void thexpdb::export_csv_file(class thdatabase * dbp) {
 
   while (oi != dbp->object_list.end()) {
     if ((*oi)->get_class_id() == TT_DATA_CMD) {
-      dp = (thdata *) (*oi);
+      dp = (thdata *) (*oi).get();
 
       for (lei = dp->leg_list.begin(); lei != dp->leg_list.end(); lei++) {
         if (lei->is_valid) {

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -364,10 +364,6 @@ void thexpmap::process_db(class thdatabase * dbp)
       this->export_th2(this->projptr);
       break;
   }
-  
-  //if (tmp != NULL) {
-  //  tmp->self_delete();
-  //}
 }
 
 

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -603,8 +603,8 @@ void thexpmap::export_xvi(class thdb2dprj * prj)
     thpic * skpic;
     thscrap * scrap;
     for (obi = thdb.object_list.begin(); obi != thdb.object_list.end(); obi++) {
-      if (((*obi)->get_class_id() == TT_SCRAP_CMD) && (!((thscrap *)(*obi))->centerline_io) && (*obi)->fsptr->is_selected() && (((thscrap *)(*obi))->proj->id == prj->id)) {
-        scrap = (thscrap *)(*obi);
+      if (((*obi)->get_class_id() == TT_SCRAP_CMD) && (!((thscrap *)(*obi).get())->centerline_io) && (*obi)->fsptr->is_selected() && (((thscrap *)(*obi).get())->proj->id == prj->id)) {
+        scrap = (thscrap *)(*obi).get();
         skit = scrap->sketch_list.begin();
         while (skit != scrap->sketch_list.end()) {
           skpic = skit->morph(sf);
@@ -837,8 +837,8 @@ void thexpmap::export_th2(class thdb2dprj * prj)
 
   // export scraps & scrap objects
   for (obi = thdb.object_list.begin(); obi != thdb.object_list.end(); obi++) {
-    if (((*obi)->get_class_id() == TT_SCRAP_CMD) && (!((thscrap *)(*obi))->centerline_io) && (*obi)->fsptr->is_selected() && (((thscrap *)(*obi))->proj->id == prj->id)) {
-      scrap = (thscrap *)(*obi);
+    if (((*obi)->get_class_id() == TT_SCRAP_CMD) && (!((thscrap *)(*obi).get())->centerline_io) && (*obi)->fsptr->is_selected() && (((thscrap *)(*obi).get())->proj->id == prj->id)) {
+      scrap = (thscrap *)(*obi).get();
 
 
       // export sketches
@@ -1781,7 +1781,7 @@ else
     obi = thdb.object_list.begin();
     while (obi != thdb.object_list.end()) {
       if ((*obi)->get_class_id() == TT_SURFACE_CMD) {
-        surf = (thsurface *)(*obi);
+        surf = (thsurface *)(*obi).get();
         if (surf->pict_name != NULL) {
           surf->calibrate();
           srfpr.filename = surf->pict_name;
@@ -3462,6 +3462,7 @@ void thexpmap::export_pdf_set_colors_new(class thdb2dxm * maps, class thdb2dprj 
 {
 
   // parsneme lookup a najdeme ho
+  std::unique_ptr<thdataobject> unique_lkp;
   thlookup * lkp = NULL;
   if (this->layout->color_crit_fname != NULL) {
     int cc;
@@ -3473,7 +3474,8 @@ void thexpmap::export_pdf_set_colors_new(class thdb2dxm * maps, class thdb2dprj 
       if (strlen(ccidx) > 0) {
         thwarning(("missing lookup -- %s", this->layout->color_crit_fname));
       }
-      lkp = (thlookup *) this->db->create("lookup", this->src);
+      unique_lkp = this->db->create("lookup", this->src);
+      lkp = dynamic_cast<thlookup*>(unique_lkp.get());
       lkp->m_type = this->layout->color_crit;
     }
   }
@@ -3598,7 +3600,7 @@ void thexpmap::export_pdf_set_colors_new(class thdb2dxm * maps, class thdb2dprj 
     cmap = cmap->next_item;
   }
 
-  lkp->export_color_legend(this->layout);
+  lkp->export_color_legend(this->layout, std::unique_ptr<thlookup>(dynamic_cast<thlookup*>(unique_lkp.release())));
 
 }
 

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -751,7 +751,7 @@ void thexpmodel::export_vrml_file(class thdatabase * dbp) {
     while (obi != dbp->object_list.end()) {
       switch ((*obi)->get_class_id()) {
         case TT_SURFACE_CMD:
-          srfc = ((thsurface*)(*obi));
+          srfc = ((thsurface*)(*obi).get());
           tmp3d = srfc->get_3d();
           srfc->calibrate();
           tinv = srfc->calib_yy*srfc->calib_xx - srfc->calib_xy*srfc->calib_yx;
@@ -1012,7 +1012,7 @@ void thexpmodel::export_3dmf_file(class thdatabase * dbp) {
     while (obi != dbp->object_list.end()) {
       switch ((*obi)->get_class_id()) {
         case TT_SURFACE_CMD:
-          tmp3d = ((thsurface*)(*obi))->get_3d();
+          tmp3d = ((thsurface*)(*obi).get())->get_3d();
           if (tmp3d != NULL) {
             tmp3d->exp_shift_x = avx;
             tmp3d->exp_shift_y = avy;
@@ -1355,7 +1355,7 @@ void thexpmodel::export_dxf_file(class thdatabase * dbp) {
     while (obi != dbp->object_list.end()) {
       switch ((*obi)->get_class_id()) {
         case TT_SURFACE_CMD:
-          tmp3d = ((thsurface*)(*obi))->get_3d();
+          tmp3d = ((thsurface*)(*obi).get())->get_3d();
           if (tmp3d != NULL) {
             tmp3d->exp_shift_x = avx;
             tmp3d->exp_shift_y = avy;
@@ -1492,7 +1492,7 @@ void thexpmodel::export_lox_file(class thdatabase * dbp) {
   obi = dbp->object_list.begin();
   while (obi != dbp->object_list.end()) {
     if ((*obi)->get_class_id() == TT_SURVEY_CMD) {
-      sptr = (thsurvey*)(*obi);
+      sptr = (thsurvey*)(*obi).get();
       if (sptr->is_selected()) {
         sptr->num1 = 1;
       } else {
@@ -1534,7 +1534,7 @@ void thexpmodel::export_lox_file(class thdatabase * dbp) {
   obi = dbp->object_list.begin();
   while (obi != dbp->object_list.end()) {
     if ((*obi)->get_class_id() == TT_SURVEY_CMD) {
-      sptr = (thsurvey*)(*obi);
+      sptr = (thsurvey*)(*obi).get();
       if ((sptr->num1 > 0) && (sptr->fsptr != NULL)) {
         tsptr = sptr->fsptr;
         if (tsptr->num1 > 0)
@@ -1561,7 +1561,7 @@ void thexpmodel::export_lox_file(class thdatabase * dbp) {
   obi = dbp->object_list.begin();
   while (obi != dbp->object_list.end()) {
     if ((*obi)->get_class_id() == TT_SURVEY_CMD) {
-      sptr = (thsurvey*)(*obi);
+      sptr = (thsurvey*)(*obi).get();
       if (sptr->num1 > 0) {
         sptr->num1 = survnum++;
         expf_survey.m_id = sptr->num1;
@@ -1657,7 +1657,7 @@ void thexpmodel::export_lox_file(class thdatabase * dbp) {
     while (obi != dbp->object_list.end()) {
       switch ((*obi)->get_class_id()) {
         case TT_SURFACE_CMD:
-          csrf = ((thsurface*)(*obi));
+          csrf = ((thsurface*)(*obi).get());
           tmp3d = csrf->get_3d();
           if ((tmp3d != NULL) && (tmp3d->nfaces > 0)) {
             expf_sfc.m_id = survnum;

--- a/thexptable.cxx
+++ b/thexptable.cxx
@@ -293,7 +293,7 @@ void thexptable::process_db(class thdatabase * dbp)
           i;
         for(oi = this->db->object_list.begin(); oi != this->db->object_list.end(); oi++) {
           if ((*oi)->get_class_id() == TT_POINT_CMD) {
-            pt = (thpoint*)(*oi);
+            pt = (thpoint*)(*oi).get();
             if ((pt->type == TT_POINT_TYPE_CONTINUATION) && ((pt->text != NULL) || (!this->filter)) && (pt->fsptr->is_selected())) {
               this->db->db2d.process_projection(pt->fscrapptr->proj);
               this->m_table.insert_object(NULL);
@@ -364,7 +364,7 @@ void thexptable::process_db(class thdatabase * dbp)
       //duplicate
       for(oi = this->db->object_list.begin(); oi != this->db->object_list.end(); oi++) {
         if (((*oi)->get_class_id() == TT_SURVEY_CMD) && (strlen((*oi)->name) > 0)) {
-          srv = (thsurvey*)(*oi);
+          srv = (thsurvey*)(*oi).get();
           if (srv->is_selected()) {
             this->m_table.insert_object(NULL);          
             this->m_table.get_object()->m_tree_level = (size_t)(srv->level - 2);

--- a/thgrade.cxx
+++ b/thgrade.cxx
@@ -105,11 +105,6 @@ void thgrade::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long
 }
 
 
-void thgrade::self_delete()
-{
-  delete this;
-}
-
 void thgrade::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thgrade.h
+++ b/thgrade.h
@@ -146,15 +146,6 @@ class thgrade : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -327,10 +327,14 @@ const char * thimport::station_name(const char * sn, const char separator, struc
               else
                 this->db->lcsobjectptr = this->db->csurveyptr->loptr;
               this->db->ccontext = THCTX_SURVEY;
-              nsurvey = (thsurvey*) this->db->create("survey", this->mysrc);
-              // TODO - nastavit mu meno cez set
-              nsurvey->name = this->db->strstore(cbf[active_survey]);
-              this->db->insert(nsurvey);
+
+              {
+                auto unique_nsurvey = this->db->create("survey", this->mysrc);
+                nsurvey = dynamic_cast<thsurvey*>(unique_nsurvey.get());
+                // TODO - nastavit mu meno cez set
+                nsurvey->name = this->db->strstore(cbf[active_survey]);
+                this->db->insert(std::move(unique_nsurvey));
+              }
               this->db->csrc.context = this;
               this->db->csurveylevel--;
 //              nendsurvey = (thendsurvey*) this->db->create("endsurvey", this->mysrc);

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -159,11 +159,6 @@ void thimport::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 }
 
 
-void thimport::self_delete()
-{
-  delete this;
-}
-
 void thimport::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thimport.h
+++ b/thimport.h
@@ -191,14 +191,6 @@ class thimport : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-  /**
    * Get context for object.
    */
    

--- a/thjoin.cxx
+++ b/thjoin.cxx
@@ -122,11 +122,6 @@ void thjoin::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long 
 }
 
 
-void thjoin::self_delete()
-{
-  delete this;
-}
-
 void thjoin::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thjoin.h
+++ b/thjoin.h
@@ -163,15 +163,6 @@ class thjoin : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thlayout.cxx
+++ b/thlayout.cxx
@@ -1053,11 +1053,6 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 }
 
 
-void thlayout::self_delete()
-{
-  delete this;
-}
-
 void thlayout::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thlayout.h
+++ b/thlayout.h
@@ -520,7 +520,7 @@ class thlayout : public thdataobject {
 
   class thconfig * m_pconfig;
 
-  class thlookup * m_lookup;
+  std::unique_ptr<thlookup> m_lookup;
     
   double scale, scale_bar, base_scale, ox, oy, oz, hsize, vsize, paphs, papvs, paghs, pagvs, marls, marts, gxs, gys, gzs, gox, goy, goz, navf, overlap, opacity,
     map_header_x, map_header_y, legend_width, surface_opacity, rotate;

--- a/thlayout.h
+++ b/thlayout.h
@@ -647,15 +647,6 @@ class thlayout : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thlibrarydata.cxx
+++ b/thlibrarydata.cxx
@@ -16,10 +16,12 @@
 
 void thlibrary_init_grades()
 {
+	std::unique_ptr<thdataobject> unique_grade;
 	thgrade * pgrade;
 	thbuffer oname;
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "BCRA3";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "BCRA grade 3";
@@ -35,9 +37,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = 0.25;
 	pgrade->dls_y = 0.25;
 	pgrade->dls_z = 0.25;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "BCRA5";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "BCRA grade 5";
@@ -53,9 +56,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = 0.05;
 	pgrade->dls_y = 0.05;
 	pgrade->dls_z = 0.05;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_-1";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 ungraded survey without map";
@@ -71,9 +75,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_0";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 ungraded survey";
@@ -89,9 +94,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_1";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 1";
@@ -107,9 +113,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_2";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 2";
@@ -125,9 +132,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_3";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 3";
@@ -143,9 +151,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_4";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 4";
@@ -161,9 +170,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_5";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 5";
@@ -179,9 +189,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_6";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 6";
@@ -197,9 +208,10 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 
-	pgrade = (thgrade *) thdb.create("grade", thobjectsrc("therion",0));
+	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
+	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
 	oname = "UISv1_X";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade X";
@@ -215,15 +227,17 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(pgrade);
+	thdb.insert(std::move(unique_grade));
 }
 
 void thlibrary_init_layouts()
 {
+	std::unique_ptr<thdataobject> unique_layout;
 	thlayout * playout;
 	thbuffer oname;
 
-	playout = (thlayout *) thdb.create("layout", thobjectsrc("therion",0));
+	unique_layout = thdb.create("layout", thobjectsrc("therion",0));
+	playout = dynamic_cast<thlayout*>(unique_layout.get());
 	oname = "AUT";
 	playout->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,TT_UTF_8,0);
 	oname = "Austrian symbol set";
@@ -379,9 +393,10 @@ void thlibrary_init_layouts()
 	playout->last_line->smid = SYMX_ICE;
 	playout->last_line->sclr = thlayout_color(0.000000,0.680000,0.940000);
 	playout->def_tex_lines = 2;
-	thdb.insert(playout);
+	thdb.insert(std::move(unique_layout));
 
-	playout = (thlayout *) thdb.create("layout", thobjectsrc("therion",0));
+	unique_layout = thdb.create("layout", thobjectsrc("therion",0));
+	playout = dynamic_cast<thlayout*>(unique_layout.get());
 	oname = "SCR200";
 	playout->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,TT_UTF_8,0);
 	oname = "Computer screen layout";
@@ -520,6 +535,6 @@ void thlibrary_init_layouts()
 	oname = "SKBB";
 	playout->set(thcmd_option_desc(TT_LAYOUT_SYMBOL_DEFAULTS,1),oname,TT_UTF_8,0);
 	playout->def_tex_lines = 2;
-	thdb.insert(playout);
+	thdb.insert(std::move(unique_layout));
 }
 

--- a/thline.cxx
+++ b/thline.cxx
@@ -241,11 +241,6 @@ void thline::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long 
 }
 
 
-void thline::self_delete()
-{
-  delete this;
-}
-
 void thline::self_print_properties(FILE * outf)
 {
   th2ddataobject::self_print_properties(outf);

--- a/thline.h
+++ b/thline.h
@@ -431,15 +431,6 @@ class thline : public th2ddataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
 

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -400,8 +400,8 @@ void thlookup::color_scrap(thscrap * s) {
 }
 
 
-void thlookup::export_color_legend(thlayout * layout) {
-  layout->m_lookup = this;
+void thlookup::export_color_legend(thlayout * layout, std::unique_ptr<thlookup> lookup_holder) {
+  layout->m_lookup = std::move(lookup_holder);
   if (layout->color_legend == TT_TRUE) {
     COLORLEGENDLIST.clear();
     thlookup_table_list::iterator tli;

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -160,12 +160,6 @@ void thlookup::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 }
 
 
-void thlookup::self_delete()
-{
-  delete this;
-}
-
-
 int thlookup::get_context()
 {
   return (THCTX_SURVEY | THCTX_NONE | THCTX_SCRAP);

--- a/thlookup.h
+++ b/thlookup.h
@@ -221,7 +221,7 @@ class thlookup : public thdataobject {
    * Export color legend, if applicable.
    */
 
-  virtual void export_color_legend(thlayout * layout);
+  virtual void export_color_legend(thlayout * layout, std::unique_ptr<thlookup> lookup_holder);
 
 };
 

--- a/thlookup.h
+++ b/thlookup.h
@@ -167,15 +167,6 @@ class thlookup : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Get context for object.
    */
    

--- a/thmap.cxx
+++ b/thmap.cxx
@@ -155,11 +155,6 @@ void thmap::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long i
 }
 
 
-void thmap::self_delete()
-{
-  delete this;
-}
-
 void thmap::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thmap.h
+++ b/thmap.h
@@ -176,15 +176,6 @@ class thmap : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thmapstat.cxx
+++ b/thmapstat.cxx
@@ -221,7 +221,7 @@ void thmapstat::scanmap(class thmap * map) {
 		thmapstat_dataptr dp;
 		thdataobject * obj;
 		for(thdb_object_list_type::iterator it = thdb.object_list.begin(); it != thdb.object_list.end(); it++) {
-			obj = *it;
+			obj = it->get();
 			if ((obj->get_class_id() == TT_DATA_CMD) && (obj->is_in_survey(map->asoc_survey.psurvey))) {
 				dp.ptr = (thdata*)obj;
 				dm[dp] = 1;

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -261,11 +261,6 @@ void thpoint::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long
 }
 
 
-void thpoint::self_delete()
-{
-  delete this;
-}
-
 void thpoint::self_print_properties(FILE * outf)
 {
   th2ddataobject::self_print_properties(outf);

--- a/thpoint.h
+++ b/thpoint.h
@@ -586,15 +586,6 @@ class thpoint : public th2ddataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
 

--- a/thscrap.cxx
+++ b/thscrap.cxx
@@ -226,12 +226,6 @@ void thscrap::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long
   }
 }
 
-void thscrap::self_delete()
-{
-  delete this;
-}
-
-
 void thscrap::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);
@@ -1487,7 +1481,7 @@ void thscrap::parse_sketch(char ** args, int argenc)
   thparse_double(sv,sk.m_y,args[2]);
   if ((sv	!= TT_SV_NUMBER) &&	(sv	!= TT_SV_NAN))
     ththrow(("invalid	number --	%s", args[2]))
-  this->sketch_list.push_back(sk);
+  this->sketch_list.push_back(std::move(sk));
 }
 
 

--- a/thscrap.h
+++ b/thscrap.h
@@ -225,15 +225,6 @@ class thscrap : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Create a sketch linked to current scrap.
    */
 

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -298,7 +298,7 @@ void thselector__prepare_map_tree_export (thdatabase * db) {
   obi = db->object_list.begin();
   while (obi != db->object_list.end()) {
     if (((*obi)->fsptr != NULL) && ((*obi)->get_class_id() == TT_MAP_CMD)) {
-      mi = ((thmap*)(*obi))->first_item;
+      mi = ((thmap*)(*obi).get())->first_item;
       while (mi != NULL) {
         if (mi->type == TT_MAPITEM_NORMAL) {
           mi->object->tmp_bool = false;
@@ -399,14 +399,14 @@ void thselector::dump_selection_db (FILE * cf, thdatabase * db)
   thdb_object_list_type::iterator obi = db->object_list.begin();
   while (obi != db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_MAP_CMD)
-      ((thmap*)(*obi))->nz = 0;
+      ((thmap*)(*obi).get())->nz = 0;
     obi++;
   }
 
   obi = db->object_list.begin();
   while (obi != db->object_list.end()) {
-    if (((*obi)->fsptr != NULL) && ((*obi)->get_class_id() == TT_MAP_CMD) && (((thmap*)(*obi))->tmp_bool))
-      thselector__export_map_tree_node(cf,1,(*obi)->id,(*obi),NULL);
+    if (((*obi)->fsptr != NULL) && ((*obi)->get_class_id() == TT_MAP_CMD) && (((thmap*)(*obi).get())->tmp_bool))
+      thselector__export_map_tree_node(cf,1,(*obi)->id,obi->get(),NULL);
     obi++;
   }
   
@@ -569,7 +569,7 @@ void thselector::select_all(thselector_item * pitm, class thdatabase * db)
   while (ii != db->object_list.end()) {
     switch((*ii)->get_class_id()) {
       case TT_SURVEY_CMD:
-        this->select_object(pitm,*ii);
+        this->select_object(pitm,ii->get());
       default:
         break;
     }

--- a/thsketch.cxx
+++ b/thsketch.cxx
@@ -40,30 +40,22 @@ thsketch::thsketch()
   this->m_warp = NULL;
 }
 
-
-thsketch::~thsketch()
-{
-  if (this->m_warp != NULL)
-    this->m_warp->self_delete();
-}
-
-
 thpic * thsketch::morph(double scale)
 {
   if (this->m_warp == NULL) {
     switch (thcfg.sketch_warp) {
       case THSKETCH_WARP_LINEAR:
-        this->m_warp = new thwarplin;
+        this->m_warp = std::make_unique<thwarplin>();
         break;
       case THSKETCH_WARP_IDPOINT:
-        this->m_warp = new thwarpinvdist;
+        this->m_warp = std::make_unique<thwarpinvdist>();
         break;
       case THSKETCH_WARP_IDLINE:
         //this->m_warp = new thwarpinvdistln;
-        this->m_warp = new thwarpfastinvdistln;
+        this->m_warp = std::make_unique<thwarpfastinvdistln>();
         break;
       default:
-        this->m_warp = new thwarpp;
+        this->m_warp = std::make_unique<thwarpp>();
     }
   }
   return this->m_warp->morph(this, scale);

--- a/thsketch.h
+++ b/thsketch.h
@@ -31,8 +31,10 @@
 
 #include <list>
 #include <map>
+#include <memory>
 
 #include "thpic.h"
+#include "thwarp.h"
 
 enum {
   THSKETCH_WARP_UNKNOWN,
@@ -51,13 +53,11 @@ struct thsketch {
   thpic m_pic;  ///< Picture.
   double m_x;  //!< sketch points X offset
   double m_y;  //!< sketch points Y offset
-  class thwarp * m_warp;  ///< Warping class.
+  std::unique_ptr<thwarp> m_warp;  ///< Warping class.
   class thscrap * m_scrap;  ///< Sketch scrap.
 
   thsketch();
 
-  ~thsketch();
-   
   thpic * morph(double scale);
   
 };

--- a/thsurface.cxx
+++ b/thsurface.cxx
@@ -201,11 +201,6 @@ void thsurface::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lo
 }
 
 
-void thsurface::self_delete()
-{
-  delete this;
-}
-
 void thsurface::self_print_properties(FILE * outf)
 {
   thdataobject::self_print_properties(outf);

--- a/thsurface.h
+++ b/thsurface.h
@@ -166,15 +166,6 @@ class thsurface : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-
-
-  /**
    * Print object properties.
    */
    

--- a/thsurvey.cxx
+++ b/thsurvey.cxx
@@ -186,12 +186,6 @@ void thsurvey::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 }
 
 
-void thsurvey::self_delete()
-{
-  delete this;
-}
-
-
 void thsurvey::self_print_properties(FILE * outf)
 {
   size_t nval, idx;

--- a/thsurvey.h
+++ b/thsurvey.h
@@ -208,15 +208,6 @@ class thsurvey : public thdataobject {
 
 
   /**
-   * Delete this object.
-   *
-   * @warn Always use this method instead of delete function.
-   */
-   
-  virtual void self_delete();
-  
-  
-  /**
    * Get context for object.
    */
    

--- a/thsurvey.h
+++ b/thsurvey.h
@@ -32,7 +32,9 @@
 #include "thdataobject.h"
 #include "thtfpwf.h"
 #include "thperson.h"
+#include "thdata.h"
 #include <map>
+#include <memory>
 
 /**
  * survey command options tokens.
@@ -113,7 +115,8 @@ class thsurvey : public thdataobject {
 
   unsigned level;
     
-  class thdata * data;
+  std::unique_ptr<class thdata> tmp_data_holder;
+  thdata * data;
   
   void parse_declination(char * str);
   

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -348,7 +348,7 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
   
     if ((*obi)->get_class_id() == TT_DATA_CMD) {
       
-      dp = (thdata *)(*obi);
+      dp = (thdata *)(*obi).get();
       
       // scan data shots
       lei = dp->leg_list.begin();

--- a/thwarp.cxx
+++ b/thwarp.cxx
@@ -41,11 +41,6 @@ thpic * thwarp::morph(thsketch * sketch, double scale) {
   return NULL;
 }
 
-void thwarp::self_delete()
-{
-  delete this;
-}
-
 
 /**
  * Sketch station structure.
@@ -398,24 +393,4 @@ thpic * thwarplin::morph(thsketch * sketch, double scale)
   thtext_inline = false;
   return &(this->mpic);
 
-}
-
-void thwarplin::self_delete()
-{
-  delete this;
-}
-
-void thwarpinvdist::self_delete()
-{
-  delete this;
-}
-
-void thwarpinvdistln::self_delete()
-{
-  delete this;
-}
-
-void thwarpfastinvdistln::self_delete()
-{
-  delete this;
 }

--- a/thwarp.h
+++ b/thwarp.h
@@ -31,14 +31,13 @@
 
 #include <cstddef>
 #include "thpic.h"
-#include "thsketch.h"
 
 
 class thwarp {
 
   protected:
 
-  thsketch * m_sketch;
+  class thsketch * m_sketch;
 
   public:
 
@@ -52,15 +51,6 @@ class thwarp {
    */
    
   virtual thpic * morph(thsketch * sketch, double scale);
-
-
-  /**
-   * Delete warp object.
-   */
-   
-  virtual void self_delete();
-
-   
 };
 
 
@@ -82,9 +72,6 @@ class thwarplin : public thwarp {
   thwarplin() : morphed(false), method(0) {}
    
   virtual thpic * morph(thsketch * sketch, double scale);
-
-  virtual void self_delete();
-   
 };
 
 
@@ -100,9 +87,6 @@ class thwarpinvdist : public thwarplin {
   thwarpinvdist() {
     this->method = 1;
   }
-
-  virtual void self_delete();
-   
 };
 
 
@@ -118,9 +102,6 @@ class thwarpinvdistln : public thwarplin {
   thwarpinvdistln() {
     this->method = 2;
   }
-
-  virtual void self_delete();
-   
 };
 
 
@@ -135,9 +116,6 @@ class thwarpfastinvdistln : public thwarplin {
   thwarpfastinvdistln() {
     this->method = 3;
   }
-
-  virtual void self_delete();
-   
 };
 
 

--- a/thwarpp.cxx
+++ b/thwarpp.cxx
@@ -36,12 +36,6 @@
 thwarpp::~thwarpp() {}
 
 
-void thwarpp::self_delete()
-{
-  delete this;
-}
-
-
 thscrap * thwarpp::get_scrap()
 {
   if (this->m_sketch != NULL)

--- a/thwarpp.h
+++ b/thwarpp.h
@@ -95,9 +95,6 @@ public:
   virtual ~thwarpp();
 
   virtual thpic * morph(thsketch * sketch, double scale);
-
-  virtual void self_delete();
-
 };
 
 


### PR DESCRIPTION
Improved memory management:
1. `thdatabase` uses unique pointers, which resolved memory leaks when compiling samples.
2. Removed method `self_delete()`, we don't need such method if lifetime of polymorphic objects is managed by unique pointers.