### PR TITLE
Fix failing copy on Windows

### DIFF
--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -869,6 +869,7 @@ void thexpmap::export_th2(class thdb2dprj * prj)
               thprintf("copying results\n");
 #endif
               const fs::path new_file = fmt::format("{}.{:03}.gif", fnm, sknum++);
+              fs::remove(new_file); // workaround for MinGW bug, can't overwrite files
               fs::copy(srcgif, new_file, fs::copy_options::overwrite_existing);
               fprintf(pltf,"##XTHERION## xth_me_image_insert {%.2f 1 1.0} {%.2f {}} %s 0 {}\n", nx, ny, new_file.filename().string().c_str());
             }
@@ -2291,6 +2292,7 @@ if (ENC_NEW.NFSS==0) {
 #ifdef THDEBUG
       thprintf("copying results\n");
 #endif
+      fs::remove(fnm); // workaround for MinGW bug, can't overwrite files
       fs::copy(thtmp.get_file_name("data.pdf"), fnm, fs::copy_options::overwrite_existing);
       break;
       // END OF PDF POSTPROCESSING

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -45,6 +45,8 @@
 #include <windows.h>
 #endif
 
+namespace fs = std::filesystem;
+
 const char * THCCC_INIT_FILE = "### Output character encodings ###\n"
 "# encoding-default  ASCII\n"
 "# encoding-sql  ASCII\n\n"
@@ -215,7 +217,9 @@ void thinit::copy_fonts() {
 #ifdef THDEBUG
     thprintf("copying font\n");
 #endif
-    std::filesystem::copy(font_src[index], thtmp.get_file_name(font_dst[index].c_str()), std::filesystem::copy_options::overwrite_existing);
+    const auto dst = thtmp.get_file_name(font_dst[index].c_str());
+    fs::remove(dst); // workaround for MinGW bug, can't overwrite files
+    fs::copy(font_src[index], dst, fs::copy_options::overwrite_existing);
   }
 
 #ifdef THWIN32


### PR DESCRIPTION
Therion is not able to overwrite existing files on Windows, probably bug in MinGW https://sourceforge.net/p/mingw-w64/bugs/852/. Workaround is to remove destination file, not overwrite it.