### PR TITLE
fixed cppcheck warnings

### DIFF
--- a/therion.h
+++ b/therion.h
@@ -176,7 +176,7 @@ void thpause_exit();
  * @param exit_code Exit code of the program
  */
 
-void thexit(int exit_code);
+[[noreturn]] void thexit(int exit_code);
 
 extern bool thtext_inline;
 

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -1999,7 +1999,7 @@ void thexpmodel::export_kml_file(class thdatabase * dbp)
 
 void thexpmodel::export_kml_survey_file(FILE * out, thsurvey * surv)
 {
-  if ((strlen(surv->name) == 0) || !(surv->is_selected()) || (surv == NULL))
+  if (!surv || (strlen(surv->name) == 0) || !(surv->is_selected()))
     return;
 
   thdataobject * obj;

--- a/thparse.cxx
+++ b/thparse.cxx
@@ -819,10 +819,10 @@ void thdecode_utf2tex(thbuffer * dest, const char * src)
 void thdecode_sql(thbuffer * dest, const char * src)
 {
 
-  size_t srcln = strlen(src), srcx = 0;
+  size_t srcln, srcx = 0;
   unsigned char * srcp, * dstp;
 //  unsigned num;
-  if ((src == NULL) || (srcln == 0)) {
+  if ((src == NULL) || ((srcln = strlen(src)) == 0)) {
     *dest = "NULL";
     return;
   }


### PR DESCRIPTION
Fixed Cppcheck warnings:
- pointers used before null check
- added hint that `thexit()` does not return