### PR TITLE
Fixed reserved identifiers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone-reserved-identifier'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt -qq update
-          sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build
+          sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build clang-tidy
       - name: Configure CMake
         run: |
           mkdir build && cd build && \

--- a/loch/lxFile.cxx
+++ b/loch/lxFile.cxx
@@ -611,7 +611,7 @@ lxFileSizeT lxFileSplitTokens(std::string& str, char ** tokens, lxFileSizeT max_
   return nt;
 }
 
-bool lxFile__CheckLRUD(double & du, double & dd, double & dl, double & dr, double mv, double mh) {
+bool lxFileCheckLRUD(double & du, double & dd, double & dl, double & dr, double mv, double mh) {
   if ((du <= 0.0) && (dd <= 0.0) && (dl <= 0.0) && (dr <= 0.0)) {
     return false;
   } else {
@@ -757,7 +757,7 @@ void lxFile::ImportPLT(const char * fn)
         tok2num(lrud[1],9);PltLrudNaN(lrud[1]);
         tok2num(lrud[2],7);PltLrudNaN(lrud[2]);
         tok2num(lrud[3],8);PltLrudNaN(lrud[3]);
-        lrudOK = lxFile__CheckLRUD(lrud[0], lrud[1], lrud[2], lrud[3], 2.0, 5.0);
+        lrudOK = lxFileCheckLRUD(lrud[0], lrud[1], lrud[2], lrud[3], 2.0, 5.0);
         if (lrudOK) {
           lrud[0] *= 0.3048;
           lrud[1] *= 0.3048;
@@ -959,7 +959,7 @@ void lxFile::Import3D(const char * fn)
           lrud[1] = pimg->r;
           lrud[2] = pimg->u;
           lrud[3] = pimg->d;
-          lrudOK = lxFile__CheckLRUD(lrud[0], lrud[1], lrud[2], lrud[3], 2.0, 5.0);
+          lrudOK = lxFileCheckLRUD(lrud[0], lrud[1], lrud[2], lrud[3], 2.0, 5.0);
           if (lrudOK) {
             stPtr->SetFlag(LXFILE_STATION_FLAG_HAS_WALLS, true);
           }

--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -1992,7 +1992,7 @@ void lxGLCanvas::OSCDestroy()
 }
 
 
-struct _TRctx * lxGLCanvas::TRCGetContext()
+struct TRctx * lxGLCanvas::TRCGetContext()
 {
   if (this->m_TRC != NULL)
     return this->m_TRC->m_ctx;

--- a/loch/lxGLC.h
+++ b/loch/lxGLC.h
@@ -142,7 +142,7 @@ class lxGLCanvas: public wxGLCanvas {
     bool OSCInit(GLint w, GLint h);
 
     void TRCInit(int type, GLint w, GLint h, GLint tw = 0, GLint th = 0);
-    struct _TRctx * TRCGetContext();
+    struct TRctx * TRCGetContext();
     void TRCDestroy();
     GLint TRCGet(int param);
     GLubyte * TRCGetBuffer();
@@ -180,7 +180,7 @@ class lxGLCanvas: public wxGLCanvas {
 
 
 struct TRC {
-  struct _TRctx * m_ctx;
+  struct TRctx * m_ctx;
   GLubyte * m_buff;
   TRC() {
     this->m_ctx = NULL;

--- a/loch/lxR2P.c
+++ b/loch/lxR2P.c
@@ -15,7 +15,7 @@
 
 #include "lxR2P.h"
 
-struct _R2PCTX {
+struct R2PCTX {
   GLXContext ctx;
   Pixmap pm;
   XVisualInfo *visinfo;

--- a/loch/lxR2P.h
+++ b/loch/lxR2P.h
@@ -2,7 +2,7 @@
 extern "C" {
 #endif
 
-typedef struct _R2PCTX R2PContext;
+typedef struct R2PCTX R2PContext;
 
 extern R2PContext *R2PCreate(int width, int height);
 

--- a/loch/lxTR.c
+++ b/loch/lxTR.c
@@ -51,7 +51,7 @@
 #endif
 #define assert(x)
 
-struct _TRctx {
+struct TRctx {
    /* Final image parameters */
    GLint ImageWidth, ImageHeight;
    GLenum ImageFormat, ImageType;

--- a/loch/lxTR.h
+++ b/loch/lxTR.h
@@ -101,7 +101,7 @@ extern "C" {
 #define TR_MINOR_VERSION 1
 
 
-typedef struct _TRctx TRcontext;
+typedef struct TRctx TRcontext;
 
 
 typedef enum {

--- a/mpost/genmpost.pl
+++ b/mpost/genmpost.pl
@@ -61,7 +61,7 @@ sub process_symbols {
   print OUT "extern int thsymsets_order[thsymbolset_size];\n\n";
   print OUT "extern int thsymsets_count[thsymsets_size];\n\n";
   print OUT "extern std::map<unsigned, std::string> thsymsets_comment;\n\n";
-  print OUT "\nstatic const thsymbolset__char_ptr thsymsets [] = {\n$ssl};\n\nvoid thsymsets_symbols_init();\n\n";
+  print OUT "\nstatic const thsymbolset_char_ptr thsymsets [] = {\n$ssl};\n\nvoid thsymsets_symbols_init();\n\n";
   print OUT "#endif\n\n";
   close(OUT);
 

--- a/th2ddataobject.cxx
+++ b/th2ddataobject.cxx
@@ -128,7 +128,7 @@ void th2ddataobject::set(thcmd_option_desc cod, char ** args, int argenc, unsign
       break;    
       
     case TT_2DOBJ_CONTEXT:
-      this->context = thsymbolset__get_id(args[0], args[1]);
+      this->context = thsymbolset_get_id(args[0], args[1]);
       if (this->context < 0)
         ththrow(("invalid object context -- %s %s", args[0], args[1]))
       if ((this->context > SYMP_ZZZ) 

--- a/thbezier.cxx
+++ b/thbezier.cxx
@@ -51,8 +51,6 @@
 #include <cstdio>
 #include <cmath>
 
-#define __SP_BEZIER_UTILS_C__
-
 #define SP_HUGE 1e5
 #define noBEZIER_DEBUG
 

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -389,7 +389,7 @@ char * thconfig::get_initialization_path()
 }
 
 
-void thconfig__pifo(char * s) {
+void thconfig_pifo(char * s) {
 #ifdef THDEBUG
   thprintf("\nconfiguration file: %s\nreading\n",s);
 #else
@@ -422,7 +422,7 @@ void thconfig::load()
     this->cfg_file.cmd_sensitivity_on();
     this->cfg_file.sp_scan_off();
     this->cfg_file.set_file_name(this->fname);
-    this->cfg_file.print_if_opened(thconfig__pifo, &fstarted);
+    this->cfg_file.print_if_opened(thconfig_pifo, &fstarted);
     this->cfg_file.reset();
     try {
       char * cfgln = this->cfg_file.read_line();
@@ -697,7 +697,7 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
     for (ai = 0; ai < objptr->get_cmd_nargs(); ai++, opts++) {
       optd.id = ai + 1;
       objptr->set(optd, opts, this->cfg_file.get_cif_encoding(),
-        thdatareader__get_opos(false,false));
+        thdatareader_get_opos(false,false));
     }
 
     // set options
@@ -716,7 +716,7 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
       }
  
       objptr->set(optd, opts, this->cfg_file.get_cif_encoding(),
-        thdatareader__get_opos(false,false));
+        thdatareader_get_opos(false,false));
       opts += optd.nargs;
       ait += optd.nargs;
     }       
@@ -757,7 +757,7 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
           optd.nargs = this->mbf1.get_size();
           objptr->set(optd, this->mbf1.get_buffer(), 
             this->cfg_file.get_cif_encoding(),
-            thdatareader__get_opos(inside_cmd,false));
+            thdatareader_get_opos(inside_cmd,false));
           continue;
         }
         
@@ -768,7 +768,7 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
         while(strcmp(opt,"!") < 0) opt++;
         if (*opt == '!') opt++;
         objptr->set(optd, & opt, this->cfg_file.get_cif_encoding(),
-          thdatareader__get_opos(inside_cmd,false));
+          thdatareader_get_opos(inside_cmd,false));
       }  
     }
     

--- a/thdata.cxx
+++ b/thdata.cxx
@@ -189,7 +189,7 @@ bool thdata::get_cmd_ends_state() {
 }
 
 
-static const thstok thdata__end_cmds[] = {
+static const thstok thdata_end_cmds[] = {
   {"endcenterline", TT_DATA_CMD},
   {"endcentreline", TT_DATA_CMD},
 	{NULL, TT_UNKNOWN_CMD},
@@ -197,7 +197,7 @@ static const thstok thdata__end_cmds[] = {
 
 
 bool thdata::get_cmd_ends_match(char * cmd) {
-  return (thmatch_token(cmd,thdata__end_cmds) == TT_DATA_CMD);
+  return (thmatch_token(cmd,thdata_end_cmds) == TT_DATA_CMD);
 }
 
 

--- a/thdatareader.cxx
+++ b/thdatareader.cxx
@@ -29,7 +29,7 @@
 #include "thexception.h"
 #include "thobjectsrc.h"
 
-unsigned long thdatareader__get_opos(bool inlineid, bool cfgid)
+unsigned long thdatareader_get_opos(bool inlineid, bool cfgid)
 {
   unsigned long opos = 0;
   
@@ -125,7 +125,7 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
           optd.nargs = this->mbf1.get_size();
           objptr->set(optd, this->mbf1.get_buffer(), 
             this->inp.get_cif_encoding(),
-            thdatareader__get_opos(inside_cmd,configure_cmd));
+            thdatareader_get_opos(inside_cmd,configure_cmd));
           continue;
         }
         
@@ -136,7 +136,7 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
         while(strcmp(opt,"!") < 0) opt++;
         if (*opt == '!') opt++;
         objptr->set(optd, & opt, this->inp.get_cif_encoding(),
-          thdatareader__get_opos(inside_cmd,configure_cmd));
+          thdatareader_get_opos(inside_cmd,configure_cmd));
 
       }
       else {
@@ -190,7 +190,7 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
           for (ai = 0; ai < objptr->get_cmd_nargs(); ai++, opts++) {
             optd.id = ai + 1;
             objptr->set(optd, opts, this->inp.get_cif_encoding(),
-              thdatareader__get_opos(inside_cmd,configure_cmd));
+              thdatareader_get_opos(inside_cmd,configure_cmd));
 
           }
         }
@@ -212,7 +212,7 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
           }
  
           objptr->set(optd, opts, this->inp.get_cif_encoding(),
-            thdatareader__get_opos(inside_cmd,configure_cmd));
+            thdatareader_get_opos(inside_cmd,configure_cmd));
           opts += optd.nargs;
           ait += optd.nargs;
         }

--- a/thdatareader.h
+++ b/thdatareader.h
@@ -83,7 +83,7 @@ extern thdatareader thdbreader;
  * Return option position.
  */
    
-unsigned long thdatareader__get_opos(bool inlineid, bool cfgid);
+unsigned long thdatareader_get_opos(bool inlineid, bool cfgid);
 
 
 #endif

--- a/thdate.cxx
+++ b/thdate.cxx
@@ -613,7 +613,7 @@ void date2tm(int y, int m, int d, int hh, int mm, double ss, tm * info)
 }
 
 void thdate::print_str(int fmt) {
-  unsigned int tl = thdate__bufflen - 1;
+  unsigned int tl = thdate_bufflen - 1;
   long yyyy, mm, dd;
   char * dst = &(this->dstr[0]);
   const char * sep = " - ";

--- a/thdate.h
+++ b/thdate.h
@@ -31,7 +31,7 @@
 #ifndef thdate_h
 #define thdate_h
 
-#define thdate__bufflen 255
+#define thdate_bufflen 255
 
 /**
  * Convert date into decimal year.
@@ -83,7 +83,7 @@ class thdate {
   double ssec, ///< Start date seconds
     esec;  ///< End date seconds
     
-  char dstr[thdate__bufflen]; ///< String for given date.
+  char dstr[thdate_bufflen]; ///< String for given date.
 
   friend bool operator < (const thdate &, const thdate &);  ///< Less operator.
   friend bool operator <= (const thdate &, const thdate &);  ///< Less operator.

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -1096,7 +1096,7 @@ void thdb1d::process_tree()
 
 
 
-void thdb1d__scan_survey_station_limits(thsurvey * ss, thdb1ds * st, bool is_under) {
+void thdb1d_scan_survey_station_limits(thsurvey * ss, thdb1ds * st, bool is_under) {
   if (st->is_temporary()) return;
   if (ss->stat.station_state == 0) {
     if (is_under)
@@ -1135,7 +1135,7 @@ void thdb1d__scan_survey_station_limits(thsurvey * ss, thdb1ds * st, bool is_und
 }
 
 
-void thdb1d__scan_data_station_limits(thdata * ss, thdb1ds * st, bool is_under) {
+void thdb1d_scan_data_station_limits(thdata * ss, thdb1ds * st, bool is_under) {
   if (ss->stat_st_state == 0) {
     if (is_under)
       ss->stat_st_state = 2;
@@ -1211,11 +1211,11 @@ void thdb1d::process_survey_stat() {
     // stations
     if ((lit->leg->flags & TT_LEGFLAG_SPLAY) == 0) {
       if ((lit->leg->flags & TT_LEGFLAG_SURFACE) != 0) {
-        thdb1d__scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->from.id - 1]), false);
-        thdb1d__scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->to.id - 1]), false);
+        thdb1d_scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->from.id - 1]), false);
+        thdb1d_scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->to.id - 1]), false);
       } else {
-        thdb1d__scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->from.id - 1]), true);
-        thdb1d__scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->to.id - 1]), true);
+        thdb1d_scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->from.id - 1]), true);
+        thdb1d_scan_data_station_limits(lit->data, &(this->station_vec[lit->leg->to.id - 1]), true);
       }
     }
 
@@ -1238,11 +1238,11 @@ void thdb1d::process_survey_stat() {
       }
       if ((lit->leg->flags & TT_LEGFLAG_SPLAY) == 0) {
         if ((lit->leg->flags & TT_LEGFLAG_SURFACE) != 0) {
-          thdb1d__scan_survey_station_limits(ss, &(this->station_vec[lit->leg->from.id - 1]), false);
-          thdb1d__scan_survey_station_limits(ss, &(this->station_vec[lit->leg->to.id - 1]), false);
+          thdb1d_scan_survey_station_limits(ss, &(this->station_vec[lit->leg->from.id - 1]), false);
+          thdb1d_scan_survey_station_limits(ss, &(this->station_vec[lit->leg->to.id - 1]), false);
         } else {
-          thdb1d__scan_survey_station_limits(ss, &(this->station_vec[lit->leg->from.id - 1]), true);
-          thdb1d__scan_survey_station_limits(ss, &(this->station_vec[lit->leg->to.id - 1]), true);
+          thdb1d_scan_survey_station_limits(ss, &(this->station_vec[lit->leg->from.id - 1]), true);
+          thdb1d_scan_survey_station_limits(ss, &(this->station_vec[lit->leg->to.id - 1]), true);
         }
       }
       ss->stat.num_shots++;

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -38,7 +38,7 @@
 #include "thlogfile.h"
 #include "thproj.h"
 
-extern const thstok thtt__texts [];
+extern const thstok thtt_texts [];
 
 const char * thhelp_text =
       "\ntherion [-q] [-L] [-l log-file]\n"

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -2801,7 +2801,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
           tmps = &(thdb.db1d.station_vec[slp->station_name.id - 1]);
           out->symset->export_mp_symbol_options(&dbg_stnms, SYMP_STATIONNAME);
           dbg_stnms.appspf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, p_label_mode_debugstation);\n",
-            (const char *) utf2tex(thobjectname__print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
+            (const char *) utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
             thxmmxst(out, slp->stx, slp->sty));
         }
       }
@@ -2880,7 +2880,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
                 if (out->layout->is_debug_stationnames() && (tmps != NULL)) {
                       out->symset->export_mp_symbol_options(&dbg_stnms, SYMP_STATIONNAME);
                       dbg_stnms.appspf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, p_label_mode_debugstation);\n",
-                      (const char *) utf2tex(thobjectname__print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
+                      (const char *) utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
                       thxmmxst(out, ptp->point->xt, ptp->point->yt));
                 }
               }
@@ -3003,7 +3003,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
     thdb2dpt tmppt;
     tmppt.xt = (scrap->lxmin + scrap->lxmax) / 2.0;
     tmppt.yt = (scrap->lymin + scrap->lymax) / 2.0;
-    thdb.buff_tmp = utf2tex(thobjectname__print_full_name(scrap->name, scrap->fsptr, layout->survey_level));
+    thdb.buff_tmp = utf2tex(thobjectname_print_full_name(scrap->name, scrap->fsptr, layout->survey_level));
     fprintf(out->file,"p_label(btex \\thlargesize %s etex,",thdb.buff_tmp.get_buffer());
     tmppt.export_mp(out);
     fprintf(out->file,",0.0,p_label_mode_debugscrap);\n");

--- a/thexpshp.cxx
+++ b/thexpshp.cxx
@@ -533,12 +533,12 @@ void thexpshp::xscrap2d(thscrap * scrap, thdb2dxm * xmap, thdb2dxs * xbasic)
 			tststr += ":";
 			tststr += ststr;
 		}
-		symid = thsymbolset__get_id("point", tststr.c_str());
+		symid = thsymbolset_get_id("point", tststr.c_str());
 		if (symid < 0)
-			symid = thsymbolset__get_id("point", tstr.c_str());
+			symid = thsymbolset_get_id("point", tstr.c_str());
 		if (symid < 0)
 			symid = 0;
-		typefc[0] = thsymbolset__fontchar[symid];
+		typefc[0] = thsymbolset_fontchar[symid];
 		this->m_fpoints.m_attributes.insert_attribute("_TYPEFC",(const char *)typefc);
 		this->m_fpoints.m_attributes.insert_attribute("_TYPEFCR", thisnan(ppt->orient) ? 0.0 : 360.0 - ppt->orient);
         this->m_fpoints.m_attributes.insert_attribute("_SUBTYPE", ppt->type != TT_POINT_TYPE_U ?

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -159,7 +159,7 @@ static const thstok thtt_initcmd[] = {
   {NULL, TTIC_UNKNOWN},
 };
 
-void thinit__print_open(char * s) {
+void thinit_print_open(char * s) {
 #ifdef THDEBUG
     thprintf("\ninitialization file: %s\nreading\n", s);
 #else
@@ -423,7 +423,7 @@ void thinit::load()
   this->ini_file.set_file_name("therion.ini");
   this->ini_file.sp_scan_on();
   this->ini_file.cmd_sensitivity_off();
-  this->ini_file.print_if_opened(thinit__print_open, &started);
+  this->ini_file.print_if_opened(thinit_print_open, &started);
   this->ini_file.reset();
   try {
     while((cmdln = this->ini_file.read_line()) != NULL) {

--- a/thlang.cxx
+++ b/thlang.cxx
@@ -86,12 +86,12 @@ const char * thlang_getcxxid(int id) {
   if (id < 0)
     return "THLANG_UNKNOWN";
   else
-    return thlang__cxxids[id];
+    return thlang_cxxids[id];
 }
 
 const thstok * thlang_get_text_table()
 {
-  return &(thtt__texts[0]);
+  return &(thtt_texts[0]);
 }
 
 void thlang_set_translation(char * lang, char * text, char * translation) {
@@ -101,7 +101,7 @@ void thlang_set_translation(char * lang, char * text, char * translation) {
   if (lang_id == THLANG_UNKNOWN)
     ththrow(("unknown language -- %s", lang));
   int text_id;
-  text_id = thmatch_token(text, thtt__texts);
+  text_id = thmatch_token(text, thtt_texts);
   if (text_id == -1) {
     if (
       (strncmp(text,"point u:",8) == 0) ||
@@ -111,29 +111,29 @@ void thlang_set_translation(char * lang, char * text, char * translation) {
     } else
       ththrow(("unknown text -- %s", text))
   } else { 
-    thlang__translations[text_id][lang_id] = thdb.strstore(translation);
+    thlang_translations[text_id][lang_id] = thdb.strstore(translation);
   }
 }
 
 const char * thT(const char * txt, int lng) {
   if (lng == THLANG_SYSTEM)
     return txt;
-  int sv = thmatch_token(txt,thtt__texts);
+  int sv = thmatch_token(txt,thtt_texts);
   const char * trans;
   lng = thlang_getlang(lng);
   // najde ci ho mame v danom jazyku
   if (sv == -1) {
     thlang_str_map::iterator it = ulang_map.find(thlang_str(lng, txt));
-    if ((it == ulang_map.end()) && (thlang__alternatives[lng] != THLANG_UNKNOWN))
-      it = ulang_map.find(thlang_str(thlang__alternatives[lng], txt));
+    if ((it == ulang_map.end()) && (thlang_alternatives[lng] != THLANG_UNKNOWN))
+      it = ulang_map.find(thlang_str(thlang_alternatives[lng], txt));
     if (it == ulang_map.end())
       return txt;
     else
       return it->second;
   }
-  trans = thlang__translations[sv][lng];
-  if ((trans == NULL) && (thlang__alternatives[lng] != THLANG_UNKNOWN)) {
-    trans = thlang__translations[sv][thlang__alternatives[lng]];
+  trans = thlang_translations[sv][lng];
+  if ((trans == NULL) && (thlang_alternatives[lng] != THLANG_UNKNOWN)) {
+    trans = thlang_translations[sv][thlang_alternatives[lng]];
   }
   if (trans != NULL)
     return trans;

--- a/thlang/process.pl
+++ b/thlang/process.pl
@@ -135,7 +135,7 @@ sub write_sources {
   my $i;
   my $lcode;
   $languages = "enum {\n  THLANG_SYSTEM = -2,\n  THLANG_UNKNOWN = -1,\n";
-  $langcxxid = "static const thlang_pchar thlang__cxxids []  = {\n";
+  $langcxxid = "static const thlang_pchar thlang_cxxids []  = {\n";
   $langparse = "static const thstok thtt_lang [] = {\n";
   for ($i = 0; $i <= $#langs; $i++) {
     $lcode = "THLANG_" . uc($langs[$i]);
@@ -148,7 +148,7 @@ sub write_sources {
   $langcxxid .= "};\n";
   $langparse .= "  {NULL, THLANG_UNKNOWN},\n};\n";
 
-  my $alternatives = "static const int thlang__alternatives [] = {\n";
+  my $alternatives = "static const int thlang_alternatives [] = {\n";
   for ($i = 0; $i <= $#langs; $i++) {
     $lkey = $langs[$i];
     if ((length($lkey) > 2) && (defined($lngs{substr($lkey,0,2)}))) {
@@ -161,8 +161,8 @@ sub write_sources {
 
   @texts = sort keys %hr;
 
-  $textparse = "static const thstok thtt__texts [" . ($#texts + 2) . "] = {\n";
-  $texttable = "static thlang_pchar thlang__translations [" . ($#texts + 1) . "][" . ($#langs + 1) . "] = {\n";
+  $textparse = "static const thstok thtt_texts [" . ($#texts + 2) . "] = {\n";
+  $texttable = "static thlang_pchar thlang_translations [" . ($#texts + 1) . "][" . ($#langs + 1) . "] = {\n";
   $i = 0;
   my $nlkey;
   foreach $key (@texts) {

--- a/thlayout.cxx
+++ b/thlayout.cxx
@@ -392,7 +392,7 @@ enum {
   TTL_MAPITEM_UNKNOWN,
 };
 
-static const thstok thlayout__mapitems[] = {
+static const thstok thlayout_mapitems[] = {
   {"carto", TTL_MAPITEM_CARTO},
   {"carto-count", TTL_MAPITEM_CARTO_LENS},
   {"copyright", TTL_MAPITEM_COPYRIGHT},
@@ -460,10 +460,10 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
           this->last_line->code = TT_LAYOUT_CODE_SYMBOL_DEFAULTS;
           break;
         case TT_LAYOUT_SYMBOL_ASSIGN:
-          this->last_line->smid = thsymbolset__get_id(args[0],args[1]);
+          this->last_line->smid = thsymbolset_get_id(args[0],args[1]);
           if (this->last_line->smid == -1)
             ththrow(("unknown symbol specification -- %s %s", args[0], args[1]))
-          if (!thsymbolset__assign[this->last_line->smid])
+          if (!thsymbolset_assign[this->last_line->smid])
             ththrow(("symbol can not be assigned -- %s %s", args[0], args[1]))
           if (!th_is_keyword(args[2]))
             ththrow(("invalid keyword -- %s", args[2]))
@@ -482,19 +482,19 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 //          this->last_line->code = TT_LAYOUT_CODE_MAP_ITEM;
 //          break;
         case TT_LAYOUT_SYMBOL_HIDE:
-          this->last_line->smid = thsymbolset__get_id(args[0],args[1]);
+          this->last_line->smid = thsymbolset_get_id(args[0],args[1]);
           if (this->last_line->smid == -1)
             ththrow(("unknown symbol specification -- %s %s", args[0], args[1]))
           this->last_line->code = TT_LAYOUT_CODE_SYMBOL_HIDE;
           break;
         case TT_LAYOUT_SYMBOL_SHOW:
-          this->last_line->smid = thsymbolset__get_id(args[0],args[1]);
+          this->last_line->smid = thsymbolset_get_id(args[0],args[1]);
           if (this->last_line->smid == -1)
             ththrow(("unknown symbol specification -- %s %s", args[0], args[1]))
           this->last_line->code = TT_LAYOUT_CODE_SYMBOL_SHOW;
           break;
         case TT_LAYOUT_SYMBOL_COLOR:
-          this->last_line->smid = thsymbolset__get_id(args[0],args[1]);
+          this->last_line->smid = thsymbolset_get_id(args[0],args[1]);
           if (this->last_line->smid == -1)
             ththrow(("unknown symbol specification -- %s %s", args[0], args[1]))
           this->last_line->sclr.parse(args[2]);
@@ -525,7 +525,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
       break;
 
     case TT_LAYOUT_MAP_ITEM:
-      sv2 = thmatch_token(args[0],thlayout__mapitems);
+      sv2 = thmatch_token(args[0],thlayout_mapitems);
       switch (sv2) {
         case TTL_MAPITEM_EXPLO_LENS:
           sv = thmatch_token(args[1],thtt_layout_lenstat);
@@ -1388,23 +1388,23 @@ void thlayout::self_print_library() {
           switch (ln->code) {
             case TT_LAYOUT_CODE_SYMBOL_HIDE:
               thprintf("\tplayout->last_line->code = TT_LAYOUT_CODE_SYMBOL_HIDE;\n");
-              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset__src[ln->smid]);
+              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset_src[ln->smid]);
               break;
             case TT_LAYOUT_CODE_SYMBOL_SHOW:
               thprintf("\tplayout->last_line->code = TT_LAYOUT_CODE_SYMBOL_SHOW;\n");
-              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset__src[ln->smid]);
+              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset_src[ln->smid]);
               break;
             case TT_LAYOUT_CODE_MAP_ITEM:
               thprintf("\tplayout->last_line->code = TT_LAYOUT_CODE_MAP_ITEM;\n");
-              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset__src[ln->smid]);
+              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset_src[ln->smid]);
               break;
             case TT_LAYOUT_CODE_SYMBOL_ASSIGN:
               thprintf("\tplayout->last_line->code = TT_LAYOUT_CODE_SYMBOL_ASSIGN;\n");
-              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset__src[ln->smid]);
+              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset_src[ln->smid]);
               break;
             case TT_LAYOUT_CODE_SYMBOL_COLOR:
               thprintf("\tplayout->last_line->code = TT_LAYOUT_CODE_SYMBOL_COLOR;\n");
-              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset__src[ln->smid]);
+              thprintf("\tplayout->last_line->smid = %s;\n", thsymbolset_src[ln->smid]);
               thprintf("\tplayout->last_line->sclr = thlayout_color(%.6f,%.6f,%.6f);\n", ln->sclr.R, ln->sclr.G, ln->sclr.B);
               break;
           }

--- a/thobjectname.cxx
+++ b/thobjectname.cxx
@@ -116,7 +116,7 @@ char * thobjectname::print_name()
 }
   
 
-char * thobjectname__print_full_name(const char * oname, thsurvey * psrv, int slevel)
+char * thobjectname_print_full_name(const char * oname, thsurvey * psrv, int slevel)
 {
   static thbuffer pname;
   size_t plen, slen, start, cx, tx;
@@ -157,6 +157,6 @@ char * thobjectname__print_full_name(const char * oname, thsurvey * psrv, int sl
 
 char * thobjectname::print_full_name(int slevel)
 {
-  return thobjectname__print_full_name(this->name, this->psurvey, slevel);
+  return thobjectname_print_full_name(this->name, this->psurvey, slevel);
 }
 

--- a/thobjectname.h
+++ b/thobjectname.h
@@ -91,7 +91,7 @@ class thobjectname {
 
 void thparse_objectname(thobjectname & ds, thmbuffer * sstore, char * src, class thdataobject * psobj = NULL);
 
-char * thobjectname__print_full_name(const char * oname, class thsurvey * psrv, int slevel = -1);
+char * thobjectname_print_full_name(const char * oname, class thsurvey * psrv, int slevel = -1);
 
 void fprintf(FILE * fh, thobjectname & ds);
 

--- a/thpic.cxx
+++ b/thpic.cxx
@@ -38,9 +38,9 @@
 #define getcwd _getcwd
 #endif
 
-long thpic__convert_number(1);
+long thpic_convert_number(1);
 
-const char * thpic__tmp(NULL);
+const char * thpic_tmp(NULL);
 
 thpic::thpic() {
   this->fname = NULL;
@@ -54,9 +54,9 @@ thpic::thpic() {
   this->y = 0.0;
   this->scale = 1.0;
 
-  if (thpic__tmp == NULL) {
+  if (thpic_tmp == NULL) {
     thdb.buff_tmp = thtmp.get_file_name("pic0000.txt");
-    thpic__tmp = thdb.strstore(thdb.buff_tmp);
+    thpic_tmp = thdb.strstore(thdb.buff_tmp);
   }
 }
 
@@ -121,9 +121,9 @@ void thpic::init(const char * pfname, const char * incfnm)
 
   // write into
   ccom += " > ";
-  isspc = (strcspn(thpic__tmp," \t") < strlen(thpic__tmp));
+  isspc = (strcspn(thpic_tmp," \t") < strlen(thpic_tmp));
   if (isspc) ccom += "\"";
-  ccom += thpic__tmp;
+  ccom += thpic_tmp;
   if (isspc) ccom += "\"";
   
 #ifdef THDEBUG
@@ -133,7 +133,7 @@ void thpic::init(const char * pfname, const char * incfnm)
   retcode = system(ccom.get_buffer());
   if (retcode == EXIT_SUCCESS) {
     FILE * tmp;
-    tmp = fopen(thpic__tmp,"r");
+    tmp = fopen(thpic_tmp,"r");
     if (tmp == NULL)
       retcode = EXIT_FAILURE;
     else {
@@ -169,7 +169,7 @@ const char * thpic::convert(const char * type, const char * ext, const char * op
   va_start(args, optfmt);
   vsprintf(options, optfmt, args);
   va_end(args);
-  sprintf(tmpfn, "pic%04ld.%s", thpic__convert_number++, ext);
+  sprintf(tmpfn, "pic%04ld.%s", thpic_convert_number++, ext);
   isspc = (strcspn(thini.get_path_convert()," \t") < strlen(thini.get_path_convert()));
   ccom = "";
   if (isspc) ccom += "\"";
@@ -266,7 +266,7 @@ void thpic::rgba_save(const char * type, const char * ext, int colors)
   tmp.width = this->width;
   tmp.height = this->height;
   char tmpfn[255];
-  sprintf(tmpfn, "pic%04ld.rgba", thpic__convert_number++);
+  sprintf(tmpfn, "pic%04ld.rgba", thpic_convert_number++);
   tmp.fname = thdb.strstore(thtmp.get_file_name(tmpfn));
   this->rgbafn = tmp.fname;
   FILE * f;
@@ -277,7 +277,7 @@ void thpic::rgba_save(const char * type, const char * ext, int colors)
     this->fname = tmp.convert(type, ext, "-depth 8 -size %dx%d -density 300 +dither -colors %d", this->width, this->height, colors);
   else
     this->fname = tmp.convert(type, ext, "-depth 8 -size %dx%d -density 300", this->width, this->height);
-  sprintf(tmpfn, "pic%04ld.%s", thpic__convert_number - 1, ext);
+  sprintf(tmpfn, "pic%04ld.%s", thpic_convert_number - 1, ext);
   this->texfname = thdb.strstore(tmpfn);
 }
 

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -447,7 +447,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         out->layout->export_mptex_font_size(out->file, this, true);
         fprintf(out->file,"%s etex,",
           ((this->type == TT_POINT_TYPE_STATION_NAME) && (!this->station_name.is_empty()))
-          ? (const char *) utf2tex(thobjectname__print_full_name(this->station_name.name, this->station_name.psurvey, out->layout->survey_level))
+          ? (const char *) utf2tex(thobjectname_print_full_name(this->station_name.name, this->station_name.psurvey, out->layout->survey_level))
           : ths2tex(this->text, out->layout->lang).c_str());
         if (this->type == TT_POINT_TYPE_STATION_NAME)
           postprocess_label = "p_label_mode_station";

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -224,7 +224,7 @@ void thselector_select_item::parse (thdataobject * op)
 
 typedef std::vector <thselector_select_item> thselector_siv;
 
-void thselector__export_survey_tree_node (FILE * cf, unsigned long level, thdataobject * optr) {
+void thselector_export_survey_tree_node (FILE * cf, unsigned long level, thdataobject * optr) {
   thsurvey * ss;
   while (optr != NULL) {
     if (optr->get_class_id() == TT_SURVEY_CMD) {
@@ -277,13 +277,13 @@ void thselector__export_survey_tree_node (FILE * cf, unsigned long level, thdata
         fprintf(cf,"\"\n");
       }
       if (ss->foptr != NULL)
-        thselector__export_survey_tree_node(cf,level+1,ss->foptr);
+        thselector_export_survey_tree_node(cf,level+1,ss->foptr);
     }
     optr = optr->nsptr;
   }
 }
 
-void thselector__prepare_map_tree_export (thdatabase * db) {
+void thselector_prepare_map_tree_export (thdatabase * db) {
 
   // prejde vsetky mapy a surveye a nastavi tmp_bool na true a tmp_ulong na 0
   thdb_object_list_type::iterator obi = db->object_list.begin();
@@ -311,7 +311,7 @@ void thselector__prepare_map_tree_export (thdatabase * db) {
   
 }
 
-void thselector__export_map_tree_node (FILE * cf, unsigned long level, unsigned long pass, thdataobject * optr, thmap * fmap) {
+void thselector_export_map_tree_node (FILE * cf, unsigned long level, unsigned long pass, thdataobject * optr, thmap * fmap) {
   if (optr->tmp_ulong == pass)
     return;
   if (optr->fsptr == NULL)
@@ -359,7 +359,7 @@ void thselector__export_map_tree_node (FILE * cf, unsigned long level, unsigned 
     mi = mptr->first_item;
     while (mi != NULL) {
       if (mi->type == TT_MAPITEM_NORMAL) {
-        thselector__export_map_tree_node(cf, level+1, pass, mi->object, mptr);
+        thselector_export_map_tree_node(cf, level+1, pass, mi->object, mptr);
       }
       mi = mi->next_item;
     }
@@ -372,7 +372,7 @@ void thselector::dump_selection_db (FILE * cf, thdatabase * db)
   // exportuje strom surveyov
   fprintf(cf,"set xth(ctrl,cp,datlist) {}\n");
   if (db->fsurveyptr != NULL) 
-    thselector__export_survey_tree_node(cf,0,db->fsurveyptr);
+    thselector_export_survey_tree_node(cf,0,db->fsurveyptr);
   fprintf(cf,"xth_cp_data_tree_create\n");
   
   // exportuje strom map po vsetkych projekciach
@@ -395,7 +395,7 @@ void thselector::dump_selection_db (FILE * cf, thdatabase * db)
     prjli++;
   }
   // exportuje vsetky mapy a scrapy
-  thselector__prepare_map_tree_export(db);
+  thselector_prepare_map_tree_export(db);
   thdb_object_list_type::iterator obi = db->object_list.begin();
   while (obi != db->object_list.end()) {
     if ((*obi)->get_class_id() == TT_MAP_CMD)
@@ -406,7 +406,7 @@ void thselector::dump_selection_db (FILE * cf, thdatabase * db)
   obi = db->object_list.begin();
   while (obi != db->object_list.end()) {
     if (((*obi)->fsptr != NULL) && ((*obi)->get_class_id() == TT_MAP_CMD) && (((thmap*)(*obi).get())->tmp_bool))
-      thselector__export_map_tree_node(cf,1,(*obi)->id,obi->get(),NULL);
+      thselector_export_map_tree_node(cf,1,(*obi)->id,obi->get(),NULL);
     obi++;
   }
   

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -57,7 +57,7 @@
 thsymbolset::thsymbolset()
 {
   for(int i = 0; i < thsymbolset_size; i++) {
-    this->assigned[i] = !(thsymbolset__hidden[i]);
+    this->assigned[i] = !(thsymbolset_hidden[i]);
     this->used[i] = false;
   }
   this->group_symbols = true;
@@ -123,7 +123,7 @@ char * thlegend_u2string(unsigned u) {
 const char * thsymbolset::get_mp_macro(int id)
 {
   this->used[id] = true;
-  return thsymbolset__mp[id];
+  return thsymbolset_mp[id];
 }
 
 
@@ -205,7 +205,7 @@ static const thstok thtt_symbol_special[] = {
             break; \
           }
 
-int thsymbolset__get_id(const char * symclass, const char * symbol)
+int thsymbolset_get_id(const char * symclass, const char * symbol)
 {
   int type, subtype, rv;
   char types[128],
@@ -524,9 +524,9 @@ void thsymbolset::export_symbol_defaults(FILE * mpf, const char * symset)
 {
   fprintf(mpf,"\n\n\n%% %s symbol set.\n",symset);
   for(int id = 0; id < SYMX_; id++) {
-    if (thsymbolset__assign[id]) {
+    if (thsymbolset_assign[id]) {
       this->assigned[id] = true;
-      fprintf(mpf,"mapsymbol(\"%s\",\"%s\",false);\n",thsymbolset__mp[id],symset);
+      fprintf(mpf,"mapsymbol(\"%s\",\"%s\",false);\n",thsymbolset_mp[id],symset);
     }
   }
 }
@@ -535,8 +535,8 @@ void thsymbolset::export_symbol_assign(FILE * mpf, int sym_id, const char * syms
 {
   if (sym_id > SYMX_)
     export_symbol_assign_group(mpf, sym_id, symset);
-  else if (thsymbolset__assign[sym_id]) {
-    fprintf(mpf,"mapsymbol(\"%s\",\"%s\",true);\n",thsymbolset__mp[sym_id],symset);
+  else if (thsymbolset_assign[sym_id]) {
+    fprintf(mpf,"mapsymbol(\"%s\",\"%s\",true);\n",thsymbolset_mp[sym_id],symset);
   }
 }
 
@@ -571,10 +571,10 @@ void thsymbolset::export_symbol_color(FILE * mpf, int sym_id, thlayout_color * c
 void thsymbolset::export_symbol_color_group(FILE * mpf, int sym_id, thlayout_color * clr)
 {
   int id = 0;
-  int cid = thsymbolset__get_group(sym_id,id++);
+  int cid = thsymbolset_get_group(sym_id,id++);
   while (cid >= 0) {
     this->export_symbol_color(mpf, cid, clr);
-    cid = thsymbolset__get_group(sym_id,id++);
+    cid = thsymbolset_get_group(sym_id,id++);
   }
 }
 
@@ -582,20 +582,20 @@ void thsymbolset::export_symbol_color_group(FILE * mpf, int sym_id, thlayout_col
 void thsymbolset::export_symbol_assign_group(FILE * mpf, int sym_id, const char * symset)
 {
   int id = 0;
-  int cid = thsymbolset__get_group(sym_id,id++);
+  int cid = thsymbolset_get_group(sym_id,id++);
   while (cid >= 0) {
     this->export_symbol_assign(mpf, cid, symset);
-    cid = thsymbolset__get_group(sym_id,id++);
+    cid = thsymbolset_get_group(sym_id,id++);
   }
 }
 
 void thsymbolset::export_symbol_hide_group(FILE * mpf, int sym_id)
 {
   int id = 0;
-  int cid = thsymbolset__get_group(sym_id,id++);
+  int cid = thsymbolset_get_group(sym_id,id++);
   while (cid >= 0) {
     this->export_symbol_hide(mpf, cid);
-    cid = thsymbolset__get_group(sym_id,id++);
+    cid = thsymbolset_get_group(sym_id,id++);
   }
 }
 
@@ -603,10 +603,10 @@ void thsymbolset::export_symbol_hide_group(FILE * mpf, int sym_id)
 void thsymbolset::export_symbol_show_group(FILE * mpf, int sym_id)
 {
   int id = 0;
-  int cid = thsymbolset__get_group(sym_id,id++);
+  int cid = thsymbolset_get_group(sym_id,id++);
   while (cid >= 0) {
     this->export_symbol_show(mpf, cid);
-    cid = thsymbolset__get_group(sym_id,id++);
+    cid = thsymbolset_get_group(sym_id,id++);
   }
 }
 
@@ -616,7 +616,7 @@ void thsymbolset::export_symbol_show_group(FILE * mpf, int sym_id)
 #define group(id,mid) case id: rv = mid; break;
 #define egroup } break;
 
-int thsymbolset__get_group(int group_id, int cid) {
+int thsymbolset_get_group(int group_id, int cid) {
   int rv = -1;
   switch (group_id) {
 
@@ -943,13 +943,13 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define legend_point(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s((0.5,0.5) inscale,0.0,1.0,(0,0));\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s((0.5,0.5) inscale,0.0,1.0,(0,0));\n",thsymbolset_mp[mid]);  \
   endfig;
 
 #define legend_hpoint(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s((0.5,0.5) inscale,270.0,1.0,(0,0));\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s((0.5,0.5) inscale,270.0,1.0,(0,0));\n",thsymbolset_mp[mid]);  \
   endfig;
 
 
@@ -957,7 +957,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define legend_station(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s((0.5,0.5) inscale);\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s((0.5,0.5) inscale);\n",thsymbolset_mp[mid]);  \
   endfig;
   // thT("point station")
   legend_station(SYMP_STATION_TEMPORARY,thT("point station:temporary",layout->lang));
@@ -985,21 +985,21 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define insert_station(x,y) \
   helpsymbol \
   if (true || isused(SYMP_STATION_TEMPORARY)) \
-    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset__mp[SYMP_STATION_TEMPORARY],x,y); \
+    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset_mp[SYMP_STATION_TEMPORARY],x,y); \
   else \
   if isused(SYMP_STATION_PAINTED) \
-    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset__mp[SYMP_STATION_PAINTED],x,y); \
+    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset_mp[SYMP_STATION_PAINTED],x,y); \
   else \
   if isused(SYMP_STATION_NATURAL) \
-    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset__mp[SYMP_STATION_NATURAL],x,y); \
+    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset_mp[SYMP_STATION_NATURAL],x,y); \
   else \
   if isused(SYMP_STATION_FIXED) \
-    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset__mp[SYMP_STATION_FIXED],x,y); \
+    fprintf(mpf,"%s((%g,%g) inscale);\n",thsymbolset_mp[SYMP_STATION_FIXED],x,y); \
   endhelpsymbol;
 
   insfig(SYML_SURVEY_CAVE,thT("line survey",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_SURVEY_CAVE);
-  fprintf(mpf,"%s(((-1,1) -- (0.8,0.6) -- (0,-1)) inscale);\n", thsymbolset__mp[SYML_SURVEY_CAVE]);
+  fprintf(mpf,"%s(((-1,1) -- (0.8,0.6) -- (0,-1)) inscale);\n", thsymbolset_mp[SYML_SURVEY_CAVE]);
   insert_station(0.8,0.6);
   endfig;
 
@@ -1013,14 +1013,14 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 
   insfig(SYML_MAPCONNECTION,thT("line map-connection",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_MAPCONNECTION);
-  fprintf(mpf,"%s(((0.2,0.8) -- (0.8,0.2)) inscale)",thsymbolset__mp[SYML_MAPCONNECTION]);
+  fprintf(mpf,"%s(((0.2,0.8) -- (0.8,0.2)) inscale)",thsymbolset_mp[SYML_MAPCONNECTION]);
   endfig;
 
   // steny + wall-altitude + altitude
 #define legend_wall(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(((-.3,0.5) .. (.3,.3) .. (.7,.7) .. (1.3,.5)) inscale);\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s(((-.3,0.5) .. (.3,.3) .. (.7,.7) .. (1.3,.5)) inscale);\n",thsymbolset_mp[mid]);  \
   endfig;
 
   // thT("line wall")
@@ -1042,10 +1042,10 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYMP_WALLALTITUDE,thT("point wall-altitude",layout->lang));
   helpsymbol;
   if (true || isused(SYML_WALL_BEDROCK))
-    fprintf(mpf,"%s(((-.3,0.5) .. controls (.2,.6) and (.2,.6) .. (.3,.7) .. controls (.4,.8) and (.4,.8) .. (.5,1.4)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]);
+    fprintf(mpf,"%s(((-.3,0.5) .. controls (.2,.6) and (.2,.6) .. (.3,.7) .. controls (.4,.8) and (.4,.8) .. (.5,1.4)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_WALLALTITUDE);
-  fprintf(mpf,"%s((0.2,0.6) inscale,(0.3,0.7) inscale,(0.4,0.8) inscale,btex \\thwallaltitude %s etex);\n",thsymbolset__mp[SYMP_WALLALTITUDE],utf2tex("1510"));
+  fprintf(mpf,"%s((0.2,0.6) inscale,(0.3,0.7) inscale,(0.4,0.8) inscale,btex \\thwallaltitude %s etex);\n",thsymbolset_mp[SYMP_WALLALTITUDE],utf2tex("1510"));
   endfig;
 
   insfig(SYMP_ALTITUDE,thT("point altitude",layout->lang));
@@ -1057,15 +1057,15 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYML_SECTION,thT("line section",layout->lang));
   helpsymbol;
   if (true || (true || isused(SYML_WALL_BEDROCK))) {
-    fprintf(mpf,"%s(((.25,1.0) .. (.2,.5){dir 270} .. (.15,0.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]);
-    fprintf(mpf,"%s(((.3,0.0) .. (.4,.5){dir 90} .. (.5,1.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]);
+    fprintf(mpf,"%s(((.25,1.0) .. (.2,.5){dir 270} .. (.15,0.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]);
+    fprintf(mpf,"%s(((.3,0.0) .. (.4,.5){dir 90} .. (.5,1.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]);
     if (true || isused(SYMP_SECTION)) {
-      fprintf(mpf,"%s(((.7,.5){dir 90} .. (.9,.75){dir 270} .. (.8,.15){dir 235} .. cycle) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]);
+      fprintf(mpf,"%s(((.7,.5){dir 90} .. (.9,.75){dir 270} .. (.8,.15){dir 235} .. cycle) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]);
     }
   }
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYML_SECTION);
-  fprintf(mpf,"%s(((0,.5) .. controls (.195,.5) and (.405,.5) .. (.6,.5)) inscale,1);\n",thsymbolset__mp[SYML_SECTION]);
+  fprintf(mpf,"%s(((0,.5) .. controls (.195,.5) and (.405,.5) .. (.6,.5)) inscale,1);\n",thsymbolset_mp[SYML_SECTION]);
   endfig;
 
 
@@ -1073,16 +1073,16 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define insert_big_passage \
   helpsymbol; \
   if (true || isused(SYML_WALL_BEDROCK)) { \
-    fprintf(mpf,"%s(((.35,1.0) .. (.3,.5){dir 270} .. (.25,0.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
-    fprintf(mpf,"%s(((.6,0.0) .. (.7,.5){dir 90} .. (.8,1.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.35,1.0) .. (.3,.5){dir 270} .. (.25,0.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.6,0.0) .. (.7,.5){dir 90} .. (.8,1.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
   } \
   endhelpsymbol;
 
 #define insert_big_water_passage \
   helpsymbol; \
   if (true || isused(SYML_WALL_BEDROCK)) { \
-    fprintf(mpf,"%s(((.35,1.0) .. (.3,.5){dir 270} .. (.25,0.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
-    fprintf(mpf,"%s(((.6,0.0) .. (.7,.5){dir 90} .. (.8,1.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.35,1.0) .. (.3,.5){dir 270} .. (.25,0.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.6,0.0) .. (.7,.5){dir 90} .. (.8,1.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
   } \
   endhelpsymbol;
 
@@ -1132,12 +1132,12 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(mid,txt); \
   helpsymbol; \
   if (true || isused(SYML_WALL_BEDROCK)) {\
-    fprintf(mpf,"%s(((0,.2){dir 30} .. {dir 0}(.5,.4)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
-    fprintf(mpf,"%s(((.5,.6){dir 180} .. {dir 210}(0,.8)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((0,.2){dir 30} .. {dir 0}(.5,.4)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.5,.6){dir 180} .. {dir 210}(0,.8)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
   } \
   endhelpsymbol; \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s((.6,.5) inscale,270.0,1.0,(0,1));\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s((.6,.5) inscale,270.0,1.0,(0,1));\n",thsymbolset_mp[mid]);  \
   endfig;
 
   legend_point(SYMP_DIG,thT("point dig",layout->lang))
@@ -1155,18 +1155,18 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define legend_step(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(%s);\n",thsymbolset__mp[mid],legend_iuline); \
+  fprintf(mpf,"%s(%s);\n",thsymbolset_mp[mid],legend_iuline); \
   endfig;
 #define legend_cycle(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(%s);\n",thsymbolset__mp[mid],legend_cline); \
+  fprintf(mpf,"%s(%s);\n",thsymbolset_mp[mid],legend_cline); \
   endfig;
 #define insert_small_passage \
   helpsymbol; \
   if (true || isused(SYML_WALL_BEDROCK)) { \
-    fprintf(mpf,"%s(((.2,1.0) .. (.15,.5){dir 270} .. (.1,0.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
-    fprintf(mpf,"%s(((.4,0.0) .. (.5,.5){dir 90} .. (.6,1.0)) inscale);\n",thsymbolset__mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.2,1.0) .. (.15,.5){dir 270} .. (.1,0.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
+    fprintf(mpf,"%s(((.4,0.0) .. (.5,.5){dir 90} .. (.6,1.0)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]); \
   } \
   endhelpsymbol;
 
@@ -1181,7 +1181,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   if isused(SYML_GRADIENT) {
     insfig(SYML_GRADIENT,thT("line gradient",layout->lang));
     this->export_mp_symbol_options(mpf, SYML_GRADIENT);
-    fprintf(mpf,"%s(((0.2,0.5) -- (0.8,0.5)) inscale);\n",thsymbolset__mp[SYML_GRADIENT]);
+    fprintf(mpf,"%s(((0.2,0.5) -- (0.8,0.5)) inscale);\n",thsymbolset_mp[SYML_GRADIENT]);
     endfig;
   }
   if ((!(isused(SYML_GRADIENT)) || (!(this->group_symbols)))) {
@@ -1194,11 +1194,11 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYMP_HEIGHT_UNSIGNED,thT("point height:unsigned",layout->lang));
   helpsymbol;
   if isused(SYML_FLOORSTEP) {
-    fprintf(mpf,"%s(((.15,.5){dir 340} .. (.5,.5)) inscale);\n",thsymbolset__mp[SYML_FLOORSTEP]);
+    fprintf(mpf,"%s(((.15,.5){dir 340} .. (.5,.5)) inscale);\n",thsymbolset_mp[SYML_FLOORSTEP]);
     insert_small_passage
   } else
   if isused(SYML_PIT) {
-    fprintf(mpf,"%s(((.15,.5){dir 340} .. (.5,.5)) inscale);\n",thsymbolset__mp[SYML_PIT]);
+    fprintf(mpf,"%s(((.15,.5){dir 340} .. (.5,.5)) inscale);\n",thsymbolset_mp[SYML_PIT]);
     insert_small_passage
   }
   endhelpsymbol;
@@ -1209,7 +1209,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYMP_HEIGHT_POSITIVE,thT("point height:positive",layout->lang));
   helpsymbol;
   if isused(SYML_CHIMNEY)
-    fprintf(mpf,"%s(%s);\n",thsymbolset__mp[SYML_CHIMNEY],legend_scline);
+    fprintf(mpf,"%s(%s);\n",thsymbolset_mp[SYML_CHIMNEY],legend_scline);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_HEIGHT_POSITIVE);
   fprintf(mpf,"p_label.rt(btex \\thheightpos %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("15"));
@@ -1218,7 +1218,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYMP_HEIGHT_NEGATIVE,thT("point height:negative",layout->lang));
   helpsymbol;
   if isused(SYML_PIT)
-    fprintf(mpf,"%s(%s);\n",thsymbolset__mp[SYML_PIT],legend_scline);
+    fprintf(mpf,"%s(%s);\n",thsymbolset_mp[SYML_PIT],legend_scline);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_HEIGHT_NEGATIVE);
   fprintf(mpf,"p_label.rt(btex \\thheightneg %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("30"));
@@ -1226,27 +1226,27 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 
   insfig(SYML_CONTOUR,thT("line contour",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_CONTOUR);
-  fprintf(mpf,"%s(%s,-1);\n",thsymbolset__mp[SYML_CONTOUR],legend_iuline);
+  fprintf(mpf,"%s(%s,-1);\n",thsymbolset_mp[SYML_CONTOUR],legend_iuline);
   endfig;
 
   insfig(SYML_SLOPE,thT("line slope",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_SLOPE);
-  fprintf(mpf,"%s((((.1,.35) .. (.5,.25) .. (.9,.35)) inscale),1,(0,-1,1u),(2,-1,1u));\n",thsymbolset__mp[SYML_SLOPE]);
+  fprintf(mpf,"%s((((.1,.35) .. (.5,.25) .. (.9,.35)) inscale),1,(0,-1,1u),(2,-1,1u));\n",thsymbolset_mp[SYML_SLOPE]);
   endfig;
 
   // kamene
   insfig(SYML_ROCKBORDER,thT("line rock-border",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_ROCKBORDER);
-  fprintf(mpf,"%s(((.16,.36) -- (.61,.21) -- (.91,.46) -- (.84,.78) -- (.38,.86) -- (.20,.55) -- cycle) inscale)",thsymbolset__mp[SYML_ROCKBORDER]);
+  fprintf(mpf,"%s(((.16,.36) -- (.61,.21) -- (.91,.46) -- (.84,.78) -- (.38,.86) -- (.20,.55) -- cycle) inscale)",thsymbolset_mp[SYML_ROCKBORDER]);
   endfig;
 
   insfig(SYML_ROCKEDGE,thT("line rock-edge",layout->lang));
   helpsymbol;
   if isused(SYML_ROCKBORDER)
-    fprintf(mpf,"%s(((.16,.36) -- (.61,.21) -- (.91,.46) -- (.84,.78) -- (.38,.86) -- (.20,.55) -- cycle) inscale)",thsymbolset__mp[SYML_ROCKBORDER]);
+    fprintf(mpf,"%s(((.16,.36) -- (.61,.21) -- (.91,.46) -- (.84,.78) -- (.38,.86) -- (.20,.55) -- cycle) inscale)",thsymbolset_mp[SYML_ROCKBORDER]);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYML_ROCKEDGE);
-  fprintf(mpf,"%s(((.16,.36) -- (.42,.62) -- (.38,.86) -- (.42,.62) -- (.6,.55) -- (.61,.21) -- (.6,.55) -- (.84,.78)) inscale)",thsymbolset__mp[SYML_ROCKEDGE]);
+  fprintf(mpf,"%s(((.16,.36) -- (.42,.62) -- (.38,.86) -- (.42,.62) -- (.6,.55) -- (.61,.21) -- (.6,.55) -- (.84,.78)) inscale)",thsymbolset_mp[SYML_ROCKEDGE]);
   endfig;
 
   // vypln bodova
@@ -1274,12 +1274,12 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define legend_area(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(buildcycle((((-1,0) -- (1,0) -- (1,1) -- (0,1) -- (0,-1))  inscale)));\n",thsymbolset__mp[mid]); \
+  fprintf(mpf,"%s(buildcycle((((-1,0) -- (1,0) -- (1,1) -- (0,1) -- (0,-1))  inscale)));\n",thsymbolset_mp[mid]); \
   endfig;
 #define legend_nocliparea(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(buildcycle((((-4,-4) -- (4,-4) -- (4,4) -- (-4,4) -- (-4,-4))  inscale)));\n",thsymbolset__mp[mid]); \
+  fprintf(mpf,"%s(buildcycle((((-4,-4) -- (4,-4) -- (4,4) -- (-4,4) -- (-4,-4))  inscale)));\n",thsymbolset_mp[mid]); \
   endfig;
   legend_area(SYMA_WATER,thT("area water",layout->lang));
   legend_area(SYMA_SUMP,thT("area sump",layout->lang));
@@ -1304,7 +1304,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define legend_waterflow(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(((0.2,0.8) -- (0.8,0.2)) inscale);\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s(((0.2,0.8) -- (0.8,0.2)) inscale);\n",thsymbolset_mp[mid]);  \
   endfig;
 
 
@@ -1313,9 +1313,9 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   if (isused(SYML_WATERFLOW_PERMANENT) && isused(SYMP_WATERFLOW_PERMANENT) && this->group_symbols) {
 	  insfig(SYML_WATERFLOW_PERMANENT,thT("line water-flow:permanent",layout->lang));
     this->export_mp_symbol_options(mpf, SYML_WATERFLOW_PERMANENT);
-	  fprintf(mpf,"%s(((0.1,0.3) -- (0.9,0.3)) inscale);\n",thsymbolset__mp[SYML_WATERFLOW_PERMANENT]);
+	  fprintf(mpf,"%s(((0.1,0.3) -- (0.9,0.3)) inscale);\n",thsymbolset_mp[SYML_WATERFLOW_PERMANENT]);
     this->export_mp_symbol_options(mpf, SYMP_WATERFLOW_PERMANENT);
-    fprintf(mpf,"%s((0.5,0.7) inscale,270.0,1.0,(0,0));\n",thsymbolset__mp[SYMP_WATERFLOW_PERMANENT]);
+    fprintf(mpf,"%s((0.5,0.7) inscale,270.0,1.0,(0,0));\n",thsymbolset_mp[SYMP_WATERFLOW_PERMANENT]);
 	  endfig;
   } else {
 	  legend_waterflow(SYML_WATERFLOW_PERMANENT,thT("line water-flow:permanent",layout->lang));
@@ -1325,9 +1325,9 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   if (isused(SYML_WATERFLOW_INTERMITTENT) && isused(SYMP_WATERFLOW_INTERMITTENT) && this->group_symbols) {
 	  insfig(SYML_WATERFLOW_INTERMITTENT,thT("line water-flow:intermittent",layout->lang));
     this->export_mp_symbol_options(mpf, SYML_WATERFLOW_INTERMITTENT);
-	  fprintf(mpf,"%s(((0.1,0.3) -- (0.9,0.3)) inscale);\n",thsymbolset__mp[SYML_WATERFLOW_INTERMITTENT]);
+	  fprintf(mpf,"%s(((0.1,0.3) -- (0.9,0.3)) inscale);\n",thsymbolset_mp[SYML_WATERFLOW_INTERMITTENT]);
     this->export_mp_symbol_options(mpf, SYML_WATERFLOW_INTERMITTENT);
-    fprintf(mpf,"%s((0.5,0.7) inscale,270.0,1.0,(0,0));\n",thsymbolset__mp[SYMP_WATERFLOW_INTERMITTENT]);
+    fprintf(mpf,"%s((0.5,0.7) inscale,270.0,1.0,(0,0));\n",thsymbolset_mp[SYMP_WATERFLOW_INTERMITTENT]);
 	  endfig;
   } else {
 	  legend_waterflow(SYML_WATERFLOW_INTERMITTENT,thT("line water-flow:intermittent",layout->lang));
@@ -1339,18 +1339,18 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 
   insfig(SYMP_SPRING,thT("point spring",layout->lang));
   helpsymbol;
-  fprintf(mpf,"%s(((0.3,0.5) -- (0.9,0.5)) inscale);\n",thsymbolset__mp[SYML_WATERFLOW_PERMANENT]);
+  fprintf(mpf,"%s(((0.3,0.5) -- (0.9,0.5)) inscale);\n",thsymbolset_mp[SYML_WATERFLOW_PERMANENT]);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_SPRING);
-  fprintf(mpf,"%s((0.3,0.5) inscale,270,1.0,(0,-1));\n",thsymbolset__mp[SYMP_SPRING]);
+  fprintf(mpf,"%s((0.3,0.5) inscale,270,1.0,(0,-1));\n",thsymbolset_mp[SYMP_SPRING]);
   endfig;
 
   insfig(SYMP_SINK,thT("point sink",layout->lang));
   helpsymbol;
-  fprintf(mpf,"%s(((0.1,0.5) -- (0.7,0.5)) inscale);\n",thsymbolset__mp[SYML_WATERFLOW_PERMANENT]);
+  fprintf(mpf,"%s(((0.1,0.5) -- (0.7,0.5)) inscale);\n",thsymbolset_mp[SYML_WATERFLOW_PERMANENT]);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_SINK);
-  fprintf(mpf,"%s((0.7,0.5) inscale,270,1.0,(0,1));\n",thsymbolset__mp[SYMP_SINK]);
+  fprintf(mpf,"%s((0.7,0.5) inscale,270,1.0,(0,1));\n",thsymbolset_mp[SYMP_SINK]);
   endfig;
 
 
@@ -1358,9 +1358,9 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   if (isused(SYMP_FLOWSTONE) && isused(SYML_FLOWSTONE) && this->group_symbols) {
 	  insfig(SYMP_FLOWSTONE,thT("point flowstone",layout->lang));
     this->export_mp_symbol_options(mpf, SYML_FLOWSTONE);
-	  fprintf(mpf,"%s(((.1,.4) .. (.5,.2) .. (.9,.4)) inscale);\n",thsymbolset__mp[SYML_FLOWSTONE]);
+	  fprintf(mpf,"%s(((.1,.4) .. (.5,.2) .. (.9,.4)) inscale);\n",thsymbolset_mp[SYML_FLOWSTONE]);
     this->export_mp_symbol_options(mpf, SYMP_FLOWSTONE);
-    fprintf(mpf,"%s((0.5,0.7) inscale,0.0,1.0,(0,0));\n",thsymbolset__mp[SYMP_FLOWSTONE]);
+    fprintf(mpf,"%s((0.5,0.7) inscale,0.0,1.0,(0,0));\n",thsymbolset_mp[SYMP_FLOWSTONE]);
 	  endfig;
   } else {
 	  legend_point(SYMP_FLOWSTONE,thT("point flowstone",layout->lang));
@@ -1370,9 +1370,9 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   if (isused(SYMP_MOONMILK) && isused(SYML_MOONMILK) && this->group_symbols) {
 	  insfig(SYMP_MOONMILK,thT("point moonmilk",layout->lang));
     this->export_mp_symbol_options(mpf, SYML_MOONMILK);
-	  fprintf(mpf,"%s(((.1,.4) .. (.5,.2) .. (.9,.4)) inscale);\n",thsymbolset__mp[SYML_MOONMILK]);
+	  fprintf(mpf,"%s(((.1,.4) .. (.5,.2) .. (.9,.4)) inscale);\n",thsymbolset_mp[SYML_MOONMILK]);
     this->export_mp_symbol_options(mpf, SYMP_MOONMILK);
-    fprintf(mpf,"%s((0.5,0.7) inscale,0.0,1.0,(0,0));\n",thsymbolset__mp[SYMP_MOONMILK]);
+    fprintf(mpf,"%s((0.5,0.7) inscale,0.0,1.0,(0,0));\n",thsymbolset_mp[SYMP_MOONMILK]);
 	  endfig;
   } else {
 	  legend_point(SYMP_MOONMILK,thT("point moonmilk",layout->lang));
@@ -1417,7 +1417,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 #define legend_eqline(mid,txt) \
   insfig(mid,txt); \
   this->export_mp_symbol_options(mpf, mid); \
-  fprintf(mpf,"%s(((0.1,0.5) .. (0.9,.5)) inscale);\n",thsymbolset__mp[mid]);  \
+  fprintf(mpf,"%s(((0.1,0.5) .. (0.9,.5)) inscale);\n",thsymbolset_mp[mid]);  \
   endfig;
 
   // vystroj
@@ -1468,13 +1468,13 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 
   insfig(SYML_ROPE,thT("line rope",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_ROPE);
-  fprintf(mpf,"%s(((0.1,0.85) -- (0.25,0.6) -- (0.5,0.1)) inscale, false, true);\n",thsymbolset__mp[SYML_ROPE]);
-  fprintf(mpf,"%s(((0.6,0.8) -- (0.8,0.2)) inscale, true, false);\n",thsymbolset__mp[SYML_ROPE]);
+  fprintf(mpf,"%s(((0.1,0.85) -- (0.25,0.6) -- (0.5,0.1)) inscale, false, true);\n",thsymbolset_mp[SYML_ROPE]);
+  fprintf(mpf,"%s(((0.6,0.8) -- (0.8,0.2)) inscale, true, false);\n",thsymbolset_mp[SYML_ROPE]);
   endfig;
 
 	insfig(SYML_STEPS,thT("line steps",layout->lang));
   this->export_mp_symbol_options(mpf, SYML_STEPS);
-  fprintf(mpf,"%s(((0.1,0.3) -- (0.9,.3) -- (0.9,0.7) -- (0.1,0.7) -- cycle) inscale);\n",thsymbolset__mp[SYML_STEPS]);
+  fprintf(mpf,"%s(((0.1,0.3) -- (0.9,.3) -- (0.9,0.7) -- (0.1,0.7) -- cycle) inscale);\n",thsymbolset_mp[SYML_STEPS]);
   endfig;
 
   legend_point(SYMP_VIAFERRATA,thT("point via-ferrata",layout->lang));
@@ -1519,7 +1519,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
         udef_desc += " u:";
         udef_desc += it->first.m_type;
         if (strlen(thT(udef_desc.c_str(), layout->lang)) > 0) {
-          insfig(0,thsymbolset__mp[0]);
+          insfig(0,thsymbolset_mp[0]);
           switch (it->first.m_command) {
             case TT_POINT_CMD:
               fprintf(mpf,"p_u_%s_legend;\n",it->first.m_type);
@@ -1775,10 +1775,10 @@ bool thsymbolset::is_assigned(int symbol)
     return this->assigned[symbol];
   if (symbol > SYMX_) {
     int id = 0;
-    int cid = thsymbolset__get_group(symbol,id++);
+    int cid = thsymbolset_get_group(symbol,id++);
     while (cid >= 0) {
       if (this->assigned[cid]) return true;
-      cid = thsymbolset__get_group(symbol,id++);
+      cid = thsymbolset_get_group(symbol,id++);
     }
   }
   return false;

--- a/thsymbolset.h
+++ b/thsymbolset.h
@@ -123,13 +123,13 @@ struct thsymbolset {
 /**
  * Vrati ID z popisu classu a symbolu.
  */
-int thsymbolset__get_id(const char * symclass, const char * symbol);
+int thsymbolset_get_id(const char * symclass, const char * symbol);
 
 
 /**
  * Vrati ID itemu z groupy.
  */
-int thsymbolset__get_group(int group_id, int cid);
+int thsymbolset_get_group(int group_id, int cid);
 
 
 /**

--- a/thsymbolsetlist.pl
+++ b/thsymbolsetlist.pl
@@ -117,21 +117,21 @@ print O <<ENDO;
 enum {
 $TK};
 
-typedef const char * thsymbolset__char_ptr;
+typedef const char * thsymbolset_char_ptr;
 
-static const thsymbolset__char_ptr thsymbolset__mp [] = {
+static const thsymbolset_char_ptr thsymbolset_mp [] = {
 $MP};
 
-static const bool thsymbolset__assign [] = {
+static const bool thsymbolset_assign [] = {
 $EX};
 
-static const bool thsymbolset__hidden [] = {
+static const bool thsymbolset_hidden [] = {
 $HN};
 
-static const thsymbolset__char_ptr thsymbolset__src [] = {
+static const thsymbolset_char_ptr thsymbolset_src [] = {
 $TS};
 
-static const char thsymbolset__fontchar [] = {
+static const char thsymbolset_fontchar [] = {
 $FC};
 
 #endif


### PR DESCRIPTION
Some identifiers are reserved by the C++ standard, for example those with double underscores, so I have renamed them. Reported by `clang-tidy`. I have also fixed CI so now static analysis finally runs there.