### PR TITLE
Disable MXE builds on CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,37 +77,37 @@ jobs:
       - run: cmake --build build -t therion loch utest -- -j 4
       - run: cmake --build build -t deploy -- -j 4
 
-  MXE:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - { os: ubuntu-20.04, osname: focal, pkg: i686,   cmd: i686,   wine-pkg: wine32, wine: wine }
-          - { os: ubuntu-20.04, osname: focal, pkg: x86-64, cmd: x86_64, wine-pkg: wine64, wine: wine64-stable }
-    steps:
-      - uses: actions/checkout@v2
-      - name: install dependencies
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-          sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt ${{ matrix.osname }} main'
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt -qq update
-          sudo apt install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
-          sudo apt purge -yqq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
-          sudo apt install -y ${{ matrix.wine-pkg }}
-          sudo apt install -y ninja-build
-          sudo apt install -y mxe-${{ matrix.pkg }}-w64-mingw32.static-binutils mxe-${{ matrix.pkg }}-w64-mingw32.static-bzip2 mxe-${{ matrix.pkg }}-w64-mingw32.static-expat mxe-${{ matrix.pkg }}-w64-mingw32.static-freetype-bootstrap mxe-${{ matrix.pkg }}-w64-mingw32.static-gcc mxe-${{ matrix.pkg }}-w64-mingw32.static-gettext mxe-${{ matrix.pkg }}-w64-mingw32.static-glib mxe-${{ matrix.pkg }}-w64-mingw32.static-harfbuzz mxe-${{ matrix.pkg }}-w64-mingw32.static-jpeg \
-                              mxe-${{ matrix.pkg }}-w64-mingw32.static-libiconv mxe-${{ matrix.pkg }}-w64-mingw32.static-libpng mxe-${{ matrix.pkg }}-w64-mingw32.static-tiff mxe-${{ matrix.pkg }}-w64-mingw32.static-vtk mxe-${{ matrix.pkg }}-w64-mingw32.static-wxwidgets mxe-${{ matrix.pkg }}-w64-mingw32.static-xz mxe-${{ matrix.pkg }}-w64-mingw32.static-zlib mxe-${{ matrix.pkg }}-w64-mingw32.static-proj
-      - name: run build
-        run: |
-          export PATH=/usr/lib/mxe/usr/bin:$PATH
-          mkdir build && cd build
-          ${{ matrix.cmd }}-w64-mingw32.static-cmake -G Ninja \
-              -DMXE_USE_CCACHE=OFF \
-              -DCMAKE_CROSSCOMPILING_EMULATOR=${{ matrix.wine }} \
-              -DCMAKE_C_FLAGS="-Werror" \
-              -DCMAKE_CXX_FLAGS="-Werror" \
-              -DBUILD_SHARED_LIBS=OFF \
-              -DBUILD_THBOOK=OFF ..
-          ninja
+  # MXE:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - { os: ubuntu-20.04, osname: focal, pkg: i686,   cmd: i686,   wine-pkg: wine32, wine: wine }
+  #         - { os: ubuntu-20.04, osname: focal, pkg: x86-64, cmd: x86_64, wine-pkg: wine64, wine: wine64-stable }
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: install dependencies
+  #       run: |
+  #         sudo dpkg --add-architecture i386
+  #         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
+  #         sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt ${{ matrix.osname }} main'
+  #         sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+  #         sudo apt -qq update
+  #         sudo apt install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+  #         sudo apt purge -yqq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
+  #         sudo apt install -y ${{ matrix.wine-pkg }}
+  #         sudo apt install -y ninja-build
+  #         sudo apt install -y mxe-${{ matrix.pkg }}-w64-mingw32.static-binutils mxe-${{ matrix.pkg }}-w64-mingw32.static-bzip2 mxe-${{ matrix.pkg }}-w64-mingw32.static-expat mxe-${{ matrix.pkg }}-w64-mingw32.static-freetype-bootstrap mxe-${{ matrix.pkg }}-w64-mingw32.static-gcc mxe-${{ matrix.pkg }}-w64-mingw32.static-gettext mxe-${{ matrix.pkg }}-w64-mingw32.static-glib mxe-${{ matrix.pkg }}-w64-mingw32.static-harfbuzz mxe-${{ matrix.pkg }}-w64-mingw32.static-jpeg \
+  #                             mxe-${{ matrix.pkg }}-w64-mingw32.static-libiconv mxe-${{ matrix.pkg }}-w64-mingw32.static-libpng mxe-${{ matrix.pkg }}-w64-mingw32.static-tiff mxe-${{ matrix.pkg }}-w64-mingw32.static-vtk mxe-${{ matrix.pkg }}-w64-mingw32.static-wxwidgets mxe-${{ matrix.pkg }}-w64-mingw32.static-xz mxe-${{ matrix.pkg }}-w64-mingw32.static-zlib mxe-${{ matrix.pkg }}-w64-mingw32.static-proj
+  #     - name: run build
+  #       run: |
+  #         export PATH=/usr/lib/mxe/usr/bin:$PATH
+  #         mkdir build && cd build
+  #         ${{ matrix.cmd }}-w64-mingw32.static-cmake -G Ninja \
+  #             -DMXE_USE_CCACHE=OFF \
+  #             -DCMAKE_CROSSCOMPILING_EMULATOR=${{ matrix.wine }} \
+  #             -DCMAKE_C_FLAGS="-Werror" \
+  #             -DCMAKE_CXX_FLAGS="-Werror" \
+  #             -DBUILD_SHARED_LIBS=OFF \
+  #             -DBUILD_THBOOK=OFF ..
+  #         ninja

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -1,61 +1,61 @@
 name: Installer
 on: push
 jobs:
