### PR TITLE
clang-tidy bugprone checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone-reserved-identifier,bugprone-use-after-move,performance-for-range-copy'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-integer-division,-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings,-bugprone-suspicious-include,-bugprone-unhandled-self-assignment,-bugprone-branch-clone,-bugprone-sizeof-expression,performance-for-range-copy'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/loch/lxPres.cxx
+++ b/loch/lxPres.cxx
@@ -145,7 +145,7 @@ void lxPresentDlg::UpdateControls() {
   size_t count = this->m_posLBox->GetCount();
   wxWindow::FindWindowById(LXMENU_PRESUPDATE, this)->Enable(count > 0);
   wxWindow::FindWindowById(LXMENU_PRESDELETE, this)->Enable(count > 0);
-  wxWindow::FindWindowById(LXMENU_PRESMOVEDOWN, this)->Enable((count > 0) && (sel != wxNOT_FOUND) && (size_t(sel + 1) < count));
+  wxWindow::FindWindowById(LXMENU_PRESMOVEDOWN, this)->Enable((count > 0) && (sel != wxNOT_FOUND) && ((size_t(sel) + 1) < count));
   wxWindow::FindWindowById(LXMENU_PRESMOVEUP, this)->Enable((count > 0) && (sel != wxNOT_FOUND) && (sel > 0));
 }
 

--- a/loch/lxWX.cxx
+++ b/loch/lxWX.cxx
@@ -21,36 +21,12 @@ wxSize lxSize;
 wxPoint lxPoint;
 
 
-lxDoubleValidator::lxDoubleValidator(double * val, const double vmin, const double vmax, const wxChar * fmt) :
-	wxValidator() 
+lxDoubleValidator::lxDoubleValidator(double * val, const double vmin, const double vmax, const wxChar * fmt)
 {
 	this->m_variable = val;
 	this->m_vMin = vmin;
 	this->m_vMax = vmax;
   this->m_fmt = fmt;
-}
-
-
-lxDoubleValidator::lxDoubleValidator(const lxDoubleValidator & val) : 
-	wxValidator() 
-
-{
-	Copy(val);
-}
-
-bool lxDoubleValidator::Copy(const lxDoubleValidator& val)
-{
-	this->m_variable = val.m_variable;
-	this->m_vMin = val.m_vMin;
-	this->m_vMax = val.m_vMax;
-  this->m_fmt = val.m_fmt;
-  wxValidator::Copy(val);
-	return TRUE;
-	
-}
-
-lxDoubleValidator::~lxDoubleValidator()
-{
 }
 
     
@@ -100,32 +76,10 @@ bool lxDoubleValidator::TransferFromWindow()
 
 
 
-lxRadioBtnValidator::lxRadioBtnValidator(long * val, const long optval) :
-	wxValidator() 
+lxRadioBtnValidator::lxRadioBtnValidator(long * val, const long optval)
 {
 	this->m_variable = val;
 	this->m_variableValue = optval;
-}
-
-
-lxRadioBtnValidator::lxRadioBtnValidator(const lxRadioBtnValidator & val) : 
-	wxValidator() 
-
-{
-	Copy(val);
-}
-
-bool lxRadioBtnValidator::Copy(const lxRadioBtnValidator& val)
-{
-	this->m_variable = val.m_variable;
-	this->m_variableValue = val.m_variableValue;
-  wxValidator::Copy(val);
-	return TRUE;
-	
-}
-
-lxRadioBtnValidator::~lxRadioBtnValidator()
-{
 }
 
     

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -105,14 +105,8 @@ public:
 
 	lxDoubleValidator(double * val, const double vmin, const double vmax, const wxChar * fmt = _T("%.0f"));
 
-	lxDoubleValidator(const lxDoubleValidator & val);
-
-	~lxDoubleValidator();
-
   wxObject *Clone() const override { return new lxDoubleValidator(*this); }
 
-  bool Copy(const lxDoubleValidator& val);
-    
 	bool Validate(wxWindow *parent) override;
 
   bool TransferToWindow() override;
@@ -147,14 +141,8 @@ public:
 
 	lxRadioBtnValidator(long * val, const long optval);
 
-	lxRadioBtnValidator(const lxRadioBtnValidator & val);
-
-	~lxRadioBtnValidator();
-
   wxObject *Clone() const override { return new lxRadioBtnValidator(*this); }
 
-  bool Copy(const lxRadioBtnValidator& val);
-    
 	bool Validate(wxWindow *parent) override;
 
   bool TransferToWindow() override;

--- a/thparse.cxx
+++ b/thparse.cxx
@@ -179,7 +179,8 @@ void thsplit_strings(thmbuffer * dest, const char * src, const char separator)
     idx0 = 0;
   dest->clear();
   short state = 0; // 0 before, 1 in
-  unsigned char * s1 = NULL, * s2 = (unsigned char *) src;
+  const char * s1 = nullptr;
+  const char * s2 = src;
   while (idx < srcl) {
     switch (state) {
       case 0:
@@ -211,7 +212,8 @@ void thsplit_paths(thmbuffer * dest, const char * src, char separator)
     idx0 = 0;
   dest->clear();
   short state = 0; // 0 before, 1 in
-  unsigned char * s1 = NULL, * s2 = (unsigned char *) src;
+  const char * s1 = nullptr;
+  const char * s2 = src;
   while (idx < srcl) {
     switch (state) {
       case 0:
@@ -426,7 +428,7 @@ bool th_is_index(const char * str)
 bool th_is_keyword_list(const char * str, char sep)
 {
   size_t sl = strlen(str), i;
-  unsigned char * s = (unsigned char *) str;
+  const char * s = str;
   if (sl == 0)
     return false;
   else 

--- a/thsvg.cxx
+++ b/thsvg.cxx
@@ -80,12 +80,11 @@ std::string escape_html(std::string s) {
 
   std::string t = "";
   std::string close_font = "";
-  size_t i,j;
+  size_t i;
   for (i=0; i<s.length(); i++) {
     if ((char) s[i] == 27) {
       thassert(i<s.length()-1);
-      j = (char) s[++i];
-      switch (j) {
+      switch (s[++i]) {
         case 0x1:
           t += "<br/>"; 
           break;


### PR DESCRIPTION
Enabled more checks in `clang-tidy` from category `bugprone`, fixed issues:
* proper widening of types in arithmetic expressions to avoid loss of precision
* use default copy constructors when inheriting from `wxValidator`
* don't mix unsigned values and chars

I have disabled some checks, some of them were not relevant, some would probably cause change of behavior, and some were too noisy. We can enable and fix them in the future.