### PR TITLE
Deleted unsupported special methods

### DIFF
--- a/thbuffer.h
+++ b/thbuffer.h
@@ -60,6 +60,10 @@ class thbuffer {
   
   thbuffer();
   
+  // Only copy assignment is implemented.
+  thbuffer(const thbuffer&) = delete;
+  thbuffer(thbuffer&&) = delete;
+  thbuffer& operator=(thbuffer&&) = delete;
   
   /**
    * Destructor.

--- a/thexport.h
+++ b/thexport.h
@@ -93,6 +93,12 @@ class thexport {
   thexport();  ///< Default constructor.
   virtual ~thexport();
   
+  // These operations are not implemented.
+  thexport(const thexport&) = delete;
+  thexport(thexport&&) = delete;
+  thexport& operator=(const thexport&) = delete; 
+  thexport& operator=(thexport&&) = delete; 
+  
   void assign_config(class thconfig * cptr); ///< ???
   
   /**

--- a/thmbuffer.h
+++ b/thmbuffer.h
@@ -72,6 +72,12 @@ class thmbuffer {
      */
      
     ~mblock();
+
+    // These operations are not implemented.
+    mblock(const mblock&) = delete;
+    mblock(mblock&&) = delete;
+    mblock& operator=(const mblock&) = delete; 
+    mblock& operator=(mblock&&) = delete; 
   };
 
   mblock * first_ptr,  ///< Pointer to the first memory block.
@@ -86,6 +92,11 @@ class thmbuffer {
   
   thmbuffer();
   
+  // These operations are not implemented.
+  thmbuffer(const thmbuffer&) = delete;
+  thmbuffer(thmbuffer&&) = delete;
+  thmbuffer& operator=(const thmbuffer&) = delete; 
+  thmbuffer& operator=(thmbuffer&&) = delete; 
   
   /**
    * Destructor.
@@ -133,7 +144,7 @@ class thmbuffer {
    
   char ** get_buffer();
   
-  
+
 };
 
 #endif

--- a/thtrans.h
+++ b/thtrans.h
@@ -258,6 +258,10 @@ struct thmorph2trans {
 
   thmorph2trans();
   ~thmorph2trans();
+  thmorph2trans(const thmorph2trans&) = delete;
+  thmorph2trans(thmorph2trans&&) = delete;
+  thmorph2trans& operator=(const thmorph2trans&) = delete; 
+  thmorph2trans& operator=(thmorph2trans&&) = delete; 
   void reset();
   void insert_point(thvec2 src, thvec2 dst, long id);
   void insert_line(long from, long to);


### PR DESCRIPTION
Removed some implicitly generated constructors and assignment operators, because they could cause memory issues.