### PR TITLE
Type safe thdatabase::create()

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone-reserved-identifier'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone-reserved-identifier,bugprone-use-after-move'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -71,16 +71,14 @@ const char * thlibrarydata_init_text =
 const char * thlibrarydata_grades_text =
   "void thlibrary_init_grades()\n"
   "{\n"
-  "\tstd::unique_ptr<thdataobject> unique_grade;\n"
-  "\tthgrade * pgrade;\n"
+  "\tstd::unique_ptr<thgrade> pgrade;\n"
   "\tthbuffer oname;\n";
 
 
 const char * thlibrarydata_layouts_text =
   "void thlibrary_init_layouts()\n"
   "{\n"
-  "\tstd::unique_ptr<thdataobject> unique_layout;\n"
-  "\tthlayout * playout;\n"
+  "\tstd::unique_ptr<thlayout> playout;\n"
   "\tthbuffer oname;\n";
 
 
@@ -147,8 +145,8 @@ void thdatabase::clear()
   this->reset_context();
 
   // create top level survey
-  auto top = this->create("survey",thobjectsrc("error",0));
-  dynamic_cast<thsurvey*>(top.get())->name = "";
+  auto top = this->create<thsurvey>(thobjectsrc("error",0));
+  top->name = "";
   this->insert(std::move(top));
 
 }
@@ -467,103 +465,58 @@ bool thdatabase::insert_datastation(thobjectname on, thsurvey * ps)
 std::unique_ptr<thdataobject> thdatabase::create(const char * oclass, 
   thobjectsrc osrc)
 {
-  int tclass = thmatch_token(oclass, thtt_commands);
-  std::unique_ptr<thdataobject> ret;
-  std::unique_ptr<thdata> retdata;
-  switch (tclass) {
-  
+  switch (thmatch_token(oclass, thtt_commands)) {
     case TT_SURVEY_CMD:
-      ret = std::make_unique<thsurvey>();
-      retdata = std::make_unique<thdata>();
-      break;
-      
+      return create<thsurvey>(osrc);
+
     case TT_ENDSURVEY_CMD:
-      ret = std::make_unique<thendsurvey>();
-      break;
-      
+      return create<thendsurvey>(osrc);
+
     case TT_SCRAP_CMD:
-      ret = std::make_unique<thscrap>();
-      break;
-      
+      return create<thscrap>(osrc);
+
     case TT_ENDSCRAP_CMD:
-      ret = std::make_unique<thendscrap>();
-      break;
+      return create<thendscrap>(osrc);
       
     case TT_DATA_CMD:
-      ret = std::make_unique<thdata>();
-      break;
+      return create<thdata>(osrc);
       
     case TT_COMMENT_CMD:
-      ret = std::make_unique<thcomment>();
-      break;
+      return create<thcomment>(osrc);
       
     case TT_GRADE_CMD:
-      ret = std::make_unique<thgrade>();
-      break;
+      return create<thgrade>(osrc);
       
     case TT_LAYOUT_CMD:
-      ret = std::make_unique<thlayout>();
-      break;
+      return create<thlayout>(osrc);
       
     case TT_LOOKUP_CMD:
-      ret = std::make_unique<thlookup>();
-      break;
+      return create<thlookup>(osrc);
 
     case TT_POINT_CMD:
-      ret = std::make_unique<thpoint>();
-      break;
+      return create<thpoint>(osrc);
       
     case TT_LINE_CMD:
-      ret = std::make_unique<thline>();
-      break;
+      return create<thline>(osrc);
       
     case TT_AREA_CMD:
-      ret = std::make_unique<tharea>();
-      break;
+      return create<tharea>(osrc);
       
     case TT_JOIN_CMD:
-      ret = std::make_unique<thjoin>();
-      break;
+      return create<thjoin>(osrc);
       
     case TT_MAP_CMD:
-      ret = std::make_unique<thmap>();
-      break;
+      return create<thmap>(osrc);
       
     case TT_IMPORT_CMD:
-      ret = std::make_unique<thimport>();
-      break;
+      return create<thimport>(osrc);
       
     case TT_SURFACE_CMD:
-      ret = std::make_unique<thsurface>();
-      break;
-  }
-  
-  if (ret != NULL) {
-    ret->assigndb(this);
-    // set object id and mark revision
-    ret->id = ++this->objid;
-    this->attr.insert_object((void *) ret.get(), (long) ret->id);
-		ret->source = osrc;
-    this->revision_set.insert(threvision(ret->id, 0, osrc));
-  }
-  
-  if (retdata != NULL) {
-    retdata->assigndb(this);    
-    // set object id and mark revision
-    retdata->id = ++this->objid;
-		retdata->source = osrc;
-    this->revision_set.insert(threvision(retdata->id, 0, osrc));
-  }
+      return create<thsurface>(osrc);
 
-  switch (tclass) {
-    case TT_SURVEY_CMD:
-      auto* survey = dynamic_cast<thsurvey*>(ret.get());
-      survey->data = retdata.get();
-      survey->tmp_data_holder = std::move(retdata);
-      break;
+    default:
+      return nullptr;
   }
-  
-  return ret;
 }
 
 
@@ -763,11 +716,10 @@ void thdatabase::self_print_library()
   thprintf(thlibrarydata_grades_text);
   thdb_grade_map_type::iterator gi = this->grade_map.begin();
   while (gi != this->grade_map.end()) {
-    thprintf("\n\tunique_grade = thdb.create(\"grade\", thobjectsrc(\"therion\",0));\n");
-    thprintf("\tpgrade = dynamic_cast<thgrade*>(unique_grade.get());\n");
+    thprintf("\n\tpgrade = thdb.create<thgrade>(thobjectsrc(\"therion\",0));\n");
     ((thgrade *)(gi->second))->self_print_library();
     gi++;
-    thprintf("\tthdb.insert(std::move(unique_grade));\n");
+    thprintf("\tthdb.insert(std::move(pgrade));\n");
   }
   thprintf("}\n\n");
 
@@ -775,11 +727,10 @@ void thdatabase::self_print_library()
   thprintf(thlibrarydata_layouts_text);
   thdb_layout_map_type::iterator li = this->layout_map.begin();
   while (li != this->layout_map.end()) {
-    thprintf("\n\tunique_layout = thdb.create(\"layout\", thobjectsrc(\"therion\",0));\n");
-    thprintf("\tplayout = dynamic_cast<thlayout*>(unique_layout.get());\n");
+    thprintf("\n\tplayout = thdb.create<thlayout>(thobjectsrc(\"therion\",0));\n");
     ((thlayout *)(li->second))->self_print_library();
     li++;
-    thprintf("\tthdb.insert(std::move(unique_layout));\n");
+    thprintf("\tthdb.insert(std::move(playout));\n");
   }
   thprintf("}\n\n");
   
@@ -926,6 +877,19 @@ void thdatabase::insert_equate(int nargs, char ** args)
   this->csurveyptr->data->set_data_equate(nargs, args);
 }
 
