### PR TITLE
Link with UBSan

### DIFF
--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -232,7 +232,7 @@ namespace OGLFT {
     //! a GLdouble[3].
     //! \return GLfloat[4] (RGBA) color specification.
     virtual GLfloat* color ( GLdouble* p ) = 0;
-    virtual ~ColorTess();
+    virtual ~ColorTess() = default;
   };
 
   //! During tesselation of a polygonal Face (outline, filled or solid),
@@ -246,7 +246,7 @@ namespace OGLFT {
     //! a GLdouble[3].
     //! \return GLfloat[2] (s,t) texture coordinates.
     virtual GLfloat* texCoord ( GLdouble* p ) = 0;
-    virtual ~TextureTess();
+    virtual ~TextureTess() = default;
   };
 
   //! The argument to setCharacterDisplayLists is an STL vector of


### PR DESCRIPTION
Fixed linker errors when compiling with Undefined Behavior Sanitizer. It didn't like missing definitions of virtual destructors.