### PR TITLE
Use override

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks: '-*,clang-analyzer-cplusplus.InnerPointer,modernize-use-override'
 WarningsAsErrors: '*'
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle: none
 CheckOptions:

--- a/loch/CMakeLists.txt
+++ b/loch/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CXX_FLAGS_WITHOUT_INCLUDE_DIRS ${wxWidgets_CXX_FLAGS_LIST})
 list(FILTER CXX_FLAGS_WITHOUT_INCLUDE_DIRS EXCLUDE REGEX "-I/")
 target_compile_options(loch PRIVATE ${CXX_FLAGS_WITHOUT_INCLUDE_DIRS})
 target_compile_definitions(loch PRIVATE ${LOCH_DEFINITIONS})
+target_include_directories(loch PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(loch SYSTEM PRIVATE ${FREETYPE_INCLUDE_DIRS} ${wxWidgets_INCLUDE_DIRS} ${VTK_INCLUDE_DIRS} ${X11_INCLUDE_DIR})
 target_link_libraries(loch PRIVATE
     loch-common

--- a/loch/CMakeLists.txt
+++ b/loch/CMakeLists.txt
@@ -29,9 +29,12 @@ endif()
 
 # loch executable
 add_executable(loch WIN32 ${LOCH_HEADERS} ${LOCH_SOURCES} $<$<BOOL:${IS_WINDOWS}>:lxR2D.c> $<$<STREQUAL:${THPLATFORM},LINUX>:lxR2P.c>)
-target_compile_options(loch PRIVATE ${wxWidgets_CXX_FLAGS_LIST})
+# we need to filter out include directories from wxWidgets cxx flags list, because we have to set them only as system headers to ignore warnings
+set(CXX_FLAGS_WITHOUT_INCLUDE_DIRS ${wxWidgets_CXX_FLAGS_LIST})
+list(FILTER CXX_FLAGS_WITHOUT_INCLUDE_DIRS EXCLUDE REGEX "-I/")
+target_compile_options(loch PRIVATE ${CXX_FLAGS_WITHOUT_INCLUDE_DIRS})
 target_compile_definitions(loch PRIVATE ${LOCH_DEFINITIONS})
-target_include_directories(loch PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${FREETYPE_INCLUDE_DIRS} ${wxWidgets_INCLUDE_DIRS} ${VTK_INCLUDE_DIRS} ${X11_INCLUDE_DIR})
+target_include_directories(loch SYSTEM PRIVATE ${FREETYPE_INCLUDE_DIRS} ${wxWidgets_INCLUDE_DIRS} ${VTK_INCLUDE_DIRS} ${X11_INCLUDE_DIR})
 target_link_libraries(loch PRIVATE
     loch-common
     ${wxWidgets_LIBRARIES}

--- a/loch/lxGUI.h
+++ b/loch/lxGUI.h
@@ -269,7 +269,7 @@ class lxApp: public wxGLApp
     wxLocale m_locale;
     wxFileName m_path;
   
-    bool OnInit();
+    bool OnInit() override;
     
 #ifdef LXMACOSX
     virtual void MacOpenFile(const wxString &fileName);

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -1210,7 +1210,7 @@ namespace OGLFT {
      * Set the individual character rotation in the Z direction.
      * \param character_rotation_z angle in degrees of the Z rotation.
      */
-    void setCharacterRotationZ ( GLfloat character_rotation_z );
+    void setCharacterRotationZ ( GLfloat character_rotation_z ) override;
 
     /*!
      * \return the character rotation in the X direction.
@@ -1225,7 +1225,7 @@ namespace OGLFT {
     /*!
      * \return the character rotation in the Z direction.
      */
-    GLfloat characterRotationZ ( void ) const { return character_rotation_.z_; }
+    GLfloat characterRotationZ ( void ) const override { return character_rotation_.z_; }
 
     /*!
      * Set an optional color tesselation object. Each tesselated vertex
@@ -1253,14 +1253,14 @@ namespace OGLFT {
     /*!
      * \return the height (i.e., line spacing) at the current character size.
      */
-    double height ( void ) const;
+    double height ( void ) const override;
 
     /*!
      * Implement measuring a character in a polygonal face.
      * \param c the (latin1) character to measure
      * \return the bounding box of c.
      */
-    BBox measure ( unsigned char c );
+    BBox measure ( unsigned char c ) override;
 #ifdef _UNICODE
 #ifndef OGLFT_NO_WX
     /*!
@@ -1268,7 +1268,7 @@ namespace OGLFT {
      * \param c the (UNICODE) character to measure
      * \return the bounding box of c.
      */
-    BBox measure ( const wxChar c );
+    BBox measure ( const wxChar c ) override;
 #endif /* OGLFT_NO_WX */
 #endif /* _UNICODE */
 
@@ -1278,7 +1278,7 @@ namespace OGLFT {
      * \param s string of (latin1) characters to measure
      * \return the bounding box of s.
      */
-    BBox measure ( const char* s ) { return Face::measure( s ); }
+    BBox measure ( const char* s ) override { return Face::measure( s ); }
 #ifndef OGLFT_NO_WX
     /*!
      * Implement measuring a formatted number
@@ -1286,17 +1286,17 @@ namespace OGLFT {
      * \param number to value to format
      * \return the bounding box of the formatted number
      */
-    BBox measure ( const wxString& format, double number )
+    BBox measure ( const wxString& format, double number ) override
     { return Face::measure( format, number ); }
 #endif /* OGLFT_NO_WX */
 
   private:
     void init ( void );
-    void setCharSize ( void );
-    void setRotationOffset ( void );
-    GLuint compileGlyph ( FT_Face face, FT_UInt glyph_index );
+    void setCharSize ( void ) override;
+    void setRotationOffset ( void ) override;
+    GLuint compileGlyph ( FT_Face face, FT_UInt glyph_index ) override;
   protected:
-    void clearCaches ( void );
+    void clearCaches ( void ) override;
   };
 
   //! Render text as a polygon outline.
@@ -1343,7 +1343,7 @@ namespace OGLFT {
     ~Outline ( void );
   private:
     void init ( void );
-    void renderGlyph ( FT_Face face, FT_UInt glyph_index );
+    void renderGlyph ( FT_Face face, FT_UInt glyph_index ) override;
     static int moveToCallback ( FT_Vector* to, Outline* outline );
     static int lineToCallback ( FT_Vector* to, Outline* outline );
     static int conicToCallback ( FT_Vector* control, FT_Vector* to, Outline* outline );
@@ -1421,7 +1421,7 @@ namespace OGLFT {
     VertexInfoList& extraVertices ( void ) { return extra_vertices_; }
 
   protected:
-    void renderGlyph ( FT_Face face, FT_UInt glyph_index );
+    void renderGlyph ( FT_Face face, FT_UInt glyph_index ) override;
   private:
     void init ( void );
     static int moveToCallback ( FT_Vector* to, Filled* filled );
@@ -1589,23 +1589,23 @@ namespace OGLFT {
      * Set the individual character rotation in the Z direction.
      * \param character_rotation_z angle in degrees of Z rotation.
      */
-    void setCharacterRotationZ ( GLfloat character_rotation_z );
+    void setCharacterRotationZ ( GLfloat character_rotation_z ) override;
     /*!
      * \return the character rotation in the Z direction.
      */
-    GLfloat characterRotationZ ( void ) const { return character_rotation_z_; }
+    GLfloat characterRotationZ ( void ) const override { return character_rotation_z_; }
 
     /*!
      * \return the height (i.e., line spacing) at the current character size.
      */
-    double height ( void ) const;
+    double height ( void ) const override;
 
     /*!
      * Implement measuring a character in a raster face.
      * \param c the (latin1) character to measure
      * \return the bounding box of c.
      */
-    BBox measure ( unsigned char c );
+    BBox measure ( unsigned char c ) override;
 
 #ifdef _UNICODE
 #ifndef OGLFT_NO_WX
@@ -1614,7 +1614,7 @@ namespace OGLFT {
      * \param c the (UNICODE) character to measure
      * \return the bounding box of c.
      */
-    BBox measure ( const wxChar c );
+    BBox measure ( const wxChar c ) override;
 #endif /* OGLFT_NO_WX */
 #endif /* _UNICODE */
 
@@ -1624,7 +1624,7 @@ namespace OGLFT {
      * \param s string of (latin1) characters to measure
      * \return the bounding box of s.
      */
-    BBox measure ( const char* s ) { return Face::measure( s ); }
+    BBox measure ( const char* s ) override { return Face::measure( s ); }
 #ifndef OGLFT_NO_WX
     /*!
      * Implement measuring a formatted number
@@ -1632,16 +1632,16 @@ namespace OGLFT {
      * \param number to value to format
      * \return the bounding box of the formatted number
      */
-    BBox measure ( const wxString& format, double number )
+    BBox measure ( const wxString& format, double number ) override
     { return Face::measure( format, number ); }
 #endif /* OGLFT_NO_WX */
 
   private:
     void init ( void );
-    GLuint compileGlyph ( FT_Face face, FT_UInt glyph_index );
-    void setCharSize ( void );
-    void setRotationOffset ( void );
-    void clearCaches ( void );
+    GLuint compileGlyph ( FT_Face face, FT_UInt glyph_index ) override;
+    void setCharSize ( void ) override;
+    void setRotationOffset ( void ) override;
+    void clearCaches ( void ) override;
   };
 
   //! Render text as a monochrome raster image.
@@ -1689,7 +1689,7 @@ namespace OGLFT {
     ~Monochrome ( void );
   private:
     GLubyte* invertBitmap ( const FT_Bitmap& bitmap );
-    void renderGlyph ( FT_Face face, FT_UInt glyph_index );
+    void renderGlyph ( FT_Face face, FT_UInt glyph_index ) override;
   };
 
   //! Render text as a grayscale raster image.
@@ -1738,7 +1738,7 @@ namespace OGLFT {
     ~Grayscale ( void );
   private:
     GLubyte* invertPixmap ( const FT_Bitmap& bitmap );
-    void renderGlyph ( FT_Face face, FT_UInt glyph_index );
+    void renderGlyph ( FT_Face face, FT_UInt glyph_index ) override;
   };
 
   //! Render text as a translucent raster image.
@@ -1795,7 +1795,7 @@ namespace OGLFT {
 
   private:
     GLubyte* invertPixmapWithAlpha ( const FT_Bitmap& bitmap );
-    void renderGlyph ( FT_Face face, FT_UInt glyph_index );
+    void renderGlyph ( FT_Face face, FT_UInt glyph_index ) override;
   };
 
   //! This is the base class of the texture style.
@@ -1883,7 +1883,7 @@ namespace OGLFT {
      * Set the individual character rotation in the Z direction.
      * \param character_rotation_z angle in degrees of Z rotation.
      */
-    void setCharacterRotationZ ( GLfloat character_rotation_z );
+    void setCharacterRotationZ ( GLfloat character_rotation_z ) override;
 
     /*!
      * \return the character rotation in the X direction.
@@ -1898,19 +1898,19 @@ namespace OGLFT {
     /*!
      * \return the character rotation in the Z direction.
      */
-    GLfloat characterRotationZ ( void ) const { return character_rotation_.z_; }
+    GLfloat characterRotationZ ( void ) const override { return character_rotation_.z_; }
 
     /*!
      * \return the height (i.e., line spacing) at the current character size.
      */
-    double height ( void ) const;
+    double height ( void ) const override;
 
     /*!
      * Implement measuring a character in a texture face.
      * \param c the (latin1) character to measure
      * \return the bounding box of c.
      */
-    BBox measure ( unsigned char c );
+    BBox measure ( unsigned char c ) override;
 
 #ifdef _UNICODE
 #ifndef OGLFT_NO_WX
@@ -1919,7 +1919,7 @@ namespace OGLFT {
      * \param c the (UNICODE) character to measure
      * \return the bounding box of c.
      */
-    BBox measure ( const wxChar c );
+    BBox measure ( const wxChar c ) override;
 #endif /* OGLFT_NO_WX */
 #endif /* _UNICODE */
 
@@ -1929,7 +1929,7 @@ namespace OGLFT {
      * \param s string of (latin1) characters to measure
      * \return the bounding box of s.
      */
-    BBox measure ( const char* s ) { return Face::measure( s ); }
+    BBox measure ( const char* s ) override { return Face::measure( s ); }
 #ifndef OGLFT_NO_WX
     /*!
      * Implement measuring a formatted number
@@ -1937,7 +1937,7 @@ namespace OGLFT {
      * \param number to value to format
      * \return the bounding box of the formatted number
      */
-    BBox measure ( const wxString& format, double number )
+    BBox measure ( const wxString& format, double number ) override
     { return Face::measure( format, number ); }
 #endif /* OGLFT_NO_WX */
 
@@ -1962,11 +1962,11 @@ namespace OGLFT {
 
   private:
     void init ( void );
-    void setCharSize ( void );
-    void setRotationOffset ( void );
-    GLuint compileGlyph ( FT_Face face, FT_UInt glyph_index );
-    void renderGlyph ( FT_Face face, FT_UInt glyph_index );
-    void clearCaches ( void );
+    void setCharSize ( void ) override;
+    void setRotationOffset ( void ) override;
+    GLuint compileGlyph ( FT_Face face, FT_UInt glyph_index ) override;
+    void renderGlyph ( FT_Face face, FT_UInt glyph_index ) override;
+    void clearCaches ( void ) override;
   };
 
   //! Render text as texture mapped monochrome quads.
@@ -2022,7 +2022,7 @@ namespace OGLFT {
     ~MonochromeTexture ( void );
   private:
     GLubyte* invertBitmap ( const FT_Bitmap& bitmap, int* width, int* height );
-    void bindTexture ( FT_Face face, FT_UInt glyph_index );
+    void bindTexture ( FT_Face face, FT_UInt glyph_index ) override;
   };
 
   //! Render text as texture mapped grayscale quads.
@@ -2078,7 +2078,7 @@ namespace OGLFT {
     ~GrayscaleTexture ( void );
   private:
     GLubyte* invertPixmap ( const FT_Bitmap& bitmap, int* width, int* height );
-    void bindTexture ( FT_Face face, FT_UInt glyph_index );
+    void bindTexture ( FT_Face face, FT_UInt glyph_index ) override;
   };
 
   //! Render text as texture mapped translucent quads.
@@ -2140,7 +2140,7 @@ namespace OGLFT {
     ~TranslucentTexture ( void );
   private:
     GLubyte* invertPixmap ( const FT_Bitmap& bitmap, int* width, int* height );
-    void bindTexture ( FT_Face face, FT_UInt glyph_index );
+    void bindTexture ( FT_Face face, FT_UInt glyph_index ) override;
   };
 } // Close OGLFT namespace
 #endif /* OGLFT_H */

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -115,15 +115,15 @@ public:
 
 	~lxDoubleValidator();
 
-  virtual wxObject *Clone() const { return new lxDoubleValidator(*this); }
+  wxObject *Clone() const override { return new lxDoubleValidator(*this); }
 
   bool Copy(const lxDoubleValidator& val);
     
-	virtual bool Validate(wxWindow *parent);
+	bool Validate(wxWindow *parent) override;
 
-  virtual bool TransferToWindow();
+  bool TransferToWindow() override;
 
-  virtual bool TransferFromWindow();
+  bool TransferFromWindow() override;
 
 protected:
 
@@ -157,15 +157,15 @@ public:
 
 	~lxRadioBtnValidator();
 
-  virtual wxObject *Clone() const { return new lxRadioBtnValidator(*this); }
+  wxObject *Clone() const override { return new lxRadioBtnValidator(*this); }
 
   bool Copy(const lxRadioBtnValidator& val);
     
-	virtual bool Validate(wxWindow *parent);
+	bool Validate(wxWindow *parent) override;
 
-  virtual bool TransferToWindow();
+  bool TransferToWindow() override;
 
-  virtual bool TransferFromWindow();
+  bool TransferFromWindow() override;
 
 protected:
 

--- a/th2ddataobject.h
+++ b/th2ddataobject.h
@@ -171,21 +171,21 @@ class th2ddataobject : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "th2ddataobject";};
+  const char * get_class_name() override {return "th2ddataobject";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
 
@@ -193,7 +193,7 @@ class th2ddataobject : public thdataobject {
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -204,21 +204,21 @@ class th2ddataobject : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
   
   
   /**

--- a/tharea.h
+++ b/tharea.h
@@ -149,49 +149,49 @@ class tharea : public th2ddataobject {
    * Return class identifier.
    */
 
-  virtual int get_class_id();
+  int get_class_id() override;
 
 
   /**
    * Return class name.
    */
 
-  virtual const char * get_class_name() {return "tharea";};
+  const char * get_class_name() override {return "tharea";};
 
 
   /**
    * Return true, if son of given class.
    */
 
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
 
 
   /**
    * Return number of command arguments.
    */
 
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
 
 
   /**
    * Return command name.
    */
 
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
 
 
   /**
    * Return command end option.
    */
 
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
 
 
   /**
    * Return option description.
    */
 
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
 
 
   /**
@@ -202,28 +202,28 @@ class tharea : public th2ddataobject {
    * @param argenc Arguments encoding.
    */
 
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
 
-  virtual void self_print_properties(FILE * outf);
+  void self_print_properties(FILE * outf) override;
 
 
   /**
    * Export to metapost file.
    */
 
-  virtual bool export_mp(class thexpmapmpxs * out);
+  bool export_mp(class thexpmapmpxs * out) override;
 
 
   void parse_type(char * tstr);  ///< Parse area type.
 
   void parse_subtype(char * ststr);  ///< Parse area subtype.
 
-  virtual void start_insert();
+  void start_insert() override;
 
 
 };

--- a/thcomment.h
+++ b/thcomment.h
@@ -78,49 +78,49 @@ class thcomment : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thcomment";};
+  const char * get_class_name() override {return "thcomment";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -131,21 +131,21 @@ class thcomment : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
   
 };
 

--- a/thdata.h
+++ b/thdata.h
@@ -264,56 +264,56 @@ class thdata : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
 
 
   /**
    * Whether multiple ends.
    */
    
-  virtual bool get_cmd_ends_state();
+  bool get_cmd_ends_state() override;
 
 
   /**
    * Whether cmd is end.
    */
    
-  virtual bool get_cmd_ends_match(char * cmd);
+  bool get_cmd_ends_match(char * cmd) override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -324,28 +324,28 @@ class thdata : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thdata";};
+  const char * get_class_name() override {return "thdata";};
   
 
   /**
    * Print object contents into file.
    */
    
-  virtual void self_print_properties(FILE * outf);  
+  void self_print_properties(FILE * outf) override;  
 
 
   /**
    * Called before insertion into database.
    */
    
-  virtual void start_insert();
+  void start_insert() override;
     
   
   /**
@@ -358,7 +358,7 @@ class thdata : public thdataobject {
    * Convert all points in object.
    */
 
-  virtual void convert_all_cs();
+  void convert_all_cs() override;
 
 
 };

--- a/thdatastation.h
+++ b/thdatastation.h
@@ -46,21 +46,21 @@ class thdatastation : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thdatastation";};
+  const char * get_class_name() override {return "thdatastation";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
 };
 
 

--- a/thendscrap.h
+++ b/thendscrap.h
@@ -76,49 +76,49 @@ class thendscrap : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thendscrap";};
+  const char * get_class_name() override {return "thendscrap";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -129,21 +129,21 @@ class thendscrap : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
 };
 

--- a/thendsurvey.h
+++ b/thendsurvey.h
@@ -58,42 +58,42 @@ class thendsurvey : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -104,28 +104,28 @@ class thendsurvey : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
 
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thendsurvey";};  
+  const char * get_class_name() override {return "thendsurvey";};  
   
 
   /**
    * Print object contents into file.
    */
    
-  virtual void self_print_properties(FILE * outf);  
+  void self_print_properties(FILE * outf) override;  
     
   
 };

--- a/thexpdb.h
+++ b/thexpdb.h
@@ -103,28 +103,28 @@ class thexpdb : public thexport {
    * Parse model export options.
    */
    
-  virtual void parse_options(int & argx, int nargs, char ** args);
+  void parse_options(int & argx, int nargs, char ** args) override;
 
   
   /**
    * Dump object into file.
    */
    
-  virtual void dump_body(FILE * xf);
+  void dump_body(FILE * xf) override;
 
 
   /**
    * Dump object into file.
    */
    
-  virtual void dump_header(FILE * xf);
+  void dump_header(FILE * xf) override;
   
 
   /**
    * Make export.
    */
    
-  virtual void process_db(class thdatabase * dbp);
+  void process_db(class thdatabase * dbp) override;
   
 };
 

--- a/thexpmap.h
+++ b/thexpmap.h
@@ -231,7 +231,7 @@ class thexpmap : public thexport {
    * Parse map export options.
    */
    
-  virtual void parse_options(int & argx, int nargs, char ** args);
+  void parse_options(int & argx, int nargs, char ** args) override;
 
   /**
    * Parse layout options.
@@ -244,21 +244,21 @@ class thexpmap : public thexport {
    * Dump object into file.
    */
    
-  virtual void dump_body(FILE * xf);
+  void dump_body(FILE * xf) override;
 
 
   /**
    * Dump object into file.
    */
    
-  virtual void dump_header(FILE * xf);
+  void dump_header(FILE * xf) override;
   
 
   /**
    * Make export.
    */
    
-  virtual void process_db(class thdatabase * dbp);
+  void process_db(class thdatabase * dbp) override;
 
 
   /**

--- a/thexpmodel.h
+++ b/thexpmodel.h
@@ -214,28 +214,28 @@ class thexpmodel : public thexport {
    * Parse model export options.
    */
    
-  virtual void parse_options(int & argx, int nargs, char ** args);
+  void parse_options(int & argx, int nargs, char ** args) override;
 
   
   /**
    * Dump object into file.
    */
    
-  virtual void dump_body(FILE * xf);
+  void dump_body(FILE * xf) override;
 
 
   /**
    * Dump object into file.
    */
    
-  virtual void dump_header(FILE * xf);
+  void dump_header(FILE * xf) override;
   
 
   /**
    * Make export.
    */
    
-  virtual void process_db(class thdatabase * dbp);
+  void process_db(class thdatabase * dbp) override;
   
 };
 

--- a/thexpsys.h
+++ b/thexpsys.h
@@ -46,7 +46,7 @@ class thexpsys : public thexport {
    * Make export.
    */
    
-  virtual void process_db(class thdatabase * dbp);
+  void process_db(class thdatabase * dbp) override;
   
 };
 

--- a/thexptable.h
+++ b/thexptable.h
@@ -119,28 +119,28 @@ class thexptable : public thexport {
    * Parse model export options.
    */
    
-  virtual void parse_options(int & argx, int nargs, char ** args);
+  void parse_options(int & argx, int nargs, char ** args) override;
 
   
   /**
    * Dump object into file.
    */
    
-  virtual void dump_body(FILE * xf);
+  void dump_body(FILE * xf) override;
 
 
   /**
    * Dump object into file.
    */
    
-  virtual void dump_header(FILE * xf);
+  void dump_header(FILE * xf) override;
   
 
   /**
    * Make export.
    */
    
-  virtual void process_db(class thdatabase * dbp);
+  void process_db(class thdatabase * dbp) override;
 
   /**
    * Export entrances from survey.

--- a/thgrade.h
+++ b/thgrade.h
@@ -89,49 +89,49 @@ class thgrade : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thgrade";};
+  const char * get_class_name() override {return "thgrade";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -142,14 +142,14 @@ class thgrade : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
   /**
@@ -163,7 +163,7 @@ class thgrade : public thdataobject {
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
   
   /**
    * Update data SD.
@@ -175,7 +175,7 @@ class thgrade : public thdataobject {
    * Start insertion into database.
    */
    
-  void start_insert();
+  void start_insert() override;
   
 };
 

--- a/thimport.h
+++ b/thimport.h
@@ -134,49 +134,49 @@ class thimport : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thimport";};
+  const char * get_class_name() override {return "thimport";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -187,20 +187,20 @@ class thimport : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
   
   void set_file_name(char * fnm);

--- a/thjoin.h
+++ b/thjoin.h
@@ -99,49 +99,49 @@ class thjoin : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thjoin";};
+  const char * get_class_name() override {return "thjoin";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -152,21 +152,21 @@ class thjoin : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
   
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
 };

--- a/thlayout.h
+++ b/thlayout.h
@@ -593,49 +593,49 @@ class thlayout : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thlayout";};
+  const char * get_class_name() override {return "thlayout";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   thcmd_option_desc get_default_cod(int id);
   
   /**
@@ -646,14 +646,14 @@ class thlayout : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
   /**
@@ -667,7 +667,7 @@ class thlayout : public thdataobject {
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
   
   /**
    * Parse option with 3 or 2 or 1 numbers and units.
@@ -720,7 +720,7 @@ class thlayout : public thdataobject {
    * Convert all points in object.
    */
 
-  virtual void convert_all_cs();
+  void convert_all_cs() override;
    
 
 };

--- a/thline.h
+++ b/thline.h
@@ -374,49 +374,49 @@ class thline : public th2ddataobject {
    * Return class identifier.
    */
 
-  virtual int get_class_id();
+  int get_class_id() override;
 
 
   /**
    * Return class name.
    */
 
-  virtual const char * get_class_name() {return "thline";};
+  const char * get_class_name() override {return "thline";};
 
 
   /**
    * Return true, if son of given class.
    */
 
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
 
 
   /**
    * Return number of command arguments.
    */
 
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
 
 
   /**
    * Return command name.
    */
 
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
 
 
   /**
    * Return command end option.
    */
 
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
 
 
   /**
    * Return option description.
    */
 
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
 
 
   /**
@@ -427,14 +427,14 @@ class thline : public th2ddataobject {
    * @param argenc Arguments encoding.
    */
 
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
 
-  virtual void self_print_properties(FILE * outf);
+  void self_print_properties(FILE * outf) override;
 
 
   /**
@@ -448,7 +448,7 @@ class thline : public th2ddataobject {
    * Export to metapost file.
    */
 
-  virtual bool export_mp(class thexpmapmpxs * out);
+  bool export_mp(class thexpmapmpxs * out) override;
 
 
   /**
@@ -458,7 +458,7 @@ class thline : public th2ddataobject {
   virtual unsigned export_path_mp(class thexpmapmpxs * out,
       int from = 0, int to = -1, int dbglevel = -1);
 
-  virtual void start_insert();
+  void start_insert() override;
 
 };
 

--- a/thlookup.h
+++ b/thlookup.h
@@ -110,49 +110,49 @@ class thlookup : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thlookup";};
+  const char * get_class_name() override {return "thlookup";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   thcmd_option_desc get_default_cod(int id);
   
   /**
@@ -163,14 +163,14 @@ class thlookup : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
   /**
    * Set scrap color.

--- a/thmap.h
+++ b/thmap.h
@@ -112,49 +112,49 @@ class thmap : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thmap";};
+  const char * get_class_name() override {return "thmap";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -165,21 +165,21 @@ class thmap : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
   
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
 
 };

--- a/thpoint.h
+++ b/thpoint.h
@@ -493,7 +493,7 @@ class thpoint : public th2ddataobject {
 
   char extend_opts;  ///< Extend options.
 
-  virtual void start_insert();
+  void start_insert() override;
 
   void parse_type(char * tstr);  ///< Parse point type.
 
@@ -529,49 +529,49 @@ class thpoint : public th2ddataobject {
    * Return class identifier.
    */
 
-  virtual int get_class_id();
+  int get_class_id() override;
 
 
   /**
    * Return class name.
    */
 
-  virtual const char * get_class_name() {return "thpoint";};
+  const char * get_class_name() override {return "thpoint";};
 
 
   /**
    * Return true, if son of given class.
    */
 
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
 
 
   /**
    * Return number of command arguments.
    */
 
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
 
 
   /**
    * Return command name.
    */
 
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
 
 
   /**
    * Return command end option.
    */
 
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
 
 
   /**
    * Return option description.
    */
 
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
 
 
   /**
@@ -582,20 +582,20 @@ class thpoint : public th2ddataobject {
    * @param argenc Arguments encoding.
    */
 
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
 
-  virtual void self_print_properties(FILE * outf);
+  void self_print_properties(FILE * outf) override;
 
   /**
    * Export to metapost file.
    */
 
-  virtual bool export_mp(class thexpmapmpxs * out);
+  bool export_mp(class thexpmapmpxs * out) override;
 
 };
 

--- a/thscrap.h
+++ b/thscrap.h
@@ -161,49 +161,49 @@ class thscrap : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thscrap";};
+  const char * get_class_name() override {return "thscrap";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -214,7 +214,7 @@ class thscrap : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
@@ -235,7 +235,7 @@ class thscrap : public thdataobject {
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
   
   /**
@@ -300,13 +300,13 @@ class thscrap : public thdataobject {
  
  void update_limits(double x, double y);
 
- virtual void start_insert();
+ void start_insert() override;
 
  /**
   * Convert all points in object.
   */
 
- virtual void convert_all_cs();
+ void convert_all_cs() override;
 
 
 

--- a/thsurface.h
+++ b/thsurface.h
@@ -109,49 +109,49 @@ class thsurface : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thsurface";};
+  const char * get_class_name() override {return "thsurface";};
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -162,14 +162,14 @@ class thsurface : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Print object properties.
    */
    
-  virtual void self_print_properties(FILE * outf); 
+  void self_print_properties(FILE * outf) override; 
   
   
   /**
@@ -178,7 +178,7 @@ class thsurface : public thdataobject {
  
   void check_stations();
 
-  virtual void start_insert();
+  void start_insert() override;
   
   thdb3ddata * get_3d();
 
@@ -186,7 +186,7 @@ class thsurface : public thdataobject {
    * Convert all points in object.
    */
 
-  virtual void convert_all_cs();
+  void convert_all_cs() override;
 
 
 };

--- a/thsurvey.h
+++ b/thsurvey.h
@@ -158,42 +158,42 @@ class thsurvey : public thdataobject {
    * Return class identifier.
    */
   
-  virtual int get_class_id();
+  int get_class_id() override;
   
   
   /**
    * Return true, if son of given class.
    */
   
-  virtual bool is(int class_id);
+  bool is(int class_id) override;
   
   
   /**
    * Return number of command arguments.
    */
    
-  virtual int get_cmd_nargs();
+  int get_cmd_nargs() override;
   
   
   /**
    * Return command end option.
    */
    
-  virtual const char * get_cmd_end();
+  const char * get_cmd_end() override;
   
   
   /**
    * Return command name.
    */
    
-  virtual const char * get_cmd_name();
+  const char * get_cmd_name() override;
   
   
   /**
    * Return option description.
    */
    
-  virtual thcmd_option_desc get_cmd_option_desc(const char * opts);
+  thcmd_option_desc get_cmd_option_desc(const char * opts) override;
   
   
   /**
@@ -204,21 +204,21 @@ class thsurvey : public thdataobject {
    * @param argenc Arguments encoding.
    */
    
-  virtual void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline);
+  void set(thcmd_option_desc cod, char ** args, int argenc, unsigned long indataline) override;
 
 
   /**
    * Get context for object.
    */
    
-  virtual int get_context();
+  int get_context() override;
 
   
   /**
    * Return class name.
    */
    
-  virtual const char * get_class_name() {return "thsurvey";};
+  const char * get_class_name() override {return "thsurvey";};
 
 
   /**
@@ -239,7 +239,7 @@ class thsurvey : public thdataobject {
    * Print object contents into file.
    */
    
-  virtual void self_print_properties(FILE * outf);
+  void self_print_properties(FILE * outf) override;
   
   
   /**

--- a/thtfangle.h
+++ b/thtfangle.h
@@ -69,9 +69,9 @@ class thtfangle : public thtf {
    
   thtfangle();
    
-  virtual void parse_units(char * ustr);
+  void parse_units(char * ustr) override;
   
-  virtual double transform(double value);
+  double transform(double value) override;
   
 };
 

--- a/thtflength.h
+++ b/thtflength.h
@@ -79,7 +79,7 @@ class thtflength : public thtf {
    * Parse units factor.
    */
    
-  virtual void parse_units(char * ustr);
+  void parse_units(char * ustr) override;
   
 };
 

--- a/thwarp.h
+++ b/thwarp.h
@@ -71,7 +71,7 @@ class thwarplin : public thwarp {
 
   thwarplin() : morphed(false), method(0) {}
    
-  virtual thpic * morph(thsketch * sketch, double scale);
+  thpic * morph(thsketch * sketch, double scale) override;
 };
 
 

--- a/thwarpp.h
+++ b/thwarpp.h
@@ -94,7 +94,7 @@ public:
 
   virtual ~thwarpp();
 
-  virtual thpic * morph(thsketch * sketch, double scale);
+  thpic * morph(thsketch * sketch, double scale) override;
 };
 
 

--- a/thwarppme.h
+++ b/thwarppme.h
@@ -626,28 +626,28 @@ namespace therion
       /** override basic_pair::pfrom()
        * @return pointer to the "from" item
        */
-      const item * pfrom() const  
+      const item * pfrom() const override  
       { return dynamic_cast<const item *>(&from); }
-      item * pfrom() 
+      item * pfrom() override 
       { return dynamic_cast<item *>(&from); }
 
       /** override basic_pair::pto()
        * @return pointer to the "to" item
        */
-      const item * pto() const  
+      const item * pto() const override  
       { return dynamic_cast<const item *>(&to); }
-      item * pto() 
+      item * pto() override 
       { return dynamic_cast<item *>(&to); }
 
       /** override basic_pair::type()
        * @return the warp type of this basic_pair
        */
-      warp_type type() const;
+      warp_type type() const override;
 
       /** override basic_pair::ngbh_nr()
        * @return the number of neighbors of this basic_pair
        */
-      int ngbh_nr() const;
+      int ngbh_nr() const override;
 
       #ifdef DEBUG
       /** override basic_pair::print()
@@ -671,7 +671,7 @@ namespace therion
        * now it is an iterative process
        * for plaquette: an iterative process (same as now)
        */
-      void forward( const thvec2 & p, thvec2 & ret ) const;
+      void forward( const thvec2 & p, thvec2 & ret ) const override;
 
       /** compute the backward map of a point
        * @param p  2D point in the "to" image
@@ -685,7 +685,7 @@ namespace therion
        * for plaquette:
        *   backward_normal_bd() with MORPH_BD == 0.5
        */
-      void backward( const thvec2 & p, thvec2 & ret ) const
+      void backward( const thvec2 & p, thvec2 & ret ) const override
       {
 	backward_normal_bd( p, ret );
       }
@@ -698,28 +698,28 @@ namespace therion
        * @param p   2D point in the "from" image
        * @return true if the point is in this basic_pair
        */
-      bool is_inside_from( const thvec2 & p ) const 
+      bool is_inside_from( const thvec2 & p ) const override 
       { return from.is_inside( p, m_bound ); }
 
       /** check if a point is inside this basic_pair in the "to" image
        * @param p   2D point in the "to" image
        * @return true if the point is in this basic_pair
        */
-      bool is_inside_to( const thvec2 & p ) const
+      bool is_inside_to( const thvec2 & p ) const override
       { return to.is_inside( p, m_bound ); }
 
       /** get the distance of a point in the "from" domain
        * @param p 2d point
        * @return distance of the point in the "from" domain
        */
-      double distance_from( const thvec2 & p ) const
+      double distance_from( const thvec2 & p ) const override
       { return from.distance( p ); }
 
       /** get the distance of a point in the "to" domain
        * @param p 2d point
        * @return distance of the point in the "to" domain
        */
-      double distance_to( const thvec2 & p ) const
+      double distance_to( const thvec2 & p ) const override
       { return to.distance( p ); }
 
       /**
@@ -734,14 +734,14 @@ namespace therion
        * @param p input 2D point
        * @return squared distance
        */
-      double distance2_to( const thvec2 & p ) const
+      double distance2_to( const thvec2 & p ) const override
       { return to.distance2( p ); }
 
       /** compute the bounding box in the "to" image
        * @param t1  upper left corner (output)
        * @param t2  lower right corner (output)
        */
-      void bounding_box_to( thvec2 & t1, thvec2 & t2 ) const
+      void bounding_box_to( thvec2 & t1, thvec2 & t2 ) const override
       {
         to.bounding_box( t1, t2, m_bound );
       }
@@ -751,7 +751,7 @@ namespace therion
        * @param ret return vector
        * @param x   rotation angle
        */
-      void left_rotate_to( const thvec2 & p, thvec2 & ret, double x ) const
+      void left_rotate_to( const thvec2 & p, thvec2 & ret, double x ) const override
       {
 	  thvec2 pa;
 	  double t = m_kl * x;
@@ -764,7 +764,7 @@ namespace therion
        * @param ret return vector
        * @param x   rotation angle
        */
-      void right_rotate_to( const thvec2 & p, thvec2 & ret, double x ) const
+      void right_rotate_to( const thvec2 & p, thvec2 & ret, double x ) const override
       {
 	  thvec2 pa;
 	  double t = m_kr * x;
@@ -903,7 +903,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: not MORPH_USE_IS_INSIDE and MORPH_USE_TRI_F
          */
-        bool is_inside( const thvec2 & p, double bound ) const 
+        bool is_inside( const thvec2 & p, double bound ) const override 
         { 
           #ifdef MORPH_USE_IS_INSIDE
             thvec2 ap( p.m_x - m_A.m_x, p.m_y - m_A.m_y );
@@ -937,7 +937,7 @@ namespace therion
          * @param p 2D point
          * @return the distance
          */
-        double distance( const thvec2 & p ) const
+        double distance( const thvec2 & p ) const override
         {
           thvec2 p1 = p - m_A;
           return p1.length();
@@ -961,7 +961,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: MORPH_USE_TRI_F
 	 */
-        double distance2( const thvec2 & p ) const
+        double distance2( const thvec2 & p ) const override
         {
           thvec2 p1;
 	  to_polar( p, p1 );
@@ -975,7 +975,7 @@ namespace therion
 	 * @param t2 upper-right corner of the bounding box
 	 * @param bound  "vertical" size of the bounding box
 	 */
-        void bounding_box( thvec2 & t1, thvec2 & t2, double bound ) const
+        void bounding_box( thvec2 & t1, thvec2 & t2, double bound ) const override
 	{
           #if 1
             thvec2 b = m_B - bound * (m_A - m_B);
@@ -995,7 +995,7 @@ namespace therion
 	 * @param p   input 2D point
 	 * @return S value in st_map
 	 */
-	double s_map( const thvec2 & p ) const
+	double s_map( const thvec2 & p ) const override
         {
           double xp = p.m_x - m_A.m_x;
           double yp = p.m_y - m_A.m_y;
@@ -1008,36 +1008,36 @@ namespace therion
 	 * @param p input 2D point
 	 * @param ret return s-t coordinates (polar coordinates)
 	 */
-        void st_map( const thvec2 & p, thvec2 & ret ) const
+        void st_map( const thvec2 & p, thvec2 & ret ) const override
 	{ to_polar(p, ret); }
 
         /** inverse s-t map for the triangle
 	 * @param p input s-t (= polar) coordinates
 	 * @param ret return 2D point
 	 */
-        void inv_st_map( const thvec2 & p, thvec2 & ret ) const
+        void inv_st_map( const thvec2 & p, thvec2 & ret ) const override
 	{ from_polar(p, ret); }
 
         /** (0.5.2)
 	 */
-        double sm_map( const thvec2 & p, thvec2 & ret ) const;
+        double sm_map( const thvec2 & p, thvec2 & ret ) const override;
 
         /** (0.5.2)
 	 */
-        void inv_sm_map( const thvec2 & p, thvec2 & ret, double d4 ) const;
+        void inv_sm_map( const thvec2 & p, thvec2 & ret, double d4 ) const override;
 
         /** Beier-Neely map for the triangle
 	 * @param p input 2D point
 	 * @param ret return B-N coordinates (polar coordinates)
 	 */
-        void bn_map( const thvec2 & p, thvec2 & ret ) const
+        void bn_map( const thvec2 & p, thvec2 & ret ) const override
 	{ to_polar(p, ret); }
 
         /** inverse Beier-Neely map for the triangle
 	 * @param p input B-N (= polar) coordinates
 	 * @param ret return 2D point
 	 */
-        void inv_bn_map( const thvec2 & p, thvec2 & ret ) const
+        void inv_bn_map( const thvec2 & p, thvec2 & ret ) const override
 	{ from_polar(p, ret); }
 
         /** rotate a point about the "left" corner 
@@ -1048,7 +1048,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: ret was return instead of param
 	 */
-	void left_rotate( const thvec2 & p, thvec2 & ret, double /* c */, double /* s */) const
+	void left_rotate( const thvec2 & p, thvec2 & ret, double /* c */, double /* s */) const override
 	{
 	  ret = p;
 	}
@@ -1061,7 +1061,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: ret was return instead of param
 	 */
-	void right_rotate( const thvec2 & p, thvec2 & ret, double /* c */, double /* s */) const
+	void right_rotate( const thvec2 & p, thvec2 & ret, double /* c */, double /* s */) const override
 	{
 	  ret = p;
 	}
@@ -1152,7 +1152,7 @@ namespace therion
          * @pre the point should lie inside the plaquette
 	 * @note in VERSION 0.5.1: s_map == s_map_straight
 	 */
-	double s_map( const thvec2 & p ) const
+	double s_map( const thvec2 & p ) const override
 	{
 	  return (this ->* s_map_impl)(p);
 	}
@@ -1179,7 +1179,7 @@ namespace therion
          * @pre the point should lie inside the plaquette
 	 * @note in VERSION 0.5.1: unchanged
          */
-        void st_map( const thvec2 & p, thvec2 & ret ) const;
+        void st_map( const thvec2 & p, thvec2 & ret ) const override;
 
         /** inverse map plaquette (s,t) coordinates to point
          * @param p plaquette (s,t) coordinates of the point
@@ -1187,13 +1187,13 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: unchanged
          */
-        void inv_st_map( const thvec2 & p, thvec2 & ret ) const;
+        void inv_st_map( const thvec2 & p, thvec2 & ret ) const override;
 
         /** sm-maps (0.5.2)
          * @return fourth power of the distance
          */
-        double sm_map( const thvec2 & p, thvec2 & ret ) const;
-        void inv_sm_map( const thvec2 & p, thvec2 & ret, double d4 ) const;
+        double sm_map( const thvec2 & p, thvec2 & ret ) const override;
+        void inv_sm_map( const thvec2 & p, thvec2 & ret, double d4 ) const override;
 
         /** h-v map
          * @param  p 2D point
@@ -1222,7 +1222,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: bn_map == bn_map_straight
 	 */
-        void bn_map( const thvec2 & p, thvec2 & ret ) const
+        void bn_map( const thvec2 & p, thvec2 & ret ) const override
 	{
 	  (this->*bn_map_impl)( p, ret );
 	}
@@ -1233,7 +1233,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: inv_bn_map == inv_bn_map_straight
 	 */
-        void inv_bn_map( const thvec2 & p, thvec2 & ret ) const
+        void inv_bn_map( const thvec2 & p, thvec2 & ret ) const override
 	{
 	  (this->*inv_bn_map_impl)( p, ret );
 	}
@@ -1252,7 +1252,7 @@ namespace therion
 	 * @param c cosine of the rotation angle
 	 * @param s sine of the rotation angle
 	 */
-	void left_rotate( const thvec2 & p, thvec2 & ret, double c, double s ) const
+	void left_rotate( const thvec2 & p, thvec2 & ret, double c, double s ) const override
 	{
 	  double x = p.m_x - m_A.m_x;
 	  double y = p.m_y - m_A.m_y;
@@ -1266,7 +1266,7 @@ namespace therion
 	 * @param c cosine of the rotation angle
 	 * @param s sine of the rotation angle
 	 */
-	void right_rotate( const thvec2 & p, thvec2 & ret, double c, double s ) const
+	void right_rotate( const thvec2 & p, thvec2 & ret, double c, double s ) const override
 	{
 	  double x = p.m_x - m_B.m_x;
 	  double y = p.m_y - m_B.m_y;
@@ -1281,7 +1281,7 @@ namespace therion
 	 *
 	 * @note in VERSION 0.5.1: st_map (ie not MORPH_USE_IS_INSIDE)
          */
-        bool is_inside( const thvec2 & p, double bound ) const 
+        bool is_inside( const thvec2 & p, double bound ) const override 
         {
           // thvec2 v;
 	  // st_map( p, v );
@@ -1346,7 +1346,7 @@ namespace therion
 	 * @pre p is inside the plaquette
 	 * this could be any reasonable distance function
          */
-        double distance( const thvec2 & p ) const
+        double distance( const thvec2 & p ) const override
         {
           return t_map( p );
         }
@@ -1372,7 +1372,7 @@ namespace therion
 	}
 	 */
     
-        double distance2( const thvec2 & p ) const
+        double distance2( const thvec2 & p ) const override
         {
           thvec2 v;
 	  st_map( p, v );
@@ -1386,7 +1386,7 @@ namespace therion
 	 * @param t2 upper-right corner of the bounding box
 	 * @param bound  "vertical" size of the bounding box
 	 */
-        void bounding_box( thvec2 & t1, thvec2 & t2, double bound ) const
+        void bounding_box( thvec2 & t1, thvec2 & t2, double bound ) const override
 	{
           thvec2 c = m_B + bound * m_BC;
           thvec2 d = m_A + bound * m_AD;

--- a/thwarppt.h
+++ b/thwarppt.h
@@ -138,7 +138,7 @@ namespace therion
          * @param u3    new point U (survey frame)
          */
         line * add_extra_line( point_pair * p1, size_t index, 
-                                       thvec2 & x3, thvec2 & u3 );
+                                       thvec2 & x3, thvec2 & u3 ) override;
     
     
         /** insert a point


### PR DESCRIPTION
Use keyword `override` to prevent mismatch of virtual methods. This will now be enforced by CI. Code was automatically transformed by `clang-tidy --fix`.