### PR TITLE
Run samples in CMake on CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,9 +6,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-18.04, type: Release, cc: gcc,   cxx: g++,     args: ""                                }
-          - { os: ubuntu-20.04, type: Release, cc: gcc,   cxx: g++,     args: "-DECM_ENABLE_SANITIZERS=address" }
-          - { os: ubuntu-20.04, type: Debug,   cc: clang, cxx: clang++, args: "-DENABLE_CLANG_TIDY=ON"          }
+          - { os: ubuntu-18.04, type: Release,        cc: gcc,   cxx: g++,     args: ""                                          }
+          - { os: ubuntu-20.04, type: Debug,          cc: gcc,   cxx: g++,     args: "-DENABLE_CLANG_TIDY=ON"                    }
+          - { os: ubuntu-20.04, type: RelWithDebInfo, cc: clang, cxx: clang++, args: "-DECM_ENABLE_SANITIZERS=address;undefined" }
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
@@ -27,6 +27,9 @@ jobs:
                 ${{ matrix.args }} ..
       - run: cmake --build build
       - run: cmake --build build -t test
+      - name: Run samples
+        if: matrix.type == 'RelWithDebInfo'
+        run: cmake --build build -t samples-cmake
 
   macOS:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,9 +6,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-18.04, type: Release,        cc: gcc,   cxx: g++,     args: ""                                          }
