### PR TITLE
Adding missing plural point types in THBook

### DIFF
--- a/thbook/ch02.tex
+++ b/thbook/ch02.tex
@@ -782,7 +782,9 @@ Point is a command for drawing a point map symbol.
     |stalactite-stalagmite|,
     |stalactites-stalagmites|,
     |stalactite|,
+    |stalactites|,
     |stalagmite|,
+    |stalagmites|,
     |volcano|,
     |wall-calcite|;
 


### PR DESCRIPTION
Just found 2 missing plural point type in Therion Book.