### PR TITLE
Coverity warnings: wrong printf argument types

### DIFF
--- a/thdata.cxx
+++ b/thdata.cxx
@@ -2729,7 +2729,7 @@ void thdata::set_survey_declination()
       }
       this->dl_survey_declination = csptr->get_declin()->evaluate(ad);
       if (!addef)
-      thwarning(("%s [%d] -- no declination specified for undated survey data -- using average (%.2f degrees)",
+      thwarning(("%s [%lu] -- no declination specified for undated survey data -- using average (%.2f degrees)",
         thdbreader.get_cinf()->get_cif_name(),
         thdbreader.get_cinf()->get_cif_line_number(),
         this->dl_survey_declination));

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -537,7 +537,7 @@ void thdatabase::end_insert()
   if (this->csurveyptr->id != this->fsurveyptr->id) {
     thdb_revision_set_type::iterator ii = 
         this->revision_set.find(threvision(this->csurveyptr->id, 0));
-    therror(("%s [%d] -- incomplete survey - endsurvey pair -- %s",
+    therror(("%s [%lu] -- incomplete survey - endsurvey pair -- %s",
       ii->srcf.name, ii->srcf.line, this->csurveyptr->full_name))
   }
 }

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -252,7 +252,7 @@ void thdb1d::scan_data()
                   else
                 	  bearing_sd = lei->bearing_sd;
                   if (abs(bearing_diff) > 3.0 * bearing_sd)
-                  	thwarning(("%s [%d] -- forwards and backwards bearing readings do not match -- %.2f > %.2f", lei->srcf.name, lei->srcf.line, bearing_diff, 2.0 * bearing_sd));
+                  	thwarning(("%s [%lu] -- forwards and backwards bearing readings do not match -- %.2f > %.2f", lei->srcf.name, lei->srcf.line, bearing_diff, 2.0 * bearing_sd));
 									// calculate average of two angles
                   //lei->bearing += lei->backbearing;
                   //lei->bearing = lei->bearing / 2.0;

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -1056,7 +1056,7 @@ void thexpmap::export_pdf(thdb2dxm * maps, thdb2dprj * prj) {
   // spusti mp - thpdf - pdftex
 
   if (maps == NULL) {
-    thwarning(("%s [%d] -- no selected projection data -- %s",
+    thwarning(("%s [%lu] -- no selected projection data -- %s",
       this->src.name, this->src.line, this->projstr))
     return;
   }
@@ -3216,7 +3216,7 @@ void thexpmap::export_uni(class thdb2dxm * maps, class thdb2dprj * /*prj*/) // T
 {
 
   if (maps == NULL) {
-    thwarning(("%s [%d] -- no selected projection data -- %s",
+    thwarning(("%s [%lu] -- no selected projection data -- %s",
       this->src.name, this->src.line, this->projstr))
     return;
   }

--- a/thexpshp.cxx
+++ b/thexpshp.cxx
@@ -560,7 +560,7 @@ void thexpmap::export_shp(class thdb2dxm * maps, class thdb2dprj * prj)
 {
 
   if (maps == NULL) {
-    thwarning(("%s [%d] -- no selected projection data -- %s",
+    thwarning(("%s [%lu] -- no selected projection data -- %s",
       this->src.name, this->src.line, this->projstr))
     return;
   }

--- a/thexpuni.cxx
+++ b/thexpuni.cxx
@@ -435,7 +435,7 @@ void thexpmap::export_kml(class thdb2dxm * maps, class thdb2dprj * prj)
   }
 
   if (maps == NULL) {
-    thwarning(("%s [%d] -- no selected projection data -- %s",
+    thwarning(("%s [%lu] -- no selected projection data -- %s",
       this->src.name, this->src.line, this->projstr))
     return;
   }
@@ -628,7 +628,7 @@ void thexpmap::export_bbox(class thdb2dxm * maps, class thdb2dprj * prj)
   }
 
   if (maps == NULL) {
-    thwarning(("%s [%d] -- no selected projection data -- %s",
+    thwarning(("%s [%lu] -- no selected projection data -- %s",
       this->src.name, this->src.line, this->projstr))
     return;
   }
@@ -721,7 +721,7 @@ void thexpmap::export_dxf(class thdb2dxm * maps, class thdb2dprj * /*prj*/) // T
 {
 
   if (maps == NULL) {
-    thwarning(("%s [%d] -- no selected projection data -- %s",
+    thwarning(("%s [%lu] -- no selected projection data -- %s",
       this->src.name, this->src.line, this->projstr))
     return;
   }

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -540,7 +540,7 @@ void thimport::import_file_img()
   img_close(pimg);
 
   if (notimpst > 0) {
-    thwarning(("unable to import %d stations outside survey", notimpst));
+    thwarning(("unable to import %lu stations outside survey", notimpst));
   }
 
   thsurvey * s1survey, * s2survey;
@@ -653,7 +653,7 @@ void thimport::import_file_img()
   }
 
   if (notimpsh > 0) {
-    thwarning(("unable to import %d shots outside survey", notimpsh));
+    thwarning(("unable to import %lu shots outside survey", notimpsh));
   }
 
 }

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -271,12 +271,12 @@ void thinput::open_file(char * fname)
     }
 #ifdef THWIN32
     if (n_rec == THMAXFREC) {
-      therror(("%s [%d] -- too many file inclusions -- probably input recursion -- %s", \
+      therror(("%s [%lu] -- too many file inclusions -- probably input recursion -- %s", \
       this->get_cif_name(), this->get_cif_line_number(), fname));
     }
 #else
     if (is_rec) {
-      therror(("%s [%d] -- recursive file inclusion -- %s", \
+      therror(("%s [%lu] -- recursive file inclusion -- %s", \
       this->get_cif_name(), this->get_cif_line_number(), fname));
     }
 #endif
@@ -358,7 +358,7 @@ char * thinput::read_line()
     // Check, if reading was OK.
     
     if (this->last_ptr->sh.fail() && (!(this->last_ptr->sh.eof()))) {
-      therror(("%s [%d] -- line too long", \
+      therror(("%s [%lu] -- line too long", \
         this->get_cif_name(), this->get_cif_line_number()));
     }
     

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -1079,7 +1079,7 @@ void thpoint::parse_value(char * ss, bool is_dist) {
     case TT_POINT_TYPE_EXTRA:
       opt_ok = is_dist;
       if (!opt_ok) {
-          thwarning(("%s [%d] -- using -value with point extra is deprecated, please use -dist instead", this->source.name, this->source.line));
+          thwarning(("%s [%lu] -- using -value with point extra is deprecated, please use -dist instead", this->source.name, this->source.line));
     	  opt_ok = true;
       }
       break;

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -510,7 +510,7 @@ void thselector::select_db(class thdatabase * db)
         objptr = NULL;
       }
       if (objptr == NULL) {
-        thwarning(("%s [%d] -- object not found -- \"%s\"", 
+        thwarning(("%s [%lu] -- object not found -- \"%s\"", 
           ii->src_name, ii->src_ln, nobj))
         to_cont = false;
       }

--- a/thsurface.cxx
+++ b/thsurface.cxx
@@ -237,7 +237,7 @@ void thsurface::parse_picture(char ** args)
     thparse_image(this->pict_name, this->pict_width, this->pict_height, this->pict_dpi, this->pict_type);
   } catch (const std::exception& e) {
     this->pict_name = NULL;
-    thwarning(("%s [%d] -- error reading bitmap -- %s",
+    thwarning(("%s [%lu] -- error reading bitmap -- %s",
       thdbreader.get_cinf()->get_cif_name(),
       thdbreader.get_cinf()->get_cif_line_number(), e.what()));
   }


### PR DESCRIPTION
Fixed printing of unsigned longs as ints.