### PR TITLE
UBSan samples fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,9 +6,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-18.04, type: Release,        cc: gcc,   cxx: g++,     args: ""                                            }
-          - { os: ubuntu-20.04, type: Debug,          cc: gcc,   cxx: g++,     args: "-DENABLE_CLANG_TIDY=ON"                      }
-          - { os: ubuntu-20.04, type: RelWithDebInfo, cc: clang, cxx: clang++, args: '-DECM_ENABLE_SANITIZERS="address;undefined"' }
+          - { os: ubuntu-18.04, toolchain: gcc.cmake,              args: ""                                                }
+          - { os: ubuntu-20.04, toolchain: gcc.cmake,              args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug" }
+          - { os: ubuntu-20.04, toolchain: clang-sanitizers.cmake, args: ""                                                }
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
@@ -19,16 +19,14 @@ jobs:
         run: |
           mkdir build && cd build && \
           cmake -G Ninja \
-                -DCMAKE_BUILD_TYPE=${{ matrix.type }} \
-                -DCMAKE_C_COMPILER=${{ matrix.cc }} \
-                -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+                -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/${{ matrix.toolchain }} \
                 -DCMAKE_CXX_FLAGS="-Werror" \
                 -DUSE_BUNDLED_SHAPELIB=OFF \
                 ${{ matrix.args }} ..
       - run: cmake --build build
       - run: cmake --build build -t test
       - name: Run samples
-        if: matrix.type == 'RelWithDebInfo'
+        if: matrix.toolchain == 'clang-sanitizers.cmake'
         run: cmake --build build -t samples-cmake
 
   macOS:

--- a/cmake/toolchains/clang-sanitizers.cmake
+++ b/cmake/toolchains/clang-sanitizers.cmake
@@ -1,0 +1,7 @@
+# Clang + ASan + UBSan + optimizations + debug symbols
+
+include(${CMAKE_CURRENT_LIST_DIR}/clang.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/sanitizers.cmake)
+
+# Optimizations help to uncover bugs, debug symbols make reports from sanitizers readable.
+set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build.")

--- a/cmake/toolchains/clang.cmake
+++ b/cmake/toolchains/clang.cmake
@@ -1,0 +1,7 @@
+# Set Clang as a compiler.
+
+find_program(CMAKE_C_COMPILER clang)
+find_program(CMAKE_CXX_COMPILER clang++)
+
+set(CMAKE_C_COMPILER "${CMAKE_C_COMPILER}" CACHE STRING "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER "${CMAKE_CXX_COMPILER}" CACHE STRING "C++ compiler" FORCE)

--- a/cmake/toolchains/gcc.cmake
+++ b/cmake/toolchains/gcc.cmake
@@ -1,0 +1,7 @@
+# Set GCC as a compiler.
+
+find_program(CMAKE_C_COMPILER gcc)
+find_program(CMAKE_CXX_COMPILER g++)
+
+set(CMAKE_C_COMPILER "${CMAKE_C_COMPILER}" CACHE STRING "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER "${CMAKE_CXX_COMPILER}" CACHE STRING "C++ compiler" FORCE)

--- a/cmake/toolchains/sanitizers.cmake
+++ b/cmake/toolchains/sanitizers.cmake
@@ -1,7 +1,7 @@
 # Enable sanitizers.
 
 # Fail on errors.
-set(CMAKE_C_FLAGS_INIT "-fno-sanitize-recover")
-set(CMAKE_CXX_FLAGS_INIT "-fno-sanitize-recover")
+set(CMAKE_C_FLAGS_INIT "-fno-sanitize-recover=all")
+set(CMAKE_CXX_FLAGS_INIT "-fno-sanitize-recover=all")
 # ASan and UBSan can be run together.
 set(ECM_ENABLE_SANITIZERS "address;undefined" CACHE STRING "Enable runtime sanitizers, available options: address,memory,thread,leak,undefined." )

--- a/cmake/toolchains/sanitizers.cmake
+++ b/cmake/toolchains/sanitizers.cmake
@@ -1,0 +1,7 @@
+# Enable sanitizers.
+
+# Fail on errors.
+set(CMAKE_C_FLAGS_INIT "-fno-sanitize-recover")
+set(CMAKE_CXX_FLAGS_INIT "-fno-sanitize-recover")
+# ASan and UBSan can be run together.
+set(ECM_ENABLE_SANITIZERS "address;undefined" CACHE STRING "Enable runtime sanitizers, available options: address,memory,thread,leak,undefined." )

--- a/extern/img.c
+++ b/extern/img.c
@@ -98,9 +98,9 @@ static INT32_T
 get32(FILE *fh)
 {
    INT32_T w = GETC(fh);
-   w |= (INT32_T)GETC(fh) << 8l;
-   w |= (INT32_T)GETC(fh) << 16l;
-   w |= (INT32_T)GETC(fh) << 24l;
+   w |= (unsigned int)GETC(fh) << 8l;
+   w |= (unsigned int)GETC(fh) << 16l;
+   w |= (unsigned int)GETC(fh) << 24l;
    return w;
 }
 

--- a/thattr.h
+++ b/thattr.h
@@ -143,7 +143,7 @@ struct thattr {
   size_t m_num_fields,  ///< Number of fields.
     m_num_objects;  ///< Number of objects.
 
-  bool m_tree; ///< Whether table has a tree structure.
+  bool m_tree = false; ///< Whether table has a tree structure.
 
   thattr_obj_list m_obj_list;  ///< List of objects.
   thattr_id2obj_map m_obj_map;  ///< ID -> Object map.


### PR DESCRIPTION
Fixed warnings from UBSan:
* shift of signed number:
```
UndefinedBehaviorSanitizer: undefined-behavior
../extern/img.c:103:27: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
```
* uninitialized variable:
```
UndefinedBehaviorSanitizer: undefined-behavior
../thattr.cxx:756:11: runtime error: load of value 190, which is not a valid value for type 'bool'
```