### PR TITLE
Fix struct warning

### DIFF
--- a/thcs.cxx
+++ b/thcs.cxx
@@ -166,7 +166,7 @@ void thcs_add_cs(char * id, char * proj4id, size_t nargs, char ** args)
   thcs_custom_int2data[thcs_custom_id] = pd;
 }
 
-bool operator < (const struct thcstrans & t1, const class thcstrans &t2) {
+bool operator < (const thcstrans & t1, const thcstrans &t2) {
   if (t1.from_id < t2.from_id)
 	return true;
   else if ((t1.from_id == t2.from_id) && (t1.to_id < t2.to_id))

--- a/thcs.h
+++ b/thcs.h
@@ -44,7 +44,7 @@ class thcstrans {
 	int from_id, to_id;
 	thcstrans() : from_id(TTCS_UNKNOWN), to_id(TTCS_UNKNOWN) {}
 	thcstrans(int from, int to) : from_id(from), to_id(to) {}
-    friend bool operator < (const struct thcstrans & t1, const class thcstrans &t2);
+    friend bool operator < (const thcstrans & t1, const thcstrans &t2);
 };
 
 void thcs_add_cs(char * id, char * proj4id, size_t nargs, char ** args);


### PR DESCRIPTION
Fix warning from Clang:
```
therion/thcs.h:47:35: warning: struct 'thcstrans' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
friend bool operator < (const struct thcstrans & t1, const class thcstrans &t2);
                              ^
```