### PR TITLE
Fix uninitialized variables

### DIFF
--- a/loch/lxGLC.h
+++ b/loch/lxGLC.h
@@ -100,7 +100,7 @@ class lxGLCanvas: public wxGLCanvas {
 
 		bool m_sCameraAutoRotate, m_sCameraLockRotation;
     wxStopWatch m_sCameraAutoRotateSWatch;
-    long m_sCameraAutoRotateCounter;
+    long m_sCameraAutoRotateCounter = 0;
     double m_sCameraAutoRotateAngle, m_sCameraStartAutoRotateAngle = 0.0;
 
     void OnPaint(wxPaintEvent& event);

--- a/loch/lxMath.h
+++ b/loch/lxMath.h
@@ -129,7 +129,7 @@ struct lxTriGeom {
 
 struct lxPlane {
   lxVec m_point, m_normal;
-  double m_delta;
+  double m_delta = {};
   void Init(lxVec pt, lxVec norm);
   double CalcPosition(lxVec pt);
   bool CalcIntersection(lxVec fp, lxVec tp, lxVec & tgt);

--- a/loch/lxSetup.cxx
+++ b/loch/lxSetup.cxx
@@ -41,11 +41,9 @@
 lxSetup::lxSetup(lxData * dat) 
 {
   this->data = dat;
-  this->UpdateData();
   this->cam_dir = 0;
   this->cam_tilt = 90;
   this->cam_persp = true;
-  this->SetLens(50.0);
   this->cam_anaglyph = false;
   this->cam_anaglyph_bw = true;
   this->cam_anaglyph_left = false;
@@ -84,6 +82,8 @@ lxSetup::lxSetup(lxData * dat)
   this->m_walls_transparency = false;
   this->m_walls_opacity = 0.5;
 
+  this->UpdateData();
+  this->SetLens(50.0);
 }
 
 

--- a/thattr.cxx
+++ b/thattr.cxx
@@ -64,7 +64,7 @@ void thattr_obj::set_tree_level(size_t level) {
 
 thattr_field * thattr::insert_field(const char * name)
 {
-  thattr_field tmp, * r;
+  thattr_field tmp = {}, * r;
   tmp.m_id = this->m_num_fields++;
   tmp.m_name = name;
   tmp.m_parent = this;

--- a/thdate.cxx
+++ b/thdate.cxx
@@ -457,7 +457,7 @@ void thdate::join(thdate & dt)
 
 char * thdate::get_str(int fmt) {
   this->print_str(fmt);
-  return &(this->dstr[0]);
+  return this->dstr.begin();
 }
 
 
@@ -615,7 +615,7 @@ void date2tm(int y, int m, int d, int hh, int mm, double ss, tm * info)
 void thdate::print_str(int fmt) {
   unsigned int tl = thdate_bufflen - 1;
   long yyyy, mm, dd;
-  char * dst = &(this->dstr[0]);
+  char * dst = this->dstr.begin();
   const char * sep = " - ";
 
   switch (fmt) {

--- a/thdate.h
+++ b/thdate.h
@@ -27,6 +27,7 @@
  */
  
 #include <time.h>
+#include <array>
 
 #ifndef thdate_h
 #define thdate_h
@@ -83,7 +84,7 @@ class thdate {
   double ssec, ///< Start date seconds
     esec;  ///< End date seconds
     
-  char dstr[thdate_bufflen]; ///< String for given date.
+  std::array<char, thdate_bufflen> dstr = {}; ///< String for given date.
 
   friend bool operator < (const thdate &, const thdate &);  ///< Less operator.
   friend bool operator <= (const thdate &, const thdate &);  ///< Less operator.

--- a/thdb2d.h
+++ b/thdb2d.h
@@ -95,7 +95,7 @@ struct thdb2d_udef_prop {
   
   thlayout_color m_color;
   
-  int m_symid;
+  int m_symid = 0;
 
   void reset();
 

--- a/thepsparse.cxx
+++ b/thepsparse.cxx
@@ -912,7 +912,7 @@ void parse_eps(std::string fname, std::string cname, double dx, double dy,
   std::string tok, buffer;
   std::string font, patt;
   color pattcolor;
-  gradient grad;
+  gradient grad = {};
   bool comment = true, concat = false, 
        already_transp = false, transp_used = false, before_group_transp = false, cancel_transp = true;
   double llx = 0, lly = 0, urx = 0, ury = 0, HS = 0.0, VS = 0.0;

--- a/thpdf.cxx
+++ b/thpdf.cxx
@@ -140,7 +140,7 @@ std::list<sheetrecord>::iterator find_sheet(int x, int y, int z) {
 void make_sheets() {
   double llx = 0, lly = 0, urx = 0, ury = 0;
   double a,b,w,h;
-  sheetrecord SHREC;
+  sheetrecord SHREC = {};
 
   if (mode == ATLAS) {
     for (std::map<int,layerrecord>::iterator I = LAYERHASH.begin(); 

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -710,7 +710,7 @@ void thsvxctrl::load_err_file(class thdatabase * dbp, const char * lfnm) {
 
 //		thprintf("SCANNING: %s\n", line.c_str());
 		thsplit_args(&b, line.c_str());
-		thdb1d_traverse t, * ct;
+		thdb1d_traverse t = {}, * ct;
 		thdb1d_loop_leg l;
 		thdb1d_loop_leg * cl;
 		thdb1d_tree_node * cn;


### PR DESCRIPTION
Avoid using uninitialized variables, fixes warnings reported by Coverity Scan.