### PR TITLE
Static analysis with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+---
+Checks: '-*,clang-analyzer-cplusplus.InnerPointer,modernize-use-override'
+WarningsAsErrors: '*'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle: none
+CheckOptions:
+  - key:             modernize-use-override.IgnoreDestructors
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,19 +5,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        type: [Debug, Release]
-        sanitizer: ["", address]
-        compiler: 
-          - { cc: gcc,   cxx: g++     }
-          - { cc: clang, cxx: clang++ }
         include:
-          - os: ubuntu-18.04
-            type: Release
-            sanitizer: ""
-            compiler:
-              cc: gcc
-              cxx: g++
+          - { os: ubuntu-18.04, type: Release, cc: gcc,   cxx: g++,     args: ""                                }
+          - { os: ubuntu-20.04, type: Release, cc: gcc,   cxx: g++,     args: "-DECM_ENABLE_SANITIZERS=address" }
+          - { os: ubuntu-20.04, type: Debug,   cc: clang, cxx: clang++, args: "-DENABLE_CLANG_TIDY=ON"          }
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
@@ -29,10 +20,10 @@ jobs:
           mkdir build && cd build && \
           cmake -G Ninja \
                 -DCMAKE_BUILD_TYPE=${{ matrix.type }} \
-                -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
-                -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
-                -DECM_ENABLE_SANITIZERS=${{ matrix.sanitizer }} \
-                -DBUILD_SHAPELIB=OFF ..
+                -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+                -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+                -DBUILD_SHAPELIB=OFF \
+                ${{ matrix.args }} ..
       - run: cmake --build build
       - run: cmake --build build -t test
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ SYMBOLS.txt
 innosetup.ini
 xtherion/therion.tcl
 .*
+!.clang-tidy
 !.gitignore
 !.github/
 !.gitattributes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ set(ECM_ENABLE_SANITIZERS "" CACHE STRING
     "Enable runtime sanitizers, available options: address,memory,thread,leak,undefined." )
 set(ENABLE_THDEBUG OFF CACHE BOOL "Print debug information.")
 
+option(ENABLE_CLANG_TIDY "Enable static analysis with clang-tidy." OFF)
+if (ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXECUTABLE clang-tidy)
+    if (CLANG_TIDY_EXECUTABLE)
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXECUTABLE};--quiet")
+    endif()
+endif()
+
 # determine platform
 if(UNIX AND NOT APPLE)
     set(THPLATFORM LINUX)
@@ -41,7 +49,7 @@ set_source_files_properties(
 )
 
 # copy files needed by some build steps
-file(COPY thcsdata.tcl thsymbolsetfont.txt DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY thcsdata.tcl thsymbolsetfont.txt .clang-tidy DESTINATION ${CMAKE_BINARY_DIR})
 
 # generate thcsdata sources
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/thcsdata.h

--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -128,7 +128,7 @@ class DnDFile : public wxFileDropTarget {
 	
     DnDFile(lxFrame *parent) : m_Parent(parent) { }
 	
-    virtual bool OnDropFiles(wxCoord, wxCoord, const wxArrayString &filenames);
+    bool OnDropFiles(wxCoord, wxCoord, const wxArrayString &filenames) override;
 
 };
 


### PR DESCRIPTION
Added CMake option `ENABLE_CLANG_TIDY`, which will enable static analysis with `clang-tidy`. Also reworked Github Actions to run static analysis.