### PR TITLE
Convert eligible lines to curves 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Therion 6.1.4 (in progress):
 
+xtherion:
+ * Added support for converting all eligible poly lines to curves in one operation [Mark Dickey]
 
 --------------------------------------------------------------------------------
 

--- a/xtherion/lang/xtexts.txt
+++ b/xtherion/lang/xtexts.txt
@@ -7075,3 +7075,66 @@ ru: стрелка
 sk: šípka
 sl: puščica krivulje
 
+therion: Convert eligible lines to curves
+bg: Convert eligible lines to curves
+cs: Convert eligible lines to curves
+de: Convert eligible lines to curves
+el: Convert eligible lines to curves
+en: Convert eligible lines to curves
+es: Convert eligible lines to curves
+fr: Convert eligible lines to curves
+it: Convert eligible lines to curves
+pt: Convert eligible lines to curves
+ru: Convert eligible lines to curves
+sk: Convert eligible lines to curves
+sl: Convert eligible lines to curves
+sq: Convert eligible lines to curves
+zh_CN: Convert eligible lines to curves
+
+therion: No
+bg: No
+cs: No
+de: No
+el: No
+en: No
+es: No
+fr: No
+it: No
+pt: No
+ru: No
+sk: No
+sl: No
+sq: No
+zh_CN: No
+
+therion: Yes
+bg: Yes
+cs: Yes
+de: Yes
+el: Yes
+en: Yes
+es: Yes
+fr: Yes
+it: Yes
+pt: Yes
+ru: Yes
+sk: Yes
+sl: Yes
+sq: Yes
+zh_CN: Yes
+
+therion: Converting
+bg: Converting
+cs: Converting
+de: Converting
+el: Converting
+en: Converting
+es: Converting
+fr: Converting
+it: Converting
+pt: Converting
+ru: Converting
+sk: Converting
+sl: Converting
+sq: Converting
+zh_CN: Converting

--- a/xtherion/me.tcl
+++ b/xtherion/me.tcl
@@ -2577,6 +2577,9 @@ $xth(me,menu,edit) add command -label [mc "Insert image"] \
 $xth(me,menu,edit) add separator
 $xth(me,menu,edit) add checkbutton -label [mc "Hide inactive scraps"] -variable xth(me,hinactives) -command xth_me_cmds_toggleishiding
 
+$xth(me,menu,edit) add separator
+$xth(me,menu,edit) add command -label [mc "Convert eligible lines to curves"] -command xth_me_cmds_line_allpoly2bezier
+
 set xth(me,menu,edit,undo) [$xth(me,menu,edit) index [mc "Undo"]]
 set xth(me,menu,edit,redo) [$xth(me,menu,edit) index [mc "Redo"]]
 set xth(me,menu,edit,zoom) [$xth(me,menu,edit) index [mc "Zoom 100 %"]]


### PR DESCRIPTION
Added support for converting all eligible lines to curves

A new option has been added to the Edit menu allowing all eligible lines to be converted to bezier curves in a single operation. This duplicates the logic from the existing conversion function to determine the count of lines and provide a confirmation prompt. A progress bar is provided while the process is running.