+
+void thdatabase::add_data(thsurvey& survey, const thobjectsrc& osrc)
+{
+  auto retdata = std::make_unique<thdata>();
+  retdata->assigndb(this);    
+  // set object id and mark revision
+  retdata->id = ++this->objid;
+  retdata->source = osrc;
+  this->revision_set.insert(threvision(retdata->id, 0, osrc));
+
+  survey.data = retdata.get();
+  survey.tmp_data_holder = std::move(retdata);
+}
 
 
 

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -878,17 +878,20 @@ void thdatabase::insert_equate(int nargs, char ** args)
 }
 
 
-void thdatabase::add_data(thsurvey& survey, const thobjectsrc& osrc)
+void thdatabase::add_data(thdataobject* obj, const thobjectsrc& osrc)
 {
-  auto retdata = std::make_unique<thdata>();
-  retdata->assigndb(this);    
-  // set object id and mark revision
-  retdata->id = ++this->objid;
-  retdata->source = osrc;
-  this->revision_set.insert(threvision(retdata->id, 0, osrc));
+  if (auto* survey = dynamic_cast<thsurvey*>(obj))
+  {
+    auto retdata = std::make_unique<thdata>();
+    retdata->assigndb(this);    
+    // set object id and mark revision
+    retdata->id = ++this->objid;
+    retdata->source = osrc;
+    this->revision_set.insert(threvision(retdata->id, 0, osrc));
 
-  survey.data = retdata.get();
-  survey.tmp_data_holder = std::move(retdata);
+    survey->data = retdata.get();
+    survey->tmp_data_holder = std::move(retdata);
+  }
 }
 
 

--- a/thdatabase.h
+++ b/thdatabase.h
@@ -379,21 +379,11 @@ class thdatabase {
 
 private:
   /**
-   * @brief add thdata to the new thsurvey object
-   * @param survey new survey object
+   * @brief adds thdata if the object is thsurvey
+   * @param obj new object
    * @param osrc source info
    */
-  void add_data(thsurvey& survey, const thobjectsrc& osrc);
-
-  /**
-   * @brief helper template, do nothing for other types than thsurvey
-   */
-  template <typename T>
-  void add_data(const T&, const thobjectsrc&)
-  {
-    static_assert(!std::is_same<T, thsurvey>::value, "wrong method chosen by overloading");
-    // noop for types other than thsurvey
-  }
+  void add_data(thdataobject* obj, const thobjectsrc& osrc);
 };
 
 // Template definition must be available in a header file.
