### PR TITLE
fix(docs): explain that select affects the whole file

### DIFF
--- a/thbook/ch03.tex
+++ b/thbook/ch03.tex
@@ -110,11 +110,14 @@ Works like |input| command in data files---includes other files.
   are selected. If there is no map selected, all scraps belonging to
   selected surveys are selected by default for map export.
 
-  If there are no scraps or maps in the data, centreline from all surveys is
+  If there are no scraps or maps in the data, centerline from all surveys is
   exported in the map.
 
   When exporting maps in different projections, you need to select
   them for each projection separately.
+
+  |select| does not only affect subsequent |<export>| commands but instead 
+  also |<export>| commands preceding the |select| command in the configuration file.
 \enddescription
 
 \syntax


### PR DESCRIPTION
Explain why this does not work as expected:

```
...
select ms_brot-kirche
export map -projection plan -output ../output/windloch-teil-brot-kirche-scraps.pdf -layout l_brot-kirche -layout-map-comment "Zeichenabschnitte" -layout-colour-legend off -layout-color map-fg scrap -layout-debug scrap-names 
export map -projection plan -output ../output/windloch-teil-brot-kirche.pdf -layout l_brot-kirche
export map -projection plan -output ../output/windloch-teil-brot-kirche-errors.pdf -layout l_brot-kirche -layout-map-comment "Fehler" -layout-colour-legend off -layout-debug all -layout l_alledaten 

select mc_brot-kirche1
export map -projection plan -output ../output/windloch-teil-brot-kirche-konstruktion.pdf -layout l_brot-kirche -layout l_konstruktion -layout-scale 1 100
```