### PR TITLE
THBook: NaN is zero in altitude

### DIFF
--- a/thbook/ch02.tex
+++ b/thbook/ch02.tex
@@ -946,7 +946,8 @@ Point is a command for drawing a point map symbol.
       distance to floor).
 
       {\it altitude:} the value specified is the altitude difference from
-      the nearest station. If the altitude value is prefixed by ``|fix|''
+      the nearest station. The value will be set to 0 if defined as "-", ".", 
+      "nan", "NAN" or "NaN". If the altitude value is prefixed by ``|fix|''
       (e.g. |-value [fix 1300]|), this value is used as an absolute altitude.
       The value can optionally be followed by length units.
 
@@ -1094,7 +1095,8 @@ respectively.
    (which is 0 by default).
          If the value is specified, it
          gives the altitude difference of the point on the wall
-         relative to the nearest station. The value can be prefixed
+         relative to the nearest station. The value will be set to 0 if defined 
+         as "-", ".", "nan", "NAN" or "NaN". The value can be prefixed
          by a keyword ``|fix|'', then no nearest station is taken into
          consideration; the absolute given value is used instead.
          Units can follow the value. Examples: |+4|, |[+4 m]|,


### PR DESCRIPTION
Include in Therion book that point altitude value option and altitude option for point type wall accept NaN as zero.