### PR TITLE
fix(docs): Mention the correct filename for compillation of version 6.x

### DIFF
--- a/thbook/ch06.tex
+++ b/thbook/ch06.tex
@@ -95,7 +95,7 @@ on Ubuntu 18.04 or 20.04:
 
 \subsubchapter Using CMake.
 
-\NEW{6.0}Unpack the source distribution |therion-5.*.tar.gz| and create a separate
+\NEW{6.0}Unpack the source distribution |therion-6.*.tar.gz| and create a separate
 directory for the build, e.g.:
 \list
 * |cd therion && mkdir build && cd build|
@@ -146,7 +146,7 @@ th-docs, loch-docs.
 \subsubchapter Legacy approach: using make.
 
 \list
-* unpack the source distribution |therion-5.*.tar.gz|
+* unpack the source distribution |therion-6.*.tar.gz|
 * |cd therion|
 * |make config-macosx| or |make config-win32|, if you use MacOS~X or Windows,
   respectively


### PR DESCRIPTION
this was still mentioning therion-5.x