### PR TITLE
Prefer const references

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone-reserved-identifier,bugprone-use-after-move'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone-reserved-identifier,bugprone-use-after-move,performance-for-range-copy'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/thepsparse.cxx
+++ b/thepsparse.cxx
@@ -105,18 +105,18 @@ void color::set(double a, double b, double c, double d) {
   }
 }
 
-bool color::is_white() {
+bool color::is_white() const {
   if ((model == colormodel::grey && a == 1.0) ||
       (model == colormodel::rgb && (a == 1.0 && b == 1.0 && c == 1.0)) ||
       (model == colormodel::cmyk && (a == 0 && b == 0 && c == 0 && d == 0))) return true;
   else return false;
 }
 
-bool color::is_defined() {
+bool color::is_defined() const {
   return model != colormodel::no;
 }
 
-std::string color::to_svg() {
+std::string color::to_svg() const {
   double r = 0, g = 0, b = 0;
   if (model == colormodel::grey)
     r = g = b = this->a;
@@ -136,7 +136,7 @@ std::string color::to_svg() {
                                            int(255*b) % 256);
 }
 
-std::string color::to_pdfliteral(fillstroke fs) {
+std::string color::to_pdfliteral(fillstroke fs) const {
   std::ostringstream s;
   if (model == colormodel::grey) {
     if (fs == fillstroke::fill || fs == fillstroke::fillstroke)
@@ -166,7 +166,7 @@ std::string color::to_pdfliteral(fillstroke fs) {
 }
 
 
-std::string color::to_elements() {
+std::string color::to_elements() const {
   std::string s;
   if (model == colormodel::grey) {
     s = fmt::format("{}", thdouble(a,prec_col));
@@ -181,7 +181,7 @@ std::string color::to_elements() {
 }
 
 
-std::string color::to_pdfpatterncolor() {
+std::string color::to_pdfpatterncolor() const {
   std::string s;
   if (model == colormodel::grey) {
     s = "/CS3 cs";
@@ -249,7 +249,7 @@ void MP_text::print_svg(std::ofstream & F, CGS & gstate) {
   F << "</text>" << std::endl;
 }
 
-void MP_text::print_pdf(std::ofstream & F) {
+void MP_text::print_pdf(std::ofstream & F) const {
   F << PL("BT");
   F << PL(fmt::format("/F\\pdffontname\\{:s}\\space {} Tf", tex_Fname(ALL_FONTS[font]), thdouble(size,prec_mp)));
   F << PL(fmt::format("{} {} {} {} {:.1f} {:.1f} Tm", thdouble(xx,prec_mp), thdouble(xy,prec_mp), thdouble(yx,prec_mp), thdouble(yy,prec_mp), x, y));
@@ -396,7 +396,7 @@ void MP_path::print_svg(std::ofstream & F, CGS & gstate, std::string unique_pref
      "<g clip-path=\"url(#clip_" << CGS::clippathID << "_" << unique_prefix << ")\">" << std::endl;
 }
 
-void MP_path::print_pdf(std::ofstream & F) {
+void MP_path::print_pdf(std::ofstream & F) const {
   double last_x = 0, last_y = 0;
   for (unsigned i=0; i < segments.size(); i++) {
     switch (segments[i].command) {
@@ -486,7 +486,7 @@ void MP_data::add(int i, std::string s, color col) {
   index.push_back(ind);
 }
 
-void MP_data::add(MP_path P) {
+void MP_data::add(const MP_path& P) {
   MP_index ind;
   ind.vector = I_path;
   ind.idx = paths.size();
@@ -494,7 +494,7 @@ void MP_data::add(MP_path P) {
   index.push_back(ind);
 }
 
-void MP_data::add(MP_transform T) {
+void MP_data::add(const MP_transform& T) {
   MP_index ind;
   ind.vector = I_transform;
   ind.idx = transforms.size();
@@ -502,7 +502,7 @@ void MP_data::add(MP_transform T) {
   index.push_back(ind);
 }
 
-void MP_data::add(MP_text T) {
+void MP_data::add(const MP_text& T) {
   MP_index ind;
   ind.vector = I_text;
   ind.idx = texts.size();
@@ -557,7 +557,7 @@ void MP_setting::print_svg (std::ofstream & F, CGS & gstate) {
   }
 }
 
-void MP_setting::print_pdf (std::ofstream & F) {
+void MP_setting::print_pdf (std::ofstream & F) const {
   switch (command) {
     case MP_rgb:
     case MP_gray:
@@ -665,7 +665,7 @@ void MP_data::print_svg (std::ofstream & F, std::string unique_prefix) {
   thassert(gstate.clippathdepth.empty());
 }
 
-void MP_data::print_pdf (std::ofstream & F) {
+void MP_data::print_pdf (std::ofstream & F) const {
   for (unsigned int i=0; i<index.size(); i++) {
     switch (index[i].vector) {
       case I_path:
@@ -773,7 +773,7 @@ void converted_data::print_svg (std::ofstream & F, std::string unique_prefix) {
   F << "</svg>" << std::endl;
 }
 
-void converted_data::print_pdf(std::ofstream & F, std::string name) {
+void converted_data::print_pdf(std::ofstream & F, std::string name) const {
 //  if (MP.index.empty()) return;  // can't skip the empty XObject definition, as it might be referenced somewhere
   conv_mode = mode;
 
@@ -814,7 +814,7 @@ void converted_data::print_pdf(std::ofstream & F, std::string name) {
           F << "/" << *I << " " << tex_get_ref(tex_Pname(ALL_PATTERNS[*I])) <<
                  "\\space 0 R ";
         }
-        for(auto & g: gradients) {
+        for(const auto & g: gradients) {
           F << "/" << tex_Pname(g) << " " << tex_get_ref(tex_Pname(g)) <<
                  "\\space 0 R ";
         }
@@ -1423,7 +1423,7 @@ void thgraphics2pdf() {
   std::ofstream TEX("th_formdef.tex");
   if(!TEX) therror((IOerr("th_formdef.tex")));
 
-  for(auto &I: SCRAPLIST) {
+  for(const auto &I: SCRAPLIST) {
     I.Fc.print_pdf(TEX, I.name);
     I.Gc.print_pdf(TEX, "G"+I.name);
     I.Bc.print_pdf(TEX, "B"+I.name);
@@ -1467,7 +1467,7 @@ void thgraphics2pdf() {
     }
   }
 
-  for(auto &I: LEGENDLIST) {
+  for(const auto &I: LEGENDLIST) {
     I.ldata.print_pdf(TEX, I.name);
   }
 
@@ -1476,7 +1476,7 @@ void thgraphics2pdf() {
   AltBar.print_pdf(TEX, "altitudebar");
 
   unsigned char c = 'a';
-  for(auto &I: GRIDLIST) {
+  for(const auto &I: GRIDLIST) {
     I.print_pdf(TEX, fmt::format("grid{:c}",c));
     c++;
   }

--- a/thepsparse.h
+++ b/thepsparse.h
@@ -43,12 +43,12 @@ struct color{
   void set(double);
   void set(double,double,double);
   void set(double,double,double,double);
-  bool is_white();
-  bool is_defined();
-  std::string to_svg();
-  std::string to_pdfliteral(fillstroke = fillstroke::fillstroke);
-  std::string to_pdfpatterncolor();
-  std::string to_elements();
+  bool is_white() const;
+  bool is_defined() const;
+  std::string to_svg() const;
+  std::string to_pdfliteral(fillstroke = fillstroke::fillstroke) const;
+  std::string to_pdfpatterncolor() const;
+  std::string to_elements() const;
 };
 
 struct CGS {  // current graphics state
@@ -95,7 +95,7 @@ struct MP_path {
   void add(int, std::string, std::string, double, double);
 
   void print_svg(std::ofstream & F, CGS & gstate, std::string prefix);
-  void print_pdf(std::ofstream & F);
+  void print_pdf(std::ofstream & F) const;
 };
 
 struct MP_index {
@@ -111,7 +111,7 @@ struct MP_text {
   MP_text();
   void clear();
   void print_svg(std::ofstream & F, CGS & gstate);
-  void print_pdf(std::ofstream & F);
+  void print_pdf(std::ofstream & F) const;
 };
 
 struct MP_setting {
@@ -123,7 +123,7 @@ struct MP_setting {
   std::string pattern;
   
   void print_svg(std::ofstream & F, CGS & gstate);
-  void print_pdf(std::ofstream & F);
+  void print_pdf(std::ofstream & F) const;
 };
 
 enum {MP_lineto, MP_moveto, MP_curveto, MP_rlineto};
@@ -153,9 +153,9 @@ struct MP_data {
   
   std::list<CGS> GSTATE_stack;
   
-  void add(MP_path);
-  void add(MP_text);
-  void add(MP_transform);
+  void add(const MP_path&);
+  void add(const MP_text&);
+  void add(const MP_transform&);
   void add(int);
   void add(int,std::string,color=color());
   void get();
@@ -165,7 +165,7 @@ struct MP_data {
   void clear();
   
   void print_svg(std::ofstream & F, std::string prefix);
-  void print_pdf(std::ofstream & F);
+  void print_pdf(std::ofstream & F) const;
 };
 
 struct converted_data {
@@ -189,7 +189,7 @@ struct converted_data {
   void clear();
   converted_data() = default;
   void print_svg(std::ofstream & F, std::string prefix="");
-  void print_pdf(std::ofstream & F, std::string);
+  void print_pdf(std::ofstream & F, std::string) const;
 };
 
 struct pattern {

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -1764,14 +1764,14 @@ else
     	  sprintf(texb.get_buffer(),"data.%d",sfig);
     	  LAYOUT.altitudebar = texb.get_buffer();
     	  sv_min = this->layout->m_lookup->m_table.begin()->m_valueDbl;
-    	  for(auto ti : this->layout->m_lookup->m_table) {
+    	  for(const auto& ti : this->layout->m_lookup->m_table) {
     		  sv_max = ti.m_valueDbl;
     	  }
           fprintf(mpf,"beginfig(%d);\ns_altitudebar(%g, %g, \"%s\")(",
             sfig++, this->layout->units.convert_length(sv_max),
                     this->layout->units.convert_length(sv_min),
                     this->layout->units.format_i18n_length_units());
-    	  for(auto ti : this->layout->m_lookup->m_table) {
+    	  for(auto& ti : this->layout->m_lookup->m_table) {
     		  if (sv_next) fprintf(mpf, ",");
     		  sv_next = true;
     		  fprintf(mpf,"%g,",(ti.m_valueDbl - sv_min)/(sv_max - sv_min));
@@ -3641,7 +3641,7 @@ void thexpmap::export_scrap_backgroud_mesh(thscrap * cs, thexpmapmpxs * out, scr
     	  mi.insert_point(thvec2(cp->pt->xt, cp->pt->yt), thvec2(cp->tx, cp->ty), cp->st->uid, cp->ta);
       cp = cp->nextcp;
     }
-    for(auto xcp : cs->joined_scrap_stations) {
+    for(const auto& xcp : cs->joined_scrap_stations) {
     	mi.insert_extra_point(thvec2(xcp->pt->xt, xcp->pt->yt), thvec2(xcp->tx, xcp->ty), xcp->st->uid, xcp->ta);
     }
     mi.insert_lines_from_db();

--- a/thpdf.cxx
+++ b/thpdf.cxx
@@ -85,11 +85,11 @@ std::map<std::string,std::set<std::string> > preview;
 std::map<std::string,std::list<sheetrecord>::iterator> SHEET_JMP;
 
 
-bool operator < (sheetrecord a, sheetrecord b) {
+bool operator < (const sheetrecord& a, const sheetrecord& b) {
   return a.id < b.id;
 }
 
-bool operator == (sheetrecord a, sheetrecord b) {
+bool operator == (const sheetrecord& a, const sheetrecord& b) {
   return a.id == b.id;
 }
 

--- a/thsvg.cxx
+++ b/thsvg.cxx
@@ -421,7 +421,7 @@ void print_surface_bitmaps (std::ofstream &F) {
 
 
 
-void thsvg(const char * fname, int fmt, legenddata ldata) {
+void thsvg(const char * fname, int fmt, const legenddata& ldata) {
   if (fmt == 0)
     thprintf("making svg map ... ");
   else

--- a/thsvg.h
+++ b/thsvg.h
@@ -23,7 +23,7 @@
 
 #include "thlegenddata.h"
 
-void thsvg(const char * fname, int, legenddata ldata);
+void thsvg(const char * fname, int, const legenddata& ldata);
 
 std::string escape_html(std::string);
 

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -569,17 +569,17 @@ void thsymbolset::export_symbol_hide(FILE * mpf, int sym_id)
   // U defined groups
   switch (sym_id) {
   case SYMP_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_POINT_CMD)
 			  this->export_symbol_hide(mpf, it.second->m_symid);
 	  break;
   case SYML_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_LINE_CMD)
 			  this->export_symbol_hide(mpf, it.second->m_symid);
 	  break;
   case SYMA_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_AREA_CMD)
 			  this->export_symbol_hide(mpf, it.second->m_symid);
 	  break;
@@ -598,17 +598,17 @@ void thsymbolset::export_symbol_show(FILE * mpf, int sym_id)
   // U defined groups
   switch (sym_id) {
   case SYMP_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_POINT_CMD)
 			  this->export_symbol_show(mpf, it.second->m_symid);
 	  break;
   case SYML_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_LINE_CMD)
 			  this->export_symbol_show(mpf, it.second->m_symid);
 	  break;
   case SYMA_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_AREA_CMD)
 			  this->export_symbol_show(mpf, it.second->m_symid);
 	  break;
@@ -631,17 +631,17 @@ void thsymbolset::export_symbol_color(FILE * mpf, int sym_id, thlayout_color * c
   // U defined groups
   switch (sym_id) {
   case SYMP_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_POINT_CMD)
 			  this->export_symbol_color(mpf, it.second->m_symid, clr);
 	  break;
   case SYML_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_LINE_CMD)
 			  this->export_symbol_color(mpf, it.second->m_symid, clr);
 	  break;
   case SYMA_U:
-	  for(auto it : thdb.db2d.m_udef_map)
+	  for(const auto& it : thdb.db2d.m_udef_map)
 		  if (it.first.m_command == TT_AREA_CMD)
 			  this->export_symbol_color(mpf, it.second->m_symid, clr);
 	  break;
@@ -658,7 +658,7 @@ void thsymbolset::export_symbol_color_group(FILE * mpf, int sym_id, thlayout_col
   }
   // U defined symbols
   if (sym_id == SYMX_ALL) {
-	  for(auto it : thdb.db2d.m_symid2udef_map)
+	  for(const auto& it : thdb.db2d.m_symid2udef_map)
 		  this->export_symbol_color(mpf, it.first, clr);
   }
 }
@@ -684,7 +684,7 @@ void thsymbolset::export_symbol_hide_group(FILE * mpf, int sym_id)
   }
   // U defined symbols
   if (sym_id == SYMX_ALL) {
-	  for(auto it : thdb.db2d.m_symid2udef_map)
+	  for(const auto& it : thdb.db2d.m_symid2udef_map)
 		  this->export_symbol_hide(mpf, it.first);
   }
 }
@@ -700,7 +700,7 @@ void thsymbolset::export_symbol_show_group(FILE * mpf, int sym_id)
   }
   // U defined symbols
   if (sym_id == SYMX_ALL) {
-	  for(auto it : thdb.db2d.m_symid2udef_map)
+	  for(const auto& it : thdb.db2d.m_symid2udef_map)
 		  this->export_symbol_show(mpf, it.first);
   }
 }


### PR DESCRIPTION
These fixes are based on Coverity warnings, clang-tidy warnings and manual inspection.