### PR TITLE
Undefined Behavior Sanitizer

### DIFF
--- a/loch/lxFile.cxx
+++ b/loch/lxFile.cxx
@@ -4,7 +4,7 @@
 #ifndef LXDEPCHECK
 #include <cstdlib>
 #include <cstdio>
-#include <string.h>
+#include <cstring>
 #include <locale.h>
 #include <map>
 #include <list>
@@ -26,7 +26,7 @@
 lxFileSizeT lxFileSize::Save(lxFileBuff & ptr)
 {
   lxFileSizeT s(sizeof(uint32_t));
-  *((uint32_t *)(ptr)) = (uint32_t) this->m_size;
+  std::memcpy(ptr, &m_size, s);
   lxFile::switchEndian(ptr, s);
   ptr += s;
   return s;
@@ -36,7 +36,7 @@ lxFileSizeT lxFileSize::Save(lxFileBuff & ptr)
 lxFileSizeT lxFileSize::Load(lxFileBuff & ptr)
 {
   lxFileSizeT s(sizeof(lxFileSizeT));
-  this->m_size = (lxFileSizeT) *((uint32_t *)(ptr));
+  std::memcpy(&m_size, ptr, s);
   lxFile::switchEndian((char *)(&this->m_size), s);
   ptr += s;
   return s;
@@ -46,7 +46,7 @@ lxFileSizeT lxFileSize::Load(lxFileBuff & ptr)
 lxFileSizeT lxFileDbl::Save(lxFileBuff & ptr)
 {
   lxFileSizeT s(sizeof(this->m_num));
-  *((double *)(ptr)) = this->m_num;
+  std::memcpy(ptr, &m_num, s);
   lxFile::switchEndian(ptr, s);
   ptr += s;
   return s;
@@ -56,7 +56,7 @@ lxFileSizeT lxFileDbl::Save(lxFileBuff & ptr)
 lxFileSizeT lxFileDbl::Load(lxFileBuff & ptr)
 {
   lxFileSizeT s(sizeof(this->m_num));
-  this->m_num = *((double *)(ptr));
+  std::memcpy(&m_num, ptr, s);
   lxFile::switchEndian((char *)(&this->m_num), s);
   ptr += s;
   return s;

--- a/thattr.h
+++ b/thattr.h
@@ -82,7 +82,7 @@ struct thattr_field {
 
   int m_type;  ///< Generic export type.
 
-  bool m_present;  ///< Whether there is any value present.
+  bool m_present = false;  ///< Whether there is any value present.
 
   long m_mini,  ///< Minimum integer value.
     m_maxi; ///< Maximum integer value.

--- a/thepsparse.h
+++ b/thepsparse.h
@@ -144,7 +144,7 @@ struct MP_data {
 struct converted_data {
   MP_data MP;
   set<string> fonts, patterns;
-  bool transparency;
+  bool transparency = false;
 //  double hsize, vsize;
   double llx, lly, urx, ury;
   


### PR DESCRIPTION
Fixed errors reported by Undefined Behavior Sanitizer:
* uninitialized variables:
```
therion/thepsparse.h:161:8: runtime error: load of value 111, which is not a valid value for type 'bool'
```
* cast `char*` to `double*` or `uint32_t*` is undefined behavior because of pointer alignment:
```
therion/loch/lxFile.cxx:49:22: runtime error: store to misaligned address 0x55b44bcaf5ec for type 'double', which requires 8 byte alignment
```