### PR TITLE
Require wxWidgets 3.0.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -44,7 +44,7 @@ endif()
 
 # loch dependencies
 if (BUILD_LOCH)
-    find_package(wxWidgets REQUIRED COMPONENTS core base gl xml html)
+    find_package(wxWidgets 3.0.0 REQUIRED COMPONENTS core base gl xml html)
     find_package(VTK REQUIRED COMPONENTS 
         vtkCommonExecutionModel
         vtkCommonDataModel

--- a/loch/lxAboutDlg.cxx
+++ b/loch/lxAboutDlg.cxx
@@ -94,7 +94,6 @@ lxAboutDlg::lxAboutDlg(wxWindow * parent)
   pbmp->SetSize(tmpsize.x - bmp.GetWidth(), tmpsize.y - bmp.GetHeight(), -1, -1);
   this->CentreOnParent();
 
-#if wxCHECK_VERSION(3,0,0)
   FindWindow(lxABDG_TEXT1)->Bind(wxEVT_KEY_DOWN, &lxAboutDlg::OnKeyPress, this);
   FindWindow(lxABDG_TEXT2)->Bind(wxEVT_KEY_DOWN, &lxAboutDlg::OnKeyPress, this);
   FindWindow(lxABDG_TEXT3)->Bind(wxEVT_KEY_DOWN, &lxAboutDlg::OnKeyPress, this);
@@ -103,12 +102,6 @@ lxAboutDlg::lxAboutDlg(wxWindow * parent)
   FindWindow(lxABDG_TEXT2)->Bind(wxEVT_LEFT_DOWN, &lxAboutDlg::OnMouseDown, this);
   FindWindow(lxABDG_TEXT3)->Bind(wxEVT_LEFT_DOWN, &lxAboutDlg::OnMouseDown, this);
   FindWindow(lxABDG_BMP)->Bind(wxEVT_LEFT_DOWN, &lxAboutDlg::OnMouseDown, this);
-#else
-  FindWindow(lxABDG_TEXT1)->SetEventHandler(this->GetEventHandler());
-  FindWindow(lxABDG_TEXT2)->SetEventHandler(this->GetEventHandler());
-  FindWindow(lxABDG_TEXT3)->SetEventHandler(this->GetEventHandler());
-  FindWindow(lxABDG_BMP)->SetEventHandler(this->GetEventHandler());
-#endif
   delete sizerBmp;
 
 }

--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -70,9 +70,7 @@ EVT_ERASE_BACKGROUND(lxGLCanvas::OnEraseBackground)
 EVT_ENTER_WINDOW(lxGLCanvas::OnEnterWindow )
 EVT_CHAR(lxGLCanvas::OnKeyPress)
 EVT_IDLE(lxGLCanvas::OnIdle)
-#if wxCHECK_VERSION(2,9,0)
 EVT_MOUSE_CAPTURE_LOST(lxGLCanvas::OnMouseCaptureLost)
-#endif
 END_EVENT_TABLE()
 
 
@@ -215,9 +213,7 @@ void lxGLCanvas::RenderScreen()
 
 }
 
-#if wxCHECK_VERSION(2,9,0)
 void lxGLCanvas::OnMouseCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event)) {}
-#endif
 
 
 
@@ -1582,11 +1578,7 @@ void lxGLCanvas::RenderICompass(double size) {
 
   glPopMatrix();
 
-#if wxCHECK_VERSION(3,0,0)
   this->GetFontNumeric()->draw((-2.0) * lxFNTSW, this->m_indRes * (-size - 1.0) - lxFNTSH, wxString::Format(wxString::FromUTF8(_("%03d\xc2\xb0")), int(this->setup->cam_dir)));
-#else
-  this->GetFontNumeric()->draw((-2.0) * lxFNTSW, this->m_indRes * (-size - 1.0) - lxFNTSH, wxString::Format(_("%03d\260)", int(this->setup->cam_dir)));
-#endif  
 
 }
 
@@ -1673,11 +1665,7 @@ void lxGLCanvas::RenderIClino(double size)
   glPopMatrix();
   glPopMatrix();
 
-#if wxCHECK_VERSION(3,0,0)
   this->GetFontNumeric()->draw(this->m_indRes * (-size) / 2.0 - 1.5 * lxFNTSW, this->m_indRes * (-1.0) - lxFNTSH, wxString::Format(wxString::FromUTF8(_("%03d\xc2\xb0")), int(this->setup->cam_tilt)));
-#else
-  this->GetFontNumeric()->draw(this->m_indRes * (-size) / 2.0 - 1.5 * lxFNTSW, this->m_indRes * (-1.0) - lxFNTSH, wxString::Format(_("%+03d\260"), int(this->setup->cam_tilt)));
-#endif  
 }
 
 

