### PR TITLE
Add ability to scale the symbol point dig

### DIFF
--- a/mpost/thPoint.mp
+++ b/mpost/thPoint.mp
@@ -706,7 +706,7 @@ enddef;
 
 def p_dig_UIS (expr pos,r,s,al) =
     U:=(.4u, .5u);
-    T:=identity aligned al shifted pos;
+    T:=identity aligned al scaled s shifted pos;
     thfill ((-.075u,-.5u){down} .. {up}(0.075u, -.5u) -- (0.075u, .15u) -- (0.3u, 0.15u) -- (0.3u, 0.5u) --
     (-.3u, .5u) -- (-.3u, .15u) -- (-.075u, .15u) -- cycle) rotated 45;
 enddef;


### PR DESCRIPTION
Add ability to scale the symbol point dig.  The symbol will continue to ignore the option to rotate.