### PR TITLE
Initialize member variables

### DIFF
--- a/loch/lxData.h
+++ b/loch/lxData.h
@@ -82,7 +82,7 @@ struct lxDataStation {
 
 struct lxDataTexture {
   double dx, dy, xx, xy, yx, yy, iw, ih;
-  unsigned texSizeS, texSizeO;
+  unsigned texSizeS = 0, texSizeO = 0;
   lxImageRGB image;
   unsigned char * texS, * texSbw, * texO, * texObw;
   lxDataTexture() : dx(0.0), dy(0.0), xx(1.0), xy(0.0), yx(0.0), yy(1.0), iw(1.0), ih(1.0), 

--- a/loch/lxFile.h
+++ b/loch/lxFile.h
@@ -49,22 +49,22 @@ typedef char * lxFileBuff;
 
 
 struct lxFileSize {
-  lxFileSizeT m_size;
+  lxFileSizeT m_size = 0;
   operator lxFileSizeT & () {return this->m_size;}
   lxFileSizeT & operator = (const lxFileSizeT & right) {return this->m_size = right;}
   lxFileSizeT Save(lxFileBuff & ptr);
   lxFileSizeT Load(lxFileBuff & ptr);
-  lxFileSize() : m_size(0) {}
+  lxFileSize() = default;
 };
 
 
 struct lxFileDbl {
-  double m_num;
+  double m_num = 0.0;
   operator double & () {return this->m_num;}
   double & operator = (const double & right) {return this->m_num = right;}
   lxFileSizeT Save(lxFileBuff & ptr);
   lxFileSizeT Load(lxFileBuff & ptr);
-  lxFileDbl() : m_num(0.0) {}
+  lxFileDbl() = default;
 };
 
 

--- a/loch/lxGLC.h
+++ b/loch/lxGLC.h
@@ -77,15 +77,15 @@ class lxGLCanvas: public wxGLCanvas {
 
     ~lxGLCanvas();
 
-    GLuint m_idTexSurface, m_idTexStation, m_initTextures;
+    GLuint m_idTexSurface = 0, m_idTexStation = 0, m_initTextures;
 
     // screen funkcie a premenne
     GLuint m_sList, m_oList, m_sFixList, m_sEntList, m_sStList,
       m_oFixList, m_oEntList, m_oStList;
     int m_sMoveLock;
-    double m_indRes, m_indLWidth;
+    double m_indRes = 0.0, m_indLWidth = 0.0;
     bool m_sInit, m_sInitReset;
-    bool m_sMoveSingle, m_isO;
+    bool m_sMoveSingle = false, m_isO;
 
     // fonty
     FT_Face m_ftFace1, m_ftFace2, m_ftFace3;
@@ -101,7 +101,7 @@ class lxGLCanvas: public wxGLCanvas {
 		bool m_sCameraAutoRotate, m_sCameraLockRotation;
     wxStopWatch m_sCameraAutoRotateSWatch;
     long m_sCameraAutoRotateCounter;
-    double m_sCameraAutoRotateAngle, m_sCameraStartAutoRotateAngle;
+    double m_sCameraAutoRotateAngle, m_sCameraStartAutoRotateAngle = 0.0;
 
     void OnPaint(wxPaintEvent& event);
     void OnSize(wxSizeEvent& event);

--- a/loch/lxLRUD.cxx
+++ b/loch/lxLRUD.cxx
@@ -150,9 +150,9 @@ enum {
 struct xcSeriesArrow {
   xcNodeArrow arrow;
   xcSeriesArrow * next, * prev;
-  int fType, tType, fXMin, tXMin;
+  int fType = 0, tType = 0, fXMin = 0, tXMin = 0;
   lxVec f, t, ft, sDir, uDir, rDir, fDir, nfDir, tDir, ntDir;
-  double fDist, tDist;
+  double fDist = 0.0, tDist = 0.0;
   lxTriGeomPoint fp[9], tp[9], nfp[9], ntp[9];
   lxPlane fPlane, tPlane, nfPlane, ntPlane;
   xcSeriesArrow() : next(NULL), prev(NULL) {}

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -1563,7 +1563,7 @@ namespace OGLFT {
   protected:
     //! Raster glyph can be rotated in the Z plane (in addition to the string
     //! rotation).
-    GLfloat character_rotation_z_;
+    GLfloat character_rotation_z_ = 0.0;
   public:
     /*!
      * \param filename the filename which contains the font face.
@@ -1803,11 +1803,11 @@ namespace OGLFT {
   protected:
     //! Angle of rotation of characters relative to text orientation.
     struct {
-      bool active_; //!< Is character rotation non-zero? (faster than checking all
+      bool active_ = false; //!< Is character rotation non-zero? (faster than checking all
 		    //!< the other values.)
-      GLfloat x_,   //!< Angle of rotation in the X direction.
-	y_,	    //!< Angle of rotation in the Y direction.
-	z_;	    //!< Angle of rotation in the Z direction.
+      GLfloat x_ = 0.0,   //!< Angle of rotation in the X direction.
+	            y_ = 0.0,   //!< Angle of rotation in the Y direction.
+	            z_ = 0.0;   //!< Angle of rotation in the Z direction.
     } character_rotation_;
 
     /*!

--- a/loch/lxOptDlg.cxx
+++ b/loch/lxOptDlg.cxx
@@ -22,7 +22,7 @@ class lxOptionsDlg : public wxDialog {
 
 public:
 
-  long tmp;
+  long tmp = 0;
   lxFrame * m_lxframe;
 
   lxOptionsDlg(wxWindow * parent);

--- a/loch/lxRender.h
+++ b/loch/lxRender.h
@@ -22,7 +22,7 @@ enum {
 struct lxRenderData {
 
 	long m_scaleMode;
-  bool m_printRenderer, 
+  bool m_printRenderer = false, 
 		m_imgWhiteBg,
     m_askFName;
 
@@ -33,8 +33,8 @@ struct lxRenderData {
 		m_imgResolution,
     m_imgWidth, 
 		m_imgHeight,
-		m_imgPixW,
-		m_imgPixH;
+		m_imgPixW = 0.0,
+		m_imgPixH = 0.0;
 
   lxRenderData();
 

--- a/loch/lxSetup.h
+++ b/loch/lxSetup.h
@@ -39,8 +39,8 @@ struct lxSetup {
   lxVec cam_center, cam_pos,
     cam_orig_center, cam_orig_pos;
   int cam_anaglyph_glasses, m_colormd;
-  double cam_dist, cam_dir, cam_tilt, cam_width,
-    cam_orig_dist, cam_orig_dir, cam_orig_tilt, cam_lens, cam_lens_vfov, cam_lens_vfovr, cam_anaglyph_eyesep,
+  double cam_dist = 0.0, cam_dir, cam_tilt, cam_width = 0.0,
+    cam_orig_dist = 0.0, cam_orig_dir = 0.0, cam_orig_tilt = 0.0, cam_lens, cam_lens_vfov, cam_lens_vfovr, cam_anaglyph_eyesep,
     data_limits_diam;
   bool cam_persp, cam_anaglyph, cam_anaglyph_bw, cam_anaglyph_left;
 

--- a/thdataobject.h
+++ b/thdataobject.h
@@ -254,12 +254,12 @@ class thdataobject {
   unsigned long id;  ///< Object identifier.
   
   bool selected,  ///< Whether object is selected.
-    tmp_bool;  ///< Temporary variable for some algorithms
+    tmp_bool = false;  ///< Temporary variable for some algorithms
 
   thlayout_color selected_color; ///< Selection color.
     
   unsigned long selected_number,  ///< Number of selection.
-    tmp_ulong;  ///< Temporary variable for some algorithms
+    tmp_ulong = 0;  ///< Temporary variable for some algorithms
   
   thdataobject * nsptr,  ///< Next object in survey.
     * psptr;  ///< Previous object in survey.

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -85,7 +85,7 @@ class thprjx_scrap {
   
   thprjx_link * via_link;
   
-  double viacpx, viacpy, viacpz;
+  double viacpx = 0.0, viacpy = 0.0, viacpz = 0.0;
   
   thprjx_link * first_link, * last_link;
   

--- a/thepsparse.cxx
+++ b/thepsparse.cxx
@@ -208,10 +208,6 @@ std::string PL(std::string s) {
   return  t + "\n";
 }
 
-MP_data::MP_data () {
-  idx = 0;
-}
-
 void MP_text::clear() {
   x = y = 0;
   xx = yy = 1;
@@ -771,10 +767,6 @@ void converted_data::print_pdf(std::ofstream & F, std::string name) {
 void converted_data::clear() {
   MP.clear();
   fonts.clear();
-}
-
-converted_data::converted_data() {
-  clear();
 }
 
 

--- a/thepsparse.h
+++ b/thepsparse.h
@@ -53,9 +53,9 @@ struct color{
 struct CGS {  // current graphics state
   color col;
   int linejoin, linecap;
-  float miterlimit, linewidth;
+  float miterlimit = 0.0, linewidth = 0.0;
   std::list<float> dasharray;
-  float dashoffset;
+  float dashoffset = 0.0;
   std::string pattern;
   
   std::map<int,int> clippathdepth;
@@ -145,7 +145,7 @@ struct MP_data {
   std::vector<MP_setting> settings;
   std::vector<MP_transform> transforms;
   
-  int idx;
+  int idx = 0;
   
   CGS gstate;
   
@@ -159,7 +159,7 @@ struct MP_data {
   void get();
   void pop();
   
-  MP_data();
+  MP_data() = default;
   void clear();
   
   void print_svg(std::ofstream & F, std::string prefix);
@@ -171,8 +171,8 @@ struct converted_data {
   std::set<std::string> fonts, patterns;
   bool transparency = false;
 //  double hsize, vsize;
-  double llx, lly, urx, ury;
-  int mode;     // conversion mode
+  double llx = 0.0, lly = 0.0, urx = 0.0, ury = 0.0;
+  int mode = 0; // conversion mode
                 //    0 patterns
                 //   10 F (see thpdfdata.h, scraprecord)
                 //   11 G
@@ -184,7 +184,7 @@ struct converted_data {
                 //   31 north arrow, scale bar
                 //   101-109 grid
   void clear();
-  converted_data();
+  converted_data() = default;
   void print_svg(std::ofstream & F, std::string prefix="");
   void print_pdf(std::ofstream & F, std::string);
 };

--- a/thinit.h
+++ b/thinit.h
@@ -53,7 +53,7 @@ class thinit {
 
   public:  
 
-  int encoding_default, encoding_sql;  ///< Default encoding.
+  int encoding_default = 0, encoding_sql = 0;  ///< Default encoding.
     
   thbuffer path_cavern, ///< Survex executable full path.
     path_pdftex, path_mpost,  ///< PDF tex and metapost path

--- a/thinput.h
+++ b/thinput.h
@@ -88,7 +88,7 @@ class thinput {
 #ifdef THMSVC
     struct _stat st;const char * thinput::get_cif_abspath()
 #else
-    struct stat st;
+    struct stat st{};
 #endif
       
     

--- a/thpdfdata.h
+++ b/thpdfdata.h
@@ -101,22 +101,22 @@ struct layout {
   bool  excl_pages,title_pages,page_numbering,
         transparency,map_grid,OCG,map_header_bg,colored_text,transparent_map_bg; 
   double hsize,vsize,overlap,
-        hgridsize, vgridsize,
-        hgridorigin, vgridorigin, gridrot,
-        nav_factor, XS,YS,XO,YO;
+        hgridsize = 0.0, vgridsize = 0.0,
+        hgridorigin, vgridorigin, gridrot = 0.0,
+        nav_factor, XS = 0.0, YS = 0.0, XO = 0.0, YO = 0.0;
   int nav_right,nav_up,own_pages,lang,legend_columns;
-  double hoffset, voffset, opacity, legend_width;
+  double hoffset, voffset, opacity = 0.0, legend_width;
   color col_background, col_foreground, col_preview_below, col_preview_above;
-  colormodel output_colormodel;
+  colormodel output_colormodel = {};
   
-  int surface, grid, proj, grid_coord_freq; // freq 0 no, 1 border, 2 all
+  int surface, grid = 0, proj = 0, grid_coord_freq; // freq 0 no, 1 border, 2 all
   std::string gridAA, gridAB, gridAC, 
          gridBA, gridBB, gridBC, 
          gridCA, gridCB, gridCC;
   paired gridcell[9];
   double surface_opacity;
   paired calibration_local[9], calibration_latlong[9];
-  double calibration_hdist;
+  double calibration_hdist = 0.0;
   
   layout();
 };

--- a/thpoint.h
+++ b/thpoint.h
@@ -491,8 +491,6 @@ class thpoint : public th2ddataobject {
   thobjectname station_name,  ///< Station name.
     from_name;  ///< Extend name.
 
-  char extend_opts;  ///< Extend options.
-
   void start_insert() override;
 
   void parse_type(char * tstr);  ///< Parse point type.

--- a/thscrapen.h
+++ b/thscrapen.h
@@ -47,8 +47,8 @@ class thscrapen {
   class thline * l2;
   class thdb2dlp * lp2;
   
-  double cxt, cyt;
-  bool active;
+  double cxt = 0.0, cyt = 0.0;
+  bool active = false;
   
   thscrapen(); ///< Default constructor
 };

--- a/thscraplp.h
+++ b/thscraplp.h
@@ -50,7 +50,7 @@ class thscraplp {
   
   thscraplp(); ///< Default constructor
   
-  double stx, sty, stz, lnx1, lnx2, lny1, lny2, lnz1, lnz2;
+  double stx = 0.0, sty = 0.0, stz = 0.0, lnx1 = 0.0, lnx2 = 0.0, lny1 = 0.0, lny2 = 0.0, lnz1 = 0.0, lnz2 = 0.0;
   bool lnio;
   int type;
 

--- a/thselector.h
+++ b/thselector.h
@@ -44,7 +44,7 @@ class thselector_item {
 
   const char * name, *src_name;
   unsigned long src_ln;
-  unsigned long number;
+  unsigned long number = 0;
   bool unselect, recursive;  
   long map_level, chapter_level;
   thlayout_color m_color;

--- a/thsvxctrl.h
+++ b/thsvxctrl.h
@@ -46,8 +46,8 @@ class thsvxctrl {
 
   thdataleg pdl;
 
-  double meridian_convergence, lastleggridmc;
-  int lastleggridmccs;
+  double meridian_convergence = 0.0, lastleggridmc = 0.0;
+  int lastleggridmccs = 0;
   
   unsigned long svxf_ln;
   thsvxctrl_src_maptype src_map;

--- a/thtf.cxx
+++ b/thtf.cxx
@@ -31,8 +31,6 @@
 #include <stdio.h>
 
 
-thtf::~thtf() {}
-
 void thtf::parse_scale(char * sstr)
 {
   int sv;

--- a/thtf.h
+++ b/thtf.h
@@ -40,8 +40,8 @@ class thtf {
 
   public:
 
-  double ufactor,  ///< Units factor.
-    sfactor;  ///< Scale factor.
+  double ufactor = 1.0,  ///< Units factor.
+    sfactor = 1.0;  ///< Scale factor.
  
   int units;
 
@@ -51,8 +51,8 @@ class thtf {
    * Standard constructor.
    */
   
-  thtf() : ufactor(1.0), sfactor(1.0) {}
-  virtual ~thtf();
+  thtf(int units) : units(units) {}
+  virtual ~thtf() = default;
   
   
   /**

--- a/thtfangle.cxx
+++ b/thtfangle.cxx
@@ -32,12 +32,7 @@
 #include "thinfnan.h"
 #include <math.h>
 
-thtfangle::thtfangle() {
-
-  this->units = TT_TFU_DEG;
-  this->allow_percentage = false;
-
-}
+thtfangle::thtfangle() : thtf(TT_TFU_DEG) {}
 
 bool mils_warning(true);
 

--- a/thtfangle.h
+++ b/thtfangle.h
@@ -61,7 +61,7 @@ class thtfangle : public thtf {
 
   public:
 	
-	bool allow_percentage;
+	bool allow_percentage = false;
   
   /**
    * Parse units factor.

--- a/thtflength.cxx
+++ b/thtflength.cxx
@@ -29,9 +29,7 @@
 #include "thtflength.h"
 #include "thexception.h"
 
-thtflength::thtflength() {
-  this->units = TT_TFU_M;
-}
+thtflength::thtflength() : thtf(TT_TFU_M) {}
 
 
 void thtflength::parse_units(char * ustr) {

--- a/thtrans.h
+++ b/thtrans.h
@@ -218,7 +218,7 @@ struct thlinzoomtrans {
   int m_flc, m_frc, m_tlc, m_trc;
 
   thline2 m_line_from, m_line_to, m_line;
-  double m_orient_from, m_orient_to, m_line_l;
+  double m_orient_from = 0.0, m_orient_to = 0.0, m_line_l = 0.0;
 
   thlinzoomtrans();
 

--- a/thwarppme.h
+++ b/thwarppme.h
@@ -147,7 +147,7 @@ namespace therion
     struct point_pair
     {
       morph_type m_type;  //!< point pair type
-      bool m_used;        //!< whether this pair has been used in making the plaquettes
+      bool m_used = false;//!< whether this pair has been used in making the plaquettes
       std::string m_name; //!< station (or whatever) name
       thvec2 x;           //!< sketch coords
       thvec2 u;           //!< survey coords
@@ -263,19 +263,19 @@ namespace therion
       morph_type m_type;     //!< morph type of the line
       point_pair * m_p1;     //!< first point pair
       point_pair * m_p2;     //!< second point pair
-      double dz;             //!< distance P1-P2 (Z coords)
-      double dw;             //!< distance P1-P2 (W coords)
+      double dz = 0.0;       //!< distance P1-P2 (Z coords)
+      double dw = 0.0;       //!< distance P1-P2 (W coords)
     
       thline2 z;             //!< line (first image - Z coords)
       thline2 w;             //!< line (second image - W coords)
-      double zab;            //!< z-line sqrt(a*a + b*b)
-      double wab;            //!< w-line sqrt(a*a + b*b)
+      double zab = 0.0;      //!< z-line sqrt(a*a + b*b)
+      double wab = 0.0;      //!< w-line sqrt(a*a + b*b)
       
       thvec2 vz; //!< unit vector in Z (P1->P2)
       thvec2 vw; //!< unit vector in W 
       
-      double z_w; // dz / dw
-      double w_z; // dw / dz
+      double z_w = 0.0; // dz / dw
+      double w_z = 0.0; // dw / dz
       
       // thmat2 R;                //!< rotation matrix R(from->to)
       // thmat2 S;                //!< rotation matrix R(to->from)

--- a/thwarppt.h
+++ b/thwarppt.h
@@ -73,10 +73,10 @@ namespace therion
       public:
         thvec2 mX0;    //!< X-Y center
         thvec2 mU0;    //!< U-V center
-        double mXUnit; //!< X-Y unit
-        double mUUnit; //!< U-V unit
+        double mXUnit = 0.0; //!< X-Y unit
+        double mUUnit = 0.0; //!< U-V unit
         thvec2 mUC;    //!< U-V center in the warped image
-        double mUCUnit; //!< U-V unit in the warped image
+        double mUCUnit = 0.0; //!< U-V unit in the warped image
         
       public:
         /** default cstr


### PR DESCRIPTION
Fixes warnings from static analysis that some class member variables are left uninitialized.