@@ -411,7 +401,9 @@ std::unique_ptr<T> thdatabase::create(const thobjectsrc& osrc)
   ret->source = osrc;
   this->revision_set.insert(threvision(ret->id, 0, osrc));
 
-  add_data(*ret, osrc);
+  // add thdata if the object is thsurvey
+  add_data(ret.get(), osrc);
+
   return ret;
 }
 

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -2481,8 +2481,8 @@ void thdb2d::pp_process_joins(thdb2dprj * prj)
           (jci->pt->y == njci->pt->y)) {
          // add automatic join here
         {
-          auto unique_tjptr = thdb.create("join",thobjectsrc());
-          tjptr = dynamic_cast<thjoin*>(unique_tjptr.get());
+          auto unique_tjptr = thdb.create<thjoin>(thobjectsrc());
+          tjptr = unique_tjptr.get();
           thdb.insert(std::move(unique_tjptr));
         }
         tjptr->proj = jci->obj->fscrapptr->proj;
@@ -2653,16 +2653,16 @@ void thdb2d::pp_process_joins(thdb2dprj * prj)
                 fse2->l2->id, fse2->lp2->point->xt, fse2->lp2->point->yt);
 #endif
             {
-              auto unique_tjptr = thdb.create("join",thobjectsrc());
-              tjptr = dynamic_cast<thjoin*>(unique_tjptr.get());
+              auto unique_tjptr = thdb.create<thjoin>(thobjectsrc());
+              tjptr = unique_tjptr.get();
               thdb.insert(std::move(unique_tjptr));
             }
             tjptr->proj = jptr->proj;
             tjptr->smooth = jptr->smooth;
             tjptr->proj_prev_join = jptr;
             {
-              auto unique_join = thdb.create("join",thobjectsrc());
-              tjptr->proj_next_join = dynamic_cast<thjoin*>(unique_join.get());
+              auto unique_join = thdb.create<thjoin>(thobjectsrc());
+              tjptr->proj_next_join = unique_join.get();
               thdb.insert(std::move(unique_join));
             }
             tjptr->proj_next_join->proj_prev_join = tjptr;
@@ -3686,6 +3686,7 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
       cln->fsptr = carea->fsptr;
       cln->type = TT_LINE_TYPE_BORDER;
       ti->area->m_outline_line = std::move(cln);