-  Win32_installer_MXE:
-    runs-on: ubuntu-20.04
-    outputs:
-      THID: ${{ steps.build.outputs.THID_out }}
-      git_branch: ${{ steps.build.outputs.git_branch }}
-    env:
-      THDIR: /home/runner/work/therion
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: install dependencies
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-          sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt -qq update
-          sudo apt install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
-          sudo apt purge -yqq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
-          sudo apt install -y wine32
-          sudo apt install -y ninja-build
-          sudo apt install -y mxe-i686-w64-mingw32.static-binutils mxe-i686-w64-mingw32.static-bzip2 mxe-i686-w64-mingw32.static-expat mxe-i686-w64-mingw32.static-freetype-bootstrap mxe-i686-w64-mingw32.static-gcc mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-glib mxe-i686-w64-mingw32.static-harfbuzz mxe-i686-w64-mingw32.static-jpeg \
-                              mxe-i686-w64-mingw32.static-libiconv mxe-i686-w64-mingw32.static-libpng mxe-i686-w64-mingw32.static-tiff mxe-i686-w64-mingw32.static-vtk mxe-i686-w64-mingw32.static-wxwidgets mxe-i686-w64-mingw32.static-xz mxe-i686-w64-mingw32.static-zlib mxe-i686-w64-mingw32.static-proj
-      - name: build and create the installation package
-        id: build
-        run: |
-          export PATH=/usr/lib/mxe/usr/bin:$PATH
-          mkdir -p $HOME/.wine/drive_c/windows
-          echo -e "mpost-path ${THDIR}/therion-batteries/bin/win32/mpost.exe\npdftex-path ${THDIR}/therion-batteries/bin/win32/pdftex.exe\nidentify-path ${THDIR}/therion-batteries/bin/identify.exe\nconvert-path ${THDIR}/therion-batteries/bin/convert.exe\n" > $HOME/.wine/drive_c/windows/therion.ini
-          wget -qO - https://github.com/therion/therion-batteries/archive/master.tar.gz | tar -xz && mv therion-batteries-master ../therion-batteries
-          if ${{startsWith(github.ref, 'refs/tags/v')}}; then THID=${GITHUB_REF##*/}; else THID=$(git rev-parse --short HEAD); fi
-          echo "::set-output name=THID_out::$THID"
-          BRANCH_FULL=$(git branch -r --contains ${{ github.ref }})
-          BRANCH=${BRANCH_FULL##*/}
-          echo "::set-output name=git_branch::$BRANCH"
-          mkdir ../therion.bin
-          cd ../therion.bin
-          i686-w64-mingw32.static-cmake -G Ninja \
-              -DMXE_USE_CCACHE=OFF \
-              -DCMAKE_CROSSCOMPILING_EMULATOR=wine \
-              -DBUILD_SHARED_LIBS=OFF ../therion
-          ninja
-          ninja samples
-          cd ../therion-batteries
-          wine InnoSetup/ISCC.exe therion.iss
-          cd ../therion.bin
-          mv therion-setup.exe therion-setup-$THID.exe
-          mv thbook/thbook.pdf thbook-$THID.pdf
-      - uses: 'actions/upload-artifact@v2'
-        with:
-          name: therion-setup-mxe-${{ steps.build.outputs.THID_out }}
-          path: |
-            ${{ env.THDIR }}/therion.bin/therion-setup-${{ steps.build.outputs.THID_out }}.exe
-            ${{ env.THDIR }}/therion.bin/thbook-${{ steps.build.outputs.THID_out }}.pdf
+  # Win32_installer_MXE:
+  #   runs-on: ubuntu-20.04
+  #   outputs:
+  #     THID: ${{ steps.build.outputs.THID_out }}
+  #     git_branch: ${{ steps.build.outputs.git_branch }}
+  #   env:
+  #     THDIR: /home/runner/work/therion
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: install dependencies
+  #       run: |
+  #         sudo dpkg --add-architecture i386
+  #         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
+  #         sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
+  #         sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+  #         sudo apt -qq update
+  #         sudo apt install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+  #         sudo apt purge -yqq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
+  #         sudo apt install -y wine32
+  #         sudo apt install -y ninja-build
+  #         sudo apt install -y mxe-i686-w64-mingw32.static-binutils mxe-i686-w64-mingw32.static-bzip2 mxe-i686-w64-mingw32.static-expat mxe-i686-w64-mingw32.static-freetype-bootstrap mxe-i686-w64-mingw32.static-gcc mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-glib mxe-i686-w64-mingw32.static-harfbuzz mxe-i686-w64-mingw32.static-jpeg \
+  #                             mxe-i686-w64-mingw32.static-libiconv mxe-i686-w64-mingw32.static-libpng mxe-i686-w64-mingw32.static-tiff mxe-i686-w64-mingw32.static-vtk mxe-i686-w64-mingw32.static-wxwidgets mxe-i686-w64-mingw32.static-xz mxe-i686-w64-mingw32.static-zlib mxe-i686-w64-mingw32.static-proj
+  #     - name: build and create the installation package
+  #       id: build
+  #       run: |
+  #         export PATH=/usr/lib/mxe/usr/bin:$PATH
+  #         mkdir -p $HOME/.wine/drive_c/windows
+  #         echo -e "mpost-path ${THDIR}/therion-batteries/bin/win32/mpost.exe\npdftex-path ${THDIR}/therion-batteries/bin/win32/pdftex.exe\nidentify-path ${THDIR}/therion-batteries/bin/identify.exe\nconvert-path ${THDIR}/therion-batteries/bin/convert.exe\n" > $HOME/.wine/drive_c/windows/therion.ini
+  #         wget -qO - https://github.com/therion/therion-batteries/archive/master.tar.gz | tar -xz && mv therion-batteries-master ../therion-batteries
+  #         if ${{startsWith(github.ref, 'refs/tags/v')}}; then THID=${GITHUB_REF##*/}; else THID=$(git rev-parse --short HEAD); fi
+  #         echo "::set-output name=THID_out::$THID"
+  #         BRANCH_FULL=$(git branch -r --contains ${{ github.ref }})
+  #         BRANCH=${BRANCH_FULL##*/}
+  #         echo "::set-output name=git_branch::$BRANCH"
+  #         mkdir ../therion.bin
+  #         cd ../therion.bin
+  #         i686-w64-mingw32.static-cmake -G Ninja \
+  #             -DMXE_USE_CCACHE=OFF \
+  #             -DCMAKE_CROSSCOMPILING_EMULATOR=wine \
+  #             -DBUILD_SHARED_LIBS=OFF ../therion
+  #         ninja
+  #         ninja samples
+  #         cd ../therion-batteries
+  #         wine InnoSetup/ISCC.exe therion.iss
+  #         cd ../therion.bin
+  #         mv therion-setup.exe therion-setup-$THID.exe
+  #         mv thbook/thbook.pdf thbook-$THID.pdf
+  #     - uses: 'actions/upload-artifact@v2'
+  #       with:
+  #         name: therion-setup-mxe-${{ steps.build.outputs.THID_out }}
+  #         path: |
+  #           ${{ env.THDIR }}/therion.bin/therion-setup-${{ steps.build.outputs.THID_out }}.exe
+  #           ${{ env.THDIR }}/therion.bin/thbook-${{ steps.build.outputs.THID_out }}.pdf
   Win32_installer:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -35,42 +35,42 @@ jobs:
           make loch/loch
           make tests
           ./therion --version
-  mxe-i686:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: install dependencies
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-          sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
-          sudo apt -qq update
-          sudo apt install -y mxe-i686-w64-mingw32.static-binutils mxe-i686-w64-mingw32.static-bzip2 mxe-i686-w64-mingw32.static-expat mxe-i686-w64-mingw32.static-freetype-bootstrap mxe-i686-w64-mingw32.static-gcc mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-glib mxe-i686-w64-mingw32.static-harfbuzz mxe-i686-w64-mingw32.static-jpeg \
-                              mxe-i686-w64-mingw32.static-libiconv mxe-i686-w64-mingw32.static-libpng mxe-i686-w64-mingw32.static-tiff mxe-i686-w64-mingw32.static-vtk mxe-i686-w64-mingw32.static-wxwidgets mxe-i686-w64-mingw32.static-xz mxe-i686-w64-mingw32.static-zlib mxe-i686-w64-mingw32.static-proj
-      - name: compile therion
-        run: |
-          export PATH=/usr/lib/mxe/usr/bin:$PATH
-          perl makeconfig.pl PLATFORM WIN32CROSS
-          cd loch; perl makeconfig.pl PLATFORM WIN32CROSS; cd ..
-          make OUTDIR=. therion
-          make OUTDIR=. loch/loch
-  mxe-x86_64:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: install dependencies
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-          sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
-          sudo apt -qq update
-          sudo apt install -y mxe-x86-64-w64-mingw32.static-binutils mxe-x86-64-w64-mingw32.static-bzip2 mxe-x86-64-w64-mingw32.static-expat mxe-x86-64-w64-mingw32.static-freetype-bootstrap mxe-x86-64-w64-mingw32.static-gcc mxe-x86-64-w64-mingw32.static-gettext mxe-x86-64-w64-mingw32.static-glib mxe-x86-64-w64-mingw32.static-harfbuzz mxe-x86-64-w64-mingw32.static-jpeg \
-                              mxe-x86-64-w64-mingw32.static-libiconv mxe-x86-64-w64-mingw32.static-libpng mxe-x86-64-w64-mingw32.static-tiff mxe-x86-64-w64-mingw32.static-vtk mxe-x86-64-w64-mingw32.static-wxwidgets mxe-x86-64-w64-mingw32.static-xz mxe-x86-64-w64-mingw32.static-zlib mxe-x86-64-w64-mingw32.static-proj
-      - name: compile therion
-        run: |
-          export PATH=/usr/lib/mxe/usr/bin:$PATH
-          perl makeconfig.pl PLATFORM WIN32CROSS
-          cd loch; perl makeconfig.pl PLATFORM WIN32CROSS; cd ..
-          make CROSS=x86_64-w64-mingw32.static- OUTDIR=. therion
-          make CROSS=x86_64-w64-mingw32.static- OUTDIR=. loch/loch
+  # mxe-i686:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: install dependencies
+  #       run: |
+  #         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
+  #         sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
+  #         sudo apt -qq update
+  #         sudo apt install -y mxe-i686-w64-mingw32.static-binutils mxe-i686-w64-mingw32.static-bzip2 mxe-i686-w64-mingw32.static-expat mxe-i686-w64-mingw32.static-freetype-bootstrap mxe-i686-w64-mingw32.static-gcc mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-glib mxe-i686-w64-mingw32.static-harfbuzz mxe-i686-w64-mingw32.static-jpeg \
+  #                             mxe-i686-w64-mingw32.static-libiconv mxe-i686-w64-mingw32.static-libpng mxe-i686-w64-mingw32.static-tiff mxe-i686-w64-mingw32.static-vtk mxe-i686-w64-mingw32.static-wxwidgets mxe-i686-w64-mingw32.static-xz mxe-i686-w64-mingw32.static-zlib mxe-i686-w64-mingw32.static-proj
+  #     - name: compile therion
+  #       run: |
+  #         export PATH=/usr/lib/mxe/usr/bin:$PATH
+  #         perl makeconfig.pl PLATFORM WIN32CROSS
+  #         cd loch; perl makeconfig.pl PLATFORM WIN32CROSS; cd ..
+  #         make OUTDIR=. therion
+  #         make OUTDIR=. loch/loch
+  # mxe-x86_64:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: install dependencies
+  #       run: |
+  #         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
+  #         sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
+  #         sudo apt -qq update
+  #         sudo apt install -y mxe-x86-64-w64-mingw32.static-binutils mxe-x86-64-w64-mingw32.static-bzip2 mxe-x86-64-w64-mingw32.static-expat mxe-x86-64-w64-mingw32.static-freetype-bootstrap mxe-x86-64-w64-mingw32.static-gcc mxe-x86-64-w64-mingw32.static-gettext mxe-x86-64-w64-mingw32.static-glib mxe-x86-64-w64-mingw32.static-harfbuzz mxe-x86-64-w64-mingw32.static-jpeg \
+  #                             mxe-x86-64-w64-mingw32.static-libiconv mxe-x86-64-w64-mingw32.static-libpng mxe-x86-64-w64-mingw32.static-tiff mxe-x86-64-w64-mingw32.static-vtk mxe-x86-64-w64-mingw32.static-wxwidgets mxe-x86-64-w64-mingw32.static-xz mxe-x86-64-w64-mingw32.static-zlib mxe-x86-64-w64-mingw32.static-proj
+  #     - name: compile therion
+  #       run: |
+  #         export PATH=/usr/lib/mxe/usr/bin:$PATH
+  #         perl makeconfig.pl PLATFORM WIN32CROSS
+  #         cd loch; perl makeconfig.pl PLATFORM WIN32CROSS; cd ..
+  #         make CROSS=x86_64-w64-mingw32.static- OUTDIR=. therion
+  #         make CROSS=x86_64-w64-mingw32.static- OUTDIR=. loch/loch
   mingw:
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
MXE packages are outdated, let's disable MXE builds until they catch up.