--- a/loch/lxGLC.h
+++ b/loch/lxGLC.h
@@ -107,11 +107,7 @@ class lxGLCanvas: public wxGLCanvas {
     void OnSize(wxSizeEvent& event);
     void OnEraseBackground(wxEraseEvent& event);
     void OnEnterWindow(wxMouseEvent& event);
-    
-#if wxCHECK_VERSION(2,9,0)
     void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
-#endif
-
     void OnMouseDouble(wxMouseEvent& event);
     void OnMouseDown(wxMouseEvent& event);
     void OnMouseUp(wxMouseEvent& event);

--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -1107,12 +1107,8 @@ void lxFrame::ImportFile(wxString fName, int fType)
 void lxFrame::LoadData(wxString fName, int fType) {
   {
   wxBusyInfo info(_("Building 3D model, please wait..."));
-#if wxCHECK_VERSION(3,0,0)
   wxWindowDisabler disableAll;
-#endif
-#if wxCHECK_VERSION(3,0,0)
   wxTheApp->Yield();
-#endif
   switch (fType) {
     case 1:
       this->data->m_input.ImportLOX(fName.mbc_str());
@@ -1127,9 +1123,7 @@ void lxFrame::LoadData(wxString fName, int fType) {
       this->data->m_input.m_error = "unable to detect file format";
       break;
   }
-#if wxCHECK_VERSION(3,0,0)
   wxTheApp->Yield();
-#endif
   switch (this->m_iniWallsInterpolate) {
     case LXWALLS_INTERP_ALL_ONLY:
       if (!this->data->m_input.HasAnyWalls())
@@ -1140,13 +1134,9 @@ void lxFrame::LoadData(wxString fName, int fType) {
       break;
   }
   this->data->Rebuild();
-#if wxCHECK_VERSION(3,0,0)
   wxTheApp->Yield();
-#endif  
   this->canvas->UpdateRenderContents();
-#if wxCHECK_VERSION(3,0,0)
   wxTheApp->Yield();
-#endif
   this->canvas->UpdateRenderList();
   }
   // We need to have disengaged the wxWindowDisabler here or else we get an
@@ -1180,12 +1170,7 @@ IMPLEMENT_APP(lxApp)
 
 bool lxApp::OnInit()
 {
-
-#if wxCHECK_VERSION(3,0,0)
     m_locale.Init(wxLANGUAGE_DEFAULT, wxLOCALE_LOAD_DEFAULT);
-#else
-    m_locale.Init(wxLANGUAGE_DEFAULT, wxLOCALE_LOAD_DEFAULT | wxLOCALE_CONV_ENCODING);
-#endif
     
 #ifdef LXWIN32
     m_locale.AddCatalogLookupPathPrefix("locale");

--- a/loch/lxSTree.cxx
+++ b/loch/lxSTree.cxx
@@ -49,12 +49,8 @@ void lxModelTreeDlg::OnCommand(wxCommandEvent& event)
       break;
     case wxID_OK: 
     	wxBusyInfo info(_("Building 3D model, please wait..."));
-#if wxCHECK_VERSION(3,0,0)
     	wxWindowDisabler disableAll;
-#endif
-#if wxCHECK_VERSION(3,0,0)
     	wxTheApp->Yield();
-#endif
 		this->m_mainFrame->data->ClearSurveySelection();
 		wxArrayTreeItemIds csel;
 		size_t selcnt = this->m_treeControl->GetSelections(csel);
@@ -67,15 +63,11 @@ void lxModelTreeDlg::OnCommand(wxCommandEvent& event)
     		}
     	}
 		this->m_mainFrame->data->Rebuild();
-#if wxCHECK_VERSION(3,0,0)
     	wxTheApp->Yield();
-#endif
 		this->m_mainFrame->canvas->UpdateContents();
 		this->m_mainFrame->setup->ResetCamera();
 		this->m_mainFrame->canvas->ForceRefresh();
-#if wxCHECK_VERSION(3,0,0)
     	wxTheApp->Yield();
-#endif
     	break;
   }
 }

--- a/loch/lxSView.cxx
+++ b/loch/lxSView.cxx
@@ -150,36 +150,20 @@ void lxViewpointSetupDlg::OnSlider(wxScrollEvent& event)
   switch (event.GetId()) {
     case LXVSTP_FACINGSLIDE:
 #ifndef LXDEPCHECK
-#if wxCHECK_VERSION(2,7,1)
       lxFTextCtrl(LXVSTP_FACING)->ChangeValue(wxString::Format(_T("%d"), event.GetInt()));
       tmpEvent.SetId(LXVSTP_FACING);
-#else
-      lxFTextCtrl(LXVSTP_FACING)->SetValue(wxString::Format(_T("%d"), event.GetInt()));
-#endif      
       break;
     case LXVSTP_TILTSLIDE:
-#if wxCHECK_VERSION(2,7,1)
       lxFTextCtrl(LXVSTP_TILT)->ChangeValue(wxString::Format(_T("%d"), event.GetInt()));
       tmpEvent.SetId(LXVSTP_TILT);
-#else
-      lxFTextCtrl(LXVSTP_TILT)->SetValue(wxString::Format(_T("%d"), event.GetInt()));
-#endif      
       break;
     case LXVSTP_ZOOMSLIDE:
-#if wxCHECK_VERSION(2,7,1)
       lxFTextCtrl(LXVSTP_ZOOM)->ChangeValue(wxString::Format(_T("%d"), int(20.0 * pow(100.0, (double(event.GetInt()) / 1000.0)))));
       tmpEvent.SetId(LXVSTP_ZOOM);
-#else
-      lxFTextCtrl(LXVSTP_ZOOM)->SetValue(wxString::Format(_T("%d"), int(20.0 * pow(100.0, (double(event.GetInt()) / 1000.0)))));
-#endif      
       break;
     case LXVSTP_DISTSLIDE:
-#if wxCHECK_VERSION(2,7,1)
       lxFTextCtrl(LXVSTP_DIST)->ChangeValue(wxString::Format(_T("%d"), int(pow(200.0 * this->m_mainFrame->setup->data_limits_diam, (double(event.GetInt()) / 1000.0)))));
       tmpEvent.SetId(LXVSTP_DIST);
-#else
-      lxFTextCtrl(LXVSTP_DIST)->SetValue(wxString::Format(_T("%d"), int(pow(200.0 * this->m_mainFrame->setup->data_limits_diam, (double(event.GetInt()) / 1000.0)))));
-#endif      
 #endif      
       break;
     case LXVSTP_ROTSPEED:
@@ -432,11 +416,7 @@ lxViewpointSetupDlg::lxViewpointSetupDlg(wxWindow *parent)
   ADDST(wxID_ANY, _("Rotation speed"))
 
   wxSlider * rspeed = new wxSlider(lxPanel, LXVSTP_ROTSPEED, 0, -1000, 1000, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL | wxSL_AUTOTICKS);
-#if wxCHECK_VERSION(3,0,0)
   rspeed->SetTickFreq(1000);
-#else
-  rspeed->SetTickFreq(1000,0);
-#endif
 
   lxBoxSizer->Add(
 		rspeed,

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -7,12 +7,6 @@
 #include <wx/spinctrl.h>
 #include <wx/slider.h>
 #include <wx/gbsizer.h>
-
-#if !wxCHECK_VERSION(2,7,0)
-#define wxFD_OVERWRITE_PROMPT wxOVERWRITE_PROMPT
-#define wxFD_SAVE wxSAVE
-#endif
-
 #endif  
 //LXDEPCHECK - standard libraries
 


### PR DESCRIPTION
wxWidgets 3.0.0 was released on  November 11, 2013, so it should not be necessary to support older releases. And because of syntax error in therion code it was not possible to build therion with older wxWidgets for the past 2 years.