### PR TITLE
feat(therion): more colors in `color map-fg scrap`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@ therion:
    pipelines between two coordinate systems
  * added support for automatic downloading of PROJ transformation grids used
    in cs-trans pipelines from cdn.proj.org
+ * layout: color map-fg scrap now uses more different colors to avoid that
+   connected scraps are colored the same. Needed in labyrinth-like caves.
 
 --------------------------------------------------------------------------------
 

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -3206,7 +3206,7 @@ void thexpmap::export_pdf_set_colors(class thdb2dxm * maps, class thdb2dprj * pr
 //            curz += prj->shift_z;
           switch (this->layout->color_crit) {
             case TT_LAYOUT_CCRIT_MAP:
-              // vsetkym scrapom v kazdej priradi farbu
+              // assigns color to each scrap in each
               if (firstmapscrap) {
                 if (cmap->selection_color.defined) {
                   clr = cmap->selection_color;
@@ -3230,14 +3230,24 @@ void thexpmap::export_pdf_set_colors(class thdb2dxm * maps, class thdb2dprj * pr
 //              thprintf("%s@%s->%.2f,%.2f,%.2f\n",cs->name,cs->fsptr->full_name,cs->R,cs->G,cs->B);
             break;
             case TT_LAYOUT_CCRIT_SCRAP:
-              // vsetkym scrapom v kazdej priradi farbu
-							switch (cmn % 6) {
+              // set a different random color for earch scrap
+							switch (cmn % 16) {
 								case 0:  clr = thlayout_color(1.0, 0.5, 0.5); break;
 								case 1:  clr = thlayout_color(0.5, 1.0, 0.5); break;
 								case 2:  clr = thlayout_color(0.5, 0.5, 1.0); break;
 								case 3:  clr = thlayout_color(1.0, 1.0, 0.0); break;
 								case 4:  clr = thlayout_color(0.0, 1.0, 1.0); break;
-								default: clr = thlayout_color(1.0, 0.0, 1.0); break;
+								case 5:  clr = thlayout_color(1.0, 0.0, 1.0); break;
+								case 6:  clr = thlayout_color(0.75, 1.0, 1.0); break;
+								case 7:  clr = thlayout_color(1.0, 0.75, 1.0); break;
+								case 8:  clr = thlayout_color(1.0, 1.0, 0.75); break;
+								case 9:  clr = thlayout_color(0.25, 0.75, 1.0); break;
+								case 10: clr = thlayout_color(0.25, 1.0, 0.75); break;
+								case 11: clr = thlayout_color(1.0, 0.75, 0.25); break;
+								case 12: clr = thlayout_color(0.75, 1.0, 0.25); break;
+                case 13: clr = thlayout_color(0.75, 0.25, 1.0); break;
+                case 14: clr = thlayout_color(1.0, 0.25, 0.75); break;
+                default: clr = thlayout_color(0.5, 0.25, 0.75); break;
 							}
               clr.alpha_correct(tmp_alpha);
               cs->clr = clr;

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -623,14 +623,24 @@ void thlookup::postprocess() {
         if ((this->m_type == TT_LAYOUT_CCRIT_SCRAP) || (this->m_type == TT_LAYOUT_CCRIT_MAP)) {
           cnt = 0;
           for(nvalid = this->m_table.begin(); nvalid != this->m_table.end(); nvalid++) {
-            switch (cnt % 6) {
-                case 0:  nvalid->m_color = thlayout_color(1.0, 0.5, 0.5); break;
-                case 1:  nvalid->m_color = thlayout_color(0.5, 1.0, 0.5); break;
-                case 2:  nvalid->m_color = thlayout_color(0.5, 0.5, 1.0); break;
-                case 3:  nvalid->m_color = thlayout_color(1.0, 1.0, 0.0); break;
-                case 4:  nvalid->m_color = thlayout_color(0.0, 1.0, 1.0); break;
-                default: nvalid->m_color = thlayout_color(1.0, 0.0, 1.0); break;
-            }
+							switch (cnt % 16) {
+								case 0:  nvalid->m_color = thlayout_color(1.0, 0.5, 0.5); break;
+								case 1:  nvalid->m_color = thlayout_color(0.5, 1.0, 0.5); break;
+								case 2:  nvalid->m_color = thlayout_color(0.5, 0.5, 1.0); break;
+								case 3:  nvalid->m_color = thlayout_color(1.0, 1.0, 0.0); break;
+								case 4:  nvalid->m_color = thlayout_color(0.0, 1.0, 1.0); break;
+								case 5:  nvalid->m_color = thlayout_color(1.0, 0.0, 1.0); break;
+								case 6:  nvalid->m_color = thlayout_color(0.75, 1.0, 1.0); break;
+								case 7:  nvalid->m_color = thlayout_color(1.0, 0.75, 1.0); break;
+								case 8:  nvalid->m_color = thlayout_color(1.0, 1.0, 0.75); break;
+								case 9:  nvalid->m_color = thlayout_color(0.25, 0.75, 1.0); break;
+								case 10: nvalid->m_color = thlayout_color(0.25, 1.0, 0.75); break;
+								case 11: nvalid->m_color = thlayout_color(1.0, 0.75, 0.25); break;
+								case 12: nvalid->m_color = thlayout_color(0.75, 1.0, 0.25); break;
+                case 13: nvalid->m_color = thlayout_color(0.75, 0.25, 1.0); break;
+                case 14: nvalid->m_color = thlayout_color(1.0, 0.25, 0.75); break;
+                default: nvalid->m_color = thlayout_color(0.5, 0.25, 0.75); break;
+							}
             nvalid->m_color.alpha_correct(tmp_alpha);
             nvalid->m_color.defined = 1;
 


### PR DESCRIPTION
 layout: color map-fg scrap provides 16 instead of 6 different colours. Helpful for lbyrinth-like caves.