+      cln = nullptr; // silence static analysis about reused moved-from variable
       //cln->preprocess();
 
       // increase area counter

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -3426,7 +3426,7 @@ void thexpmap::export_pdf_set_colors_new(class thdb2dxm * maps, class thdb2dprj 
 {
 
   // parsneme lookup a najdeme ho
-  std::unique_ptr<thdataobject> unique_lkp;
+  std::unique_ptr<thlookup> unique_lkp;
   thlookup * lkp = NULL;
   if (this->layout->color_crit_fname != NULL) {
     int cc;
@@ -3438,8 +3438,8 @@ void thexpmap::export_pdf_set_colors_new(class thdb2dxm * maps, class thdb2dprj 
       if (strlen(ccidx) > 0) {
         thwarning(("missing lookup -- %s", this->layout->color_crit_fname));
       }
-      unique_lkp = this->db->create("lookup", this->src);
-      lkp = dynamic_cast<thlookup*>(unique_lkp.get());
+      unique_lkp = this->db->create<thlookup>(this->src);
+      lkp = unique_lkp.get();
       lkp->m_type = this->layout->color_crit;
     }
   }
@@ -3558,7 +3558,7 @@ void thexpmap::export_pdf_set_colors_new(class thdb2dxm * maps, class thdb2dprj 
     cmap = cmap->next_item;
   }
 
-  lkp->export_color_legend(this->layout, std::unique_ptr<thlookup>(dynamic_cast<thlookup*>(unique_lkp.release())));
+  lkp->export_color_legend(this->layout, std::move(unique_lkp));
 
 }
 

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -324,8 +324,8 @@ const char * thimport::station_name(const char * sn, const char separator, struc
               this->db->ccontext = THCTX_SURVEY;
 
               {
-                auto unique_nsurvey = this->db->create("survey", this->mysrc);
-                nsurvey = dynamic_cast<thsurvey*>(unique_nsurvey.get());
+                auto unique_nsurvey = this->db->create<thsurvey>(this->mysrc);
+                nsurvey = unique_nsurvey.get();
                 // TODO - nastavit mu meno cez set
                 nsurvey->name = this->db->strstore(cbf[active_survey]);
                 this->db->insert(std::move(unique_nsurvey));

--- a/thlibrarydata.cxx
+++ b/thlibrarydata.cxx
@@ -16,12 +16,10 @@
 
 void thlibrary_init_grades()
 {
-	std::unique_ptr<thdataobject> unique_grade;
-	thgrade * pgrade;
+	std::unique_ptr<thgrade> pgrade;
 	thbuffer oname;
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "BCRA3";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "BCRA grade 3";
@@ -37,10 +35,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = 0.25;
 	pgrade->dls_y = 0.25;
 	pgrade->dls_z = 0.25;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "BCRA5";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "BCRA grade 5";
@@ -56,10 +53,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = 0.05;
 	pgrade->dls_y = 0.05;
 	pgrade->dls_z = 0.05;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_-1";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 ungraded survey without map";
@@ -75,10 +71,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_0";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 ungraded survey";
@@ -94,10 +89,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_1";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 1";
@@ -113,10 +107,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_2";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 2";
@@ -132,10 +125,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_3";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 3";
@@ -151,10 +143,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_4";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 4";
@@ -170,10 +161,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_5";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 5";
@@ -189,10 +179,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_6";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade 6";
@@ -208,10 +197,9 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 
-	unique_grade = thdb.create("grade", thobjectsrc("therion",0));
-	pgrade = dynamic_cast<thgrade*>(unique_grade.get());
+	pgrade = thdb.create<thgrade>(thobjectsrc("therion",0));
 	oname = "UISv1_X";
 	pgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);
 	oname = "UISv1 survey grade X";
@@ -227,17 +215,15 @@ void thlibrary_init_grades()
 	pgrade->dls_x = thnan;
 	pgrade->dls_y = thnan;
 	pgrade->dls_z = thnan;
-	thdb.insert(std::move(unique_grade));
+	thdb.insert(std::move(pgrade));
 }
 
 void thlibrary_init_layouts()
 {
-	std::unique_ptr<thdataobject> unique_layout;
-	thlayout * playout;
+	std::unique_ptr<thlayout> playout;
 	thbuffer oname;
 
-	unique_layout = thdb.create("layout", thobjectsrc("therion",0));
-	playout = dynamic_cast<thlayout*>(unique_layout.get());
+	playout = thdb.create<thlayout>(thobjectsrc("therion",0));
 	oname = "AUT";
 	playout->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,TT_UTF_8,0);
 	oname = "Austrian symbol set";
@@ -316,6 +302,10 @@ void thlibrary_init_layouts()
 	playout->explo_lens = 2;
 	playout->def_topo_lens = 0;
 	playout->topo_lens = 2;
+	playout->def_carto_lens = 0;
+	playout->carto_lens = 2;
+	playout->def_copy_lens = 0;
+	playout->copy_lens = 2;
 	playout->def_lang = 0;
 	playout->lang = THLANG_EN;
 	playout->def_units = 0;
@@ -395,10 +385,9 @@ void thlibrary_init_layouts()
 	playout->last_line->smid = SYMX_ICE;
 	playout->last_line->sclr = thlayout_color(0.000000,0.680000,0.940000);
 	playout->def_tex_lines = 2;
-	thdb.insert(std::move(unique_layout));
+	thdb.insert(std::move(playout));
 
-	unique_layout = thdb.create("layout", thobjectsrc("therion",0));
-	playout = dynamic_cast<thlayout*>(unique_layout.get());
+	playout = thdb.create<thlayout>(thobjectsrc("therion",0));
 	oname = "SCR200";
 	playout->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,TT_UTF_8,0);
 	oname = "Computer screen layout";
@@ -477,6 +466,10 @@ void thlibrary_init_layouts()
 	playout->explo_lens = 2;
 	playout->def_topo_lens = 0;
 	playout->topo_lens = 2;
+	playout->def_carto_lens = 0;
+	playout->carto_lens = 2;
+	playout->def_copy_lens = 0;
+	playout->copy_lens = 2;
 	playout->def_lang = 0;
 	playout->lang = THLANG_EN;
 	playout->def_units = 0;
@@ -539,6 +532,6 @@ void thlibrary_init_layouts()
 	oname = "SKBB";
 	playout->set(thcmd_option_desc(TT_LAYOUT_SYMBOL_DEFAULTS,1),oname,TT_UTF_8,0);
 	playout->def_tex_lines = 2;
-	thdb.insert(std::move(unique_layout));
+	thdb.insert(std::move(playout));
 }
 


### PR DESCRIPTION
New method `thdatabase::create<T>()` can return a specific instance of an object, not just its base class. This helps to remove unchecked dynamic casts.