-          - { os: ubuntu-20.04, type: Debug,          cc: gcc,   cxx: g++,     args: "-DENABLE_CLANG_TIDY=ON"                    }
-          - { os: ubuntu-20.04, type: RelWithDebInfo, cc: clang, cxx: clang++, args: "-DECM_ENABLE_SANITIZERS=address;undefined" }
+          - { os: ubuntu-18.04, type: Release,        cc: gcc,   cxx: g++,     args: ""                                            }
+          - { os: ubuntu-20.04, type: Debug,          cc: gcc,   cxx: g++,     args: "-DENABLE_CLANG_TIDY=ON"                      }
+          - { os: ubuntu-20.04, type: RelWithDebInfo, cc: clang, cxx: clang++, args: '-DECM_ENABLE_SANITIZERS="address;undefined"' }
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -11,3 +11,9 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target thbook
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   USES_TERMINAL)
+
+ # subdirectories will add dependencies to this target
+add_custom_target(samples-cmake)
+
+add_subdirectory(areas)
+add_subdirectory(basics)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,8 +1,4 @@
-file(
-  COPY ${CMAKE_CURRENT_SOURCE_DIR}
-  DESTINATION ${CMAKE_BINARY_DIR}
-  PATTERN "Makefile" EXCLUDE
-  PATTERN "CMakeLists.txt" EXCLUDE)
+therion_copy_files(samples.tcl)
 
 add_custom_target(
   samples
@@ -17,3 +13,12 @@ add_custom_target(samples-cmake)
 
 add_subdirectory(areas)
 add_subdirectory(basics)
+add_subdirectory(cave-list)
+add_subdirectory(map-offset)
+add_subdirectory(morphing/sample1)
+add_subdirectory(morphing/sample2)
+add_subdirectory(pocket-topo)
+add_subdirectory(q-marks)
+add_subdirectory(u-symbols)
+add_subdirectory(survex)
+add_subdirectory(xelevation)

--- a/samples/areas/CMakeLists.txt
+++ b/samples/areas/CMakeLists.txt
@@ -1,3 +1,5 @@
+therion_copy_files(thconfig types.th2)
+
 add_custom_command(
     OUTPUT types.pdf
     COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig

--- a/samples/areas/CMakeLists.txt
+++ b/samples/areas/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_custom_command(
+    OUTPUT types.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+            ${CMAKE_CURRENT_BINARY_DIR}/types.th2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-area-symbols DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/types.pdf)
+add_dependencies(samples-cmake samples-area-symbols)

--- a/samples/basics/CMakeLists.txt
+++ b/samples/basics/CMakeLists.txt
@@ -1,3 +1,4 @@
+therion_copy_files(thconfig rabbit.th rabbit.th2 surface.jpg)
 therion_make_files_lists(RABBIT rabbit-plan.pdf rabbit-xelev.pdf rabbit.lox)
 
 add_custom_command(

--- a/samples/basics/CMakeLists.txt
+++ b/samples/basics/CMakeLists.txt
@@ -1,0 +1,13 @@
+therion_make_files_lists(RABBIT rabbit-plan.pdf rabbit-xelev.pdf rabbit.lox)
+
+add_custom_command(
+    OUTPUT ${RABBIT_BIN}
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+            ${CMAKE_CURRENT_BINARY_DIR}/rabbit.th
+            ${CMAKE_CURRENT_BINARY_DIR}/rabbit.th2
+            ${CMAKE_CURRENT_BINARY_DIR}/surface.jpg
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-drawing-maps DEPENDS ${RABBIT_BIN})
+add_dependencies(samples-cmake samples-drawing-maps)

--- a/samples/cave-list/CMakeLists.txt
+++ b/samples/cave-list/CMakeLists.txt
@@ -1,0 +1,10 @@
+therion_copy_files(thconfig)
+
+add_custom_command(
+    OUTPUT caves.html
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-listing-caves DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/caves.html)
+add_dependencies(samples-cmake samples-listing-caves)

--- a/samples/map-offset/CMakeLists.txt
+++ b/samples/map-offset/CMakeLists.txt
@@ -1,0 +1,17 @@
+therion_copy_files(thconfig.layout cave.th cave.th2)
+
+foreach(I RANGE 1 4)
+    therion_copy_files(thconfig.${I})
+
+    add_custom_command(
+        OUTPUT map${I}.pdf
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.${I}
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.${I}
+                ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+                ${CMAKE_CURRENT_BINARY_DIR}/cave.th
+                ${CMAKE_CURRENT_BINARY_DIR}/cave.th2
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    add_custom_target(samples-map-offset-${I} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/map${I}.pdf)
+    add_dependencies(samples-cmake samples-map-offset-${I})
+endforeach()

--- a/samples/morphing/sample1/CMakeLists.txt
+++ b/samples/morphing/sample1/CMakeLists.txt
@@ -1,0 +1,18 @@
+therion_copy_files(cave1.jpg cave1.th ../thconfig.layout)
+
+foreach(I RANGE 1 2)
+    therion_copy_files(thconfig.${I} cave${I}.th2)
+    
+    add_custom_command(
+        OUTPUT cave${I}.pdf
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.${I}
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.${I}
+                ${CMAKE_CURRENT_BINARY_DIR}/cave1.jpg
+                ${CMAKE_CURRENT_BINARY_DIR}/cave1.th
+                ${CMAKE_CURRENT_BINARY_DIR}/cave${I}.th2
+                ${CMAKE_CURRENT_BINARY_DIR}/../thconfig.layout
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    add_custom_target(samples-morphing-1-${I} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cave${I}.pdf)
+    add_dependencies(samples-cmake samples-morphing-1-${I})
+endforeach()

--- a/samples/morphing/sample2/CMakeLists.txt
+++ b/samples/morphing/sample2/CMakeLists.txt
@@ -1,0 +1,18 @@
+therion_copy_files(cave.png cave.th ../thconfig.layout)
+
+foreach(I RANGE 1 3)
+    therion_copy_files(thconfig.${I} cave${I}.th2)
+
+    add_custom_command(
+        OUTPUT cave${I}.pdf
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.${I}
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.${I}
+                ${CMAKE_CURRENT_BINARY_DIR}/cave.png
+                ${CMAKE_CURRENT_BINARY_DIR}/cave.th
+                ${CMAKE_CURRENT_BINARY_DIR}/cave${I}.th2
+                ${CMAKE_CURRENT_BINARY_DIR}/../thconfig.layout
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    add_custom_target(samples-morphing-2-${I} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cave${I}.pdf)
+    add_dependencies(samples-cmake samples-morphing-2-${I})
+endforeach()

--- a/samples/pocket-topo/CMakeLists.txt
+++ b/samples/pocket-topo/CMakeLists.txt
@@ -1,0 +1,12 @@
+therion_copy_files(thconfig demo.th)
+therion_make_files_lists(POCKET_TOPO_SAMPLES cave.3d cave.plt cave.lox cave.xvi)
+
+add_custom_command(
+    OUTPUT ${POCKET_TOPO_SAMPLES_BIN}
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+            ${CMAKE_CURRENT_BINARY_DIR}/demo.th
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-pocket-topo DEPENDS ${POCKET_TOPO_SAMPLES_BIN})
+add_dependencies(samples-cmake samples-pocket-topo)

--- a/samples/q-marks/CMakeLists.txt
+++ b/samples/q-marks/CMakeLists.txt
@@ -1,0 +1,27 @@
+therion_copy_files(thconfig.1 thconfig.2 thconfig.1.layout centerline.th map.th2)
+therion_make_files_lists(OUTPUT1 map1.pdf map2.pdf map.xvi)
+
+add_custom_command(
+    OUTPUT ${OUTPUT1_BIN}
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.1
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.1
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.1.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/centerline.th
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-q-marks-1 DEPENDS ${OUTPUT1_BIN})
+add_dependencies(samples-cmake samples-q-marks-1)
+
+therion_make_files_lists(OUTPUT2 map3.pdf map4.pdf questions.html)
+
+add_custom_command(
+    OUTPUT ${OUTPUT2_BIN}
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.2
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.2
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.1.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/centerline.th
+            ${CMAKE_CURRENT_BINARY_DIR}/map.th2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-q-marks-2 DEPENDS ${OUTPUT2_BIN})
+add_dependencies(samples-cmake samples-q-marks-2)

--- a/samples/survex/CMakeLists.txt
+++ b/samples/survex/CMakeLists.txt
@@ -1,0 +1,36 @@
+find_program(SURVEX_EXECUTABLE cavern)
+if (NOT SURVEX_EXECUTABLE)
+    message("Survex not found, samples with survex will be skipped.")
+    return()
+endif()
+
+therion_copy_files(thconfig.layout cave.svx)
+
+add_custom_command(
+    OUTPUT cave.3d
+    COMMAND ${SURVEX_EXECUTABLE} cave.svx
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cave.svx
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+foreach(I RANGE 1 2)
+    therion_copy_files(thconfig.${I} cave${I}.th)
+
+    add_custom_command(
+        OUTPUT cave${I}.pdf
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.${I}
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.${I}
+                ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+                ${CMAKE_CURRENT_BINARY_DIR}/cave${I}.th
+                ${CMAKE_CURRENT_BINARY_DIR}/cave.3d
+                samples-survex-create
+                samples-survex-ignore
+                samples-survex-use
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    add_custom_target(samples-survex-${I} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cave${I}.pdf)
+    add_dependencies(samples-cmake samples-survex-${I})
+endforeach()
+
+add_subdirectory(create)
+add_subdirectory(ignore)
+add_subdirectory(use)

--- a/samples/survex/create/CMakeLists.txt
+++ b/samples/survex/create/CMakeLists.txt
@@ -1,0 +1,20 @@
+therion_copy_files(thconfig create.th create.th2 create.svx)
+
+add_custom_command(
+    OUTPUT create.3d
+    COMMAND ${SURVEX_EXECUTABLE} create.svx
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/create.svx
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT create.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+            ${CMAKE_CURRENT_BINARY_DIR}/create.th
+            ${CMAKE_CURRENT_BINARY_DIR}/create.th2
+            ${CMAKE_CURRENT_BINARY_DIR}/create.3d
+            ${CMAKE_CURRENT_BINARY_DIR}/../thconfig.layout
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-survex-create DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/create.pdf)
+add_dependencies(samples-cmake samples-survex-create)

--- a/samples/survex/ignore/CMakeLists.txt
+++ b/samples/survex/ignore/CMakeLists.txt
@@ -1,0 +1,20 @@
+therion_copy_files(thconfig ignore.th ignore.th2 ignore.svx)
+
+add_custom_command(
+    OUTPUT ignore.3d
+    COMMAND ${SURVEX_EXECUTABLE} ignore.svx
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ignore.svx
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT ignore.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+            ${CMAKE_CURRENT_BINARY_DIR}/ignore.th
+            ${CMAKE_CURRENT_BINARY_DIR}/ignore.th2
+            ${CMAKE_CURRENT_BINARY_DIR}/ignore.3d
+            ${CMAKE_CURRENT_BINARY_DIR}/../thconfig.layout
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-survex-ignore DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ignore.pdf)
+add_dependencies(samples-cmake samples-survex-ignore)

--- a/samples/survex/use/CMakeLists.txt
+++ b/samples/survex/use/CMakeLists.txt
@@ -1,0 +1,21 @@
+therion_copy_files(thconfig use.th use-in.th2 use-out.th2 use.svx)
+
+add_custom_command(
+    OUTPUT use.3d
+    COMMAND ${SURVEX_EXECUTABLE} use.svx
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/use.svx
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT use.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig
+            ${CMAKE_CURRENT_BINARY_DIR}/use.th
+            ${CMAKE_CURRENT_BINARY_DIR}/use-in.th2
+            ${CMAKE_CURRENT_BINARY_DIR}/use-out.th2
+            ${CMAKE_CURRENT_BINARY_DIR}/use.3d
+            ${CMAKE_CURRENT_BINARY_DIR}/../thconfig.layout
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-survex-use DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/use.pdf)
+add_dependencies(samples-cmake samples-survex-use)

--- a/samples/u-symbols/CMakeLists.txt
+++ b/samples/u-symbols/CMakeLists.txt
@@ -1,0 +1,15 @@
+therion_copy_files(map.th2)
+
+foreach(I RANGE 1 2)
+    therion_copy_files(thconfig.${I})
+
+    add_custom_command(
+        OUTPUT map${I}.pdf
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.${I}
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.${I}
+                ${CMAKE_CURRENT_BINARY_DIR}/map.th2
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    add_custom_target(samples-u-symbols-${I} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/map${I}.pdf)
+    add_dependencies(samples-cmake samples-u-symbols-${I})
+endforeach()

--- a/samples/xelevation/CMakeLists.txt
+++ b/samples/xelevation/CMakeLists.txt
@@ -1,0 +1,83 @@
+therion_copy_files(
+    cave1.th
+    cave1.th2
+    cave1.xvi
+    cave2.th
+    cave3.th
+    cave3.th2
+    cave3.xvi
+    thconfig.layout
+    thconfig.1
+    thconfig.2
+    thconfig.3
+    thconfig.4
+    thconfig.5
+    thconfig.6
+    thconfig.7)
+
+add_custom_command(
+    OUTPUT map1p.pdf map1x.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.1
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.1
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave1.th
+            ${CMAKE_CURRENT_BINARY_DIR}/cave1.th2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_target(samples-xelevation-1 DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/map1p.pdf ${CMAKE_CURRENT_BINARY_DIR}/map1x.pdf)
+add_dependencies(samples-cmake samples-xelevation-1)
+
+add_custom_command(
+    OUTPUT map2.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.2
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.2
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave2.th
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT map3.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.3
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.3
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT map4.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.4
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.4
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT map5.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.5
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.5
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT map6.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.6
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.6
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT map7.pdf
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:therion> --reproducible-output thconfig.7
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/thconfig.7
+            ${CMAKE_CURRENT_BINARY_DIR}/thconfig.layout
+            ${CMAKE_CURRENT_BINARY_DIR}/cave3.th
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+foreach(I RANGE 2 7)
+    add_custom_target(samples-xelevation-${I} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/map${I}.pdf)
+    add_dependencies(samples-cmake samples-xelevation-${I})
+endforeach()


### PR DESCRIPTION
Therion samples are now individual targets in CMake, so they can run in parallel and on CI. They are run by the new build target `samples-cmake`.