### PR TITLE
Use std::filesystem - removed chdir()

### DIFF
--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -50,14 +50,6 @@
 #include <set>
 #include <iterator>
 #include <cstdio>
-#ifndef THMSVC
-#include <unistd.h>
-#else
-#include <direct.h>
-#define getcwd _getcwd
-#define chdir _chdir
-#define putenv _putenv
-#endif
 
 class thprjx_link {
 
@@ -3627,10 +3619,9 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
   }
 #endif  
 
-  thbuffer com, wdir;
-  wdir.guarantee(1024);
-  thassert(getcwd(wdir.get_buffer(),1024) != NULL);
-  thassert(chdir(thtmp.get_dir_name()) == 0);
+  thbuffer com;
+  // working directory will be the tmpdir until this scope ends
+  const auto tmp_handle = thtmp.switch_to_tmpdir();
   int retcode;
 
   com = "\"";
@@ -3646,7 +3637,6 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
   "####################### metapost log file ########################\n",
   "#################### end of metapost log file ####################\n",true);
   if (retcode != EXIT_SUCCESS) {
-    thassert(chdir(wdir.get_buffer()) == 0);
     ththrow("metapost exit code -- {}", retcode);
   }
 
@@ -3718,9 +3708,6 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
 
     }
   }
-
-  thassert(chdir(wdir.get_buffer()) == 0);
-
 }
 
 

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -44,14 +44,6 @@
 #include <stdio.h>
 #include "thtmpdir.h"
 #include "thtrans.h"
-#ifndef THMSVC
-#include <unistd.h>
-#else
-#include <direct.h>
-#define getcwd _getcwd
-#define chdir _chdir
-#define putenv _putenv
-#endif
 #include "thchenc.h"
 #include "thdb1d.h"
 #include "thinit.h"
@@ -77,6 +69,7 @@
 #include "thsvg.h"
 #include "extern/img.h"
 #include "thcs.h"
+#include <optional>
 
 #include <fmt/printf.h>
 
@@ -2213,10 +2206,8 @@ if (ENC_NEW.NFSS==0) {
   fclose(tf);
 
   // teraz sa hodi do temp adresara - spusti metapost, thpdf, a pdftex a skopiruje vysledok
-  thbuffer com, wdir;
-  wdir.guarantee(1024);
-  thassert(getcwd(wdir.get_buffer(),1024) != NULL);
-  thassert(chdir(thtmp.get_dir_name()) == 0);
+  auto tmp_handle = std::optional(thtmp.switch_to_tmpdir());
+  thbuffer com;
   
   // vypise kodovania
   print_fonts_setup();
@@ -2286,7 +2277,6 @@ if (ENC_NEW.NFSS==0) {
     "####################### metapost log file ########################\n",
     "#################### end of metapost log file ####################\n",true);
     if (retcode != EXIT_SUCCESS) {
-      thassert(chdir(wdir.get_buffer()) == 0);
       ththrow("metapost exit code -- {}", retcode);
     }
   }
@@ -2334,12 +2324,11 @@ if (ENC_NEW.NFSS==0) {
       "######################## pdftex log file #########################\n",
       "##################### end of pdftex log file #####################\n",false);
       if (retcode != EXIT_SUCCESS) {
-        thassert(chdir(wdir.get_buffer()) == 0);
         ththrow("pdftex exit code -- {}", retcode);
       }
 
       // Let's copy results and log-file to working directory
-      thassert(chdir(wdir.get_buffer()) == 0);
+      tmp_handle = std::nullopt;
 #ifdef THWIN32
       com = "copy \"";
 #else
@@ -2370,14 +2359,14 @@ if (ENC_NEW.NFSS==0) {
 
     case TT_EXPMAP_FMT_SVG:
       thconvert_eps();
-      thassert(chdir(wdir.get_buffer()) == 0);
+      tmp_handle = std::nullopt;
       thsvg(fnm, 0, ldata);
       break;
       
 
     case TT_EXPMAP_FMT_XHTML:
       thconvert_eps();
-      thassert(chdir(wdir.get_buffer()) == 0);
+      tmp_handle = std::nullopt;
       thsvg(fnm, 1, ldata);
       break;
 

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -69,7 +69,6 @@
 #include "thsvg.h"
 #include "extern/img.h"
 #include "thcs.h"
-#include <optional>
 
 #include <fmt/printf.h>
 
@@ -2206,7 +2205,7 @@ if (ENC_NEW.NFSS==0) {
   fclose(tf);
 
   // teraz sa hodi do temp adresara - spusti metapost, thpdf, a pdftex a skopiruje vysledok
-  auto tmp_handle = std::optional(thtmp.switch_to_tmpdir());
+  auto tmp_handle = thtmp.switch_to_tmpdir();
   thbuffer com;
   
   // vypise kodovania
@@ -2328,7 +2327,7 @@ if (ENC_NEW.NFSS==0) {
       }
 
       // Let's copy results and log-file to working directory
-      tmp_handle = std::nullopt;
+      tmp_handle.switch_from_tmpdir();
 #ifdef THWIN32
       com = "copy \"";
 #else
@@ -2359,14 +2358,14 @@ if (ENC_NEW.NFSS==0) {
 
     case TT_EXPMAP_FMT_SVG:
       thconvert_eps();
-      tmp_handle = std::nullopt;
+      tmp_handle.switch_from_tmpdir();
       thsvg(fnm, 0, ldata);
       break;
       
 
     case TT_EXPMAP_FMT_XHTML:
       thconvert_eps();
-      tmp_handle = std::nullopt;
+      tmp_handle.switch_from_tmpdir();
       thsvg(fnm, 1, ldata);
       break;
 

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -716,10 +716,8 @@ void thinit::load()
       fprintf(ff,"\\nopagenumbers\n\\batchmode\n\\def\\fonttest#1{\\font\\a=#1\\a}\n\\fonttest{%s}\n\\fonttest{%s}\n\\fonttest{%s}\n\\fonttest{%s}\n\\fonttest{%s}\n\\end", J->rm.c_str(), J->it.c_str(), J->bf.c_str(), J->ss.c_str(), J->si.c_str());
       fclose(ff);
 
-      thbuffer com, wdir;
-      wdir.guarantee(1024);
-      thassert(getcwd(wdir.get_buffer(),1024) != NULL);
-      thassert(chdir(thtmp.get_dir_name()) == 0);
+      thbuffer com;
+      const auto tmp_handle = thtmp.switch_to_tmpdir();
       int retcode;
 
       com = "\"";
@@ -735,7 +733,6 @@ void thinit::load()
         TMPFONTS.push_back(*J);
         thprintf(" OK\n");
       }
-      thassert(chdir(wdir.get_buffer()) == 0);
     } else {
       TMPFONTS.push_back(*J);
     }

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -42,10 +42,6 @@
 #include "thpdf.h"
 #include "thtexfonts.h"
 #include <string.h>
-#ifdef THMSVC
-#include <direct.h>
-#define getcwd _getcwd
-#endif
 
 
 thlookup::thlookup()

--- a/thtmpdir.cxx
+++ b/thtmpdir.cxx
@@ -41,6 +41,25 @@
 
 namespace fs = std::filesystem;
 
+thtmpdir::tmpdir_handle::tmpdir_handle(const std::string& tmp_dir)
+{
+  try {
+    prev_dir = fs::current_path().string();
+    fs::current_path(tmp_dir);
+  } catch(const std::exception& e) {
+    thwarning(("error switching to temporary directory -- %s", e.what()));
+  }
+}
+
+thtmpdir::tmpdir_handle::~tmpdir_handle()
+{
+  try {
+    fs::current_path(prev_dir);
+  } catch(const std::exception& e) {
+    thwarning(("error switching from temporary directory -- %s", e.what()));
+  }
+}
+
 thtmpdir::thtmpdir()
 {
   this->exist = false;
@@ -160,6 +179,12 @@ void thtmpdir::delete_on()
 void thtmpdir::delete_off()
 {
   this->delete_all = false;
+}
+
+
+thtmpdir::tmpdir_handle thtmpdir::switch_to_tmpdir()
+{
+  return tmpdir_handle(get_dir_name());
 }
 
 thtmpdir thtmp;

--- a/thtmpdir.cxx
+++ b/thtmpdir.cxx
@@ -53,11 +53,21 @@ thtmpdir::tmpdir_handle::tmpdir_handle(const std::string& tmp_dir)
 
 thtmpdir::tmpdir_handle::~tmpdir_handle()
 {
+  switch_from_tmpdir();
+}
+
+void thtmpdir::tmpdir_handle::switch_from_tmpdir() noexcept
+{
+  if (prev_dir.empty())
+    return;
+
   try {
     fs::current_path(prev_dir);
   } catch(const std::exception& e) {
     thwarning(("error switching from temporary directory -- %s", e.what()));
   }
+
+  prev_dir.clear();
 }
 
 thtmpdir::thtmpdir()

--- a/thtmpdir.h
+++ b/thtmpdir.h
@@ -50,6 +50,17 @@ class thtmpdir {
         explicit tmpdir_handle(const std::string& tmp_dir);
         ~tmpdir_handle();
 
+        /**
+         * @brief Explicitly switch to the previous working directory.
+         */
+        void switch_from_tmpdir() noexcept;
+
+        // copy and move disabled, we don't need them
+        tmpdir_handle(const tmpdir_handle&) = delete;
+        tmpdir_handle(tmpdir_handle&& other) = delete;
+        tmpdir_handle& operator=(const tmpdir_handle&) = delete;
+        tmpdir_handle& operator=(tmpdir_handle&& other) = delete;
+
       private:
         std::string prev_dir;
     };

--- a/thtmpdir.h
+++ b/thtmpdir.h
@@ -38,6 +38,21 @@
  */
  
 class thtmpdir {
+  private:
+    /**
+     * @brief Helper class to switch between cwd and tmpdir.
+     * Constructor will set current working directory to the temporary directory,
+     * destructor vice versa.
+     */
+    class [[nodiscard]] tmpdir_handle
+    {
+      public:
+        explicit tmpdir_handle(const std::string& tmp_dir);
+        ~tmpdir_handle();
+
+      private:
+        std::string prev_dir;
+    };
 
   public:
 
@@ -116,7 +131,13 @@ class thtmpdir {
    */
   
   void delete_off();
-  
+
+  /**
+   * @brief Switch working directory to the temporary directory.
+   * @return Handle object which will switch back to the previous
+   * working directory in its destructor.
+   */
+  tmpdir_handle switch_to_tmpdir();
 };
 
 extern thtmpdir thtmp;


### PR DESCRIPTION
Introduced helper class for a common use case: switch to a temporary directory and back.