### PR TITLE
Use std::string_view

### DIFF
--- a/loch/icase.h
+++ b/loch/icase.h
@@ -2,17 +2,18 @@
 
 #include <algorithm>
 #include <functional>
-#include <string> // in C++17 replace with <string_view>
+#include <string_view>
+#include <cctype>
 
 namespace detail {
 
 using uchar_type = const unsigned char; // we need to convert chars to unsigned chars because of std::tolower's requirements
-using str_it = std::string::const_iterator;
+using str_it = std::string_view::const_iterator;
 using comparator = bool (*)(uchar_type, uchar_type);
 using algorithm = bool (*)(str_it, str_it, str_it, str_it, comparator);
 
 template <typename Comparator>
-inline bool icase_for_each(const std::string& a, const std::string& b, algorithm alg)
+inline bool icase_for_each(std::string_view a, std::string_view b, algorithm alg)
 {
     return alg(a.begin(), a.end(), 
                b.begin(), b.end(),
@@ -23,7 +24,7 @@ inline bool icase_for_each(const std::string& a, const std::string& b, algorithm
 /**
  * @brief Case insensitive comparison of two strings.
  */ 
-inline bool icase_equals(const std::string& a, const std::string& b)
+inline bool icase_equals(std::string_view a, std::string_view b)
 {
      return detail::icase_for_each<std::equal_to<>>(a, b, std::equal);
 }
@@ -31,7 +32,7 @@ inline bool icase_equals(const std::string& a, const std::string& b)
 /**
  * @brief Case insensitive ordering of two strings.
  */ 
-inline bool icase_less_than(const std::string& a, const std::string& b)
+inline bool icase_less_than(std::string_view a, std::string_view b)
 {
      return detail::icase_for_each<std::less<>>(a, b, std::lexicographical_compare);
 }

--- a/thparse.cxx
+++ b/thparse.cxx
@@ -44,10 +44,10 @@
 thmbuffer thparse_mbuff;
 
 template <typename Equality, typename Ordering>
-int binary_search_token(const std::string& token, const thstok *tab, const std::size_t tab_size, Equality equality, Ordering ordering)
+int binary_search_token(std::string_view token, const thstok *tab, const std::size_t tab_size, Equality equality, Ordering ordering)
 {
-  // comparator between thstok and string
-  auto compare_thstok = [&ordering](const thstok& a, const std::string& b){ return ordering(a.s, b); };
+  // comparator between thstok and string_view
+  auto compare_thstok = [&ordering](const thstok& a, std::string_view b){ return ordering(a.s, b); };
   // binary search, we leave out the last item
   auto it = std::lower_bound(tab, tab + tab_size - 1, token, compare_thstok);
   // if bound was found we also need to compare for equality
@@ -57,13 +57,13 @@ int binary_search_token(const std::string& token, const thstok *tab, const std::
   return tab[tab_size - 1].tok;
 }
 
-int thmatch_stok(const std::string& token, const thstok *tab, const std::size_t tab_size)
+int thmatch_stok(std::string_view token, const thstok *tab, const std::size_t tab_size)
 {
-  return binary_search_token(token, tab, tab_size, std::equal_to<std::string>(), std::less<std::string>());
+  return binary_search_token(token, tab, tab_size, std::equal_to<std::string_view>(), std::less<std::string_view>());
 }
 
 
-int thcasematch_stok(const std::string& token, const thstok *tab, const std::size_t tab_size)
+int thcasematch_stok(std::string_view token, const thstok *tab, const std::size_t tab_size)
 {
   return binary_search_token(token, tab, tab_size, icase_equals, icase_less_than);
 }

--- a/thparse.h
+++ b/thparse.h
@@ -66,9 +66,9 @@ typedef struct {
  * @sa thmatch_token
  */
  
-int thmatch_stok(const std::string& token, const thstok *tab, std::size_t tab_size);
+int thmatch_stok(std::string_view token, const thstok *tab, std::size_t tab_size);
  
-int thcasematch_stok(const std::string& token, const thstok *tab, std::size_t tab_size);
+int thcasematch_stok(std::string_view token, const thstok *tab, std::size_t tab_size);
 
 
 /**
@@ -76,13 +76,13 @@ int thcasematch_stok(const std::string& token, const thstok *tab, std::size_t ta
  */
 
 template <std::size_t N>
-inline int thmatch_token(const std::string& token, const thstok (&table)[N])
+inline int thmatch_token(std::string_view token, const thstok (&table)[N])
 {
   return thmatch_stok(token, table, N);
 }
 
 template <std::size_t N>
-inline int thcasematch_token(const std::string& token, const thstok (&table)[N])
+inline int thcasematch_token(std::string_view token, const thstok (&table)[N])
 {
   return thcasematch_stok(token, table, N);
 }


### PR DESCRIPTION
Use `std::string_view` for token comparison to avoid creating string temporaries.