### PR TITLE
Removed unnecessary destructor

### DIFF
--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -126,11 +126,6 @@ thdatabase::thdatabase()
   this->db2d.assigndb(this);
 }
 
-thdatabase::~thdatabase()
-{
-  this->clear(); 
-}
-
 void thdatabase::clear()
 {
 

--- a/thdatabase.h
+++ b/thdatabase.h
@@ -205,13 +205,6 @@ class thdatabase {
   
   
   /**
-   * Standard destructor.
-   */
-   
-  ~thdatabase();
-  
-  
-  /**
    * Clear the contents of the database.
    */
    


### PR DESCRIPTION
Removed destructor `~thdatabase()`, because the default one is just fine, and static analysis complained about possibly uncaught exception.