### PR TITLE
Documented prefixing metapost commands with exclamation mark in `code` block, which prevents therion to try to parse it as therion command

### DIFF
--- a/thbook/ch05.tex
+++ b/thbook/ch05.tex
@@ -453,7 +453,9 @@ There are four predefined pens {\it PenA} (thickest) \dots\ {\it PenD}
 For drawing and filling use |thdraw| and |thfill| commands instead of \MP's
 |draw| and |fill|.
 
-\NEW{5.4}The following variables are also available:
+\NEW{5.4}The following variables are also available\[If names clash with Therion
+commands (like |color|), you can add an exclamation mark "|!|" to prevent Therion parsing
+the line: |! color myNewColorDef;| ]:
 
 \list
 * boolean |ATTR__shotflag_splay|, |ATTR__shotflag_duplicate|,\hfil\break


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/13608602/117878200-c9cdfc80-b2a5-11eb-9a59-7c800ab396c2.png)
[...]
![grafik](https://user-images.githubusercontent.com/13608602/117878226-d3576480-b2a5-11eb-9dd6-9652a6ef97e0.png)



Fix #356