### PR TITLE
Remove sprintf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if (BUILD_THERION)
     # therion lib
     add_library(therion-common STATIC ${THERION_HEADERS} ${THERION_SOURCES})
     target_include_directories(therion-common BEFORE PUBLIC "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/extern")
-    target_link_libraries(therion-common PUBLIC PkgConfig::PROJ fmt::fmt shp poly2tri common-utils QuickHull)
+    target_link_libraries(therion-common PUBLIC PkgConfig::PROJ shp poly2tri common-utils QuickHull)
     target_compile_definitions(therion-common PUBLIC PROJ_VER=${PROJ_MVER} "TH${THPLATFORM}" $<$<BOOL:${ENABLE_THDEBUG}>:THDEBUG>)
     add_dependencies(therion-common 
         version

--- a/loch/CMakeLists.txt
+++ b/loch/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(img PRIVATE disable-warnings)
 # library common with therion
 add_library(common-utils STATIC icase.h lxFile.h lxFile.cxx lxMath.h lxMath.cxx)
 target_compile_definitions(common-utils PRIVATE ${LOCH_DEFINITIONS})
-target_link_libraries(common-utils PUBLIC img enable-warnings)
+target_link_libraries(common-utils PUBLIC img enable-warnings fmt::fmt)
 
 if (NOT BUILD_LOCH)
     return()

--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -51,6 +51,8 @@
 #include "lxR2P.h"
 #endif
 
+#include <fmt/printf.h>
+
 #define LXTRCBORDER (this->m_renderData->m_scaleMode == LXRENDER_FIT_SCREEN ? 0 : 16)
 
 BEGIN_EVENT_TABLE(lxGLCanvas, wxGLCanvas)
@@ -1244,7 +1246,7 @@ void lxGLCanvas::RenderOffList()
   glLoadIdentity();
   std::string cmnt;
   const char * csurvey;
-  char strCBar[10];
+  std::string strCBar;
   bool show_label;
   this->GetFontNumeric()->setForegroundColor(1.0, 1.0, 0.5, 1.0);
   if (this->setup->m_stlabel_name || this->setup->m_stlabel_comment || this->setup->m_stlabel_altitude || this->setup->m_stlabel_survey) {
@@ -1276,9 +1278,9 @@ void lxGLCanvas::RenderOffList()
       // altitude
       if (this->setup->m_stlabel_altitude) {
         if (this->frame->m_iniUnits == 1) {
-          sprintf(&(strCBar[0]), "%.0f ft", st->pos.z / 0.3048);
+          strCBar = fmt::sprintf("%.0f ft", st->pos.z / 0.3048);
         } else {
-          sprintf(&(strCBar[0]), "%.0f m", st->pos.z);
+          strCBar = fmt::sprintf("%.0f m", st->pos.z);
         }
         if (cmnt.length() > 0) cmnt += ":";
         cmnt += strCBar;
@@ -1696,14 +1698,14 @@ void lxGLCanvas::RenderIDepthbar(double size)
   clrOutCntr();
   this->RenderILine(dbw, 0.0, dbw, size);
 
-  char strCBar[10];
+  std::string strCBar;
   for(t = 0; t <= 10; t++) {
     clrOutCntr();
     this->RenderILine(dbw, double(t) * size / 10.0, dbw + dbtw, double(t) * size / 10.0);
     if (this->frame->m_iniUnits == 1) {
-      sprintf(&(strCBar[0]), "%.0f ft", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])) / 0.3048);
+      strCBar = fmt::sprintf("%.0f ft", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])) / 0.3048);
     } else {
-      sprintf(&(strCBar[0]), "%.0f m", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])));
+      strCBar = fmt::sprintf("%.0f m", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])));
     }
     this->GetFontNumeric()->draw(this->m_indRes * dbw + lxFNTSW, this->m_indRes * (double(t) * size / 10.0) - 0.333 * lxFNTSH, strCBar);
   }
@@ -1723,7 +1725,7 @@ void lxGLCanvas::RenderIScalebar(double size)
   // nasobku standardnej velkosti
 
   // pixel -> 1 meter???
-  char strLen[32];
+  std::string strLen;
   double sblen, scale;
   int sbtest;
   // scale = m / pixel
@@ -1761,11 +1763,11 @@ void lxGLCanvas::RenderIScalebar(double size)
 
 
     if (miles)
-      sprintf(&(strLen[0]),"%.0f mi", sblen);
+      strLen = fmt::sprintf("%.0f mi", sblen);
     else if (sblen > 4.0)
-      sprintf(&(strLen[0]),"%.0f ft", sblen);
+      strLen = fmt::sprintf("%.0f ft", sblen);
     else
-      sprintf(&(strLen[0]),"%g in", 12.0 * sblen);
+      strLen = fmt::sprintf("%g in", 12.0 * sblen);
 
   } else {
 
@@ -1779,13 +1781,13 @@ void lxGLCanvas::RenderIScalebar(double size)
     size = sblen / scale / this->m_indRes;
 
     if (sblen >= 10000.0)
-      sprintf(&(strLen[0]),"%.0f km", sblen / 1000.0);
+      strLen = fmt::sprintf("%.0f km", sblen / 1000.0);
     else if (sblen >= 4.0)
-      sprintf(&(strLen[0]),"%.0f m", sblen);
+      strLen = fmt::sprintf("%.0f m", sblen);
     else if (sblen >= 0.01)
-      sprintf(&(strLen[0]),"%.0f mm", sblen * 1000.0);
+      strLen = fmt::sprintf("%.0f mm", sblen * 1000.0);
     else
-      sprintf(&(strLen[0]),"%g mm", sblen * 1000.0);
+      strLen = fmt::sprintf("%g mm", sblen * 1000.0);
   }
 
 
@@ -1821,7 +1823,7 @@ void lxGLCanvas::RenderIScalebar(double size)
   this->RenderILine(0.9 * size, sbh, 0.9 * size, sbh + sbt/3.0);
   this->RenderILine(      size, 0.0,       size, sbh + sbt);
 
-  this->GetFontNumeric()->draw(0.5 * size * this->m_indRes - 0.5 * double(strlen(strLen)) * lxFNTSW, (sbh + sbt + 1.0) * this->m_indRes, strLen);
+  this->GetFontNumeric()->draw(0.5 * size * this->m_indRes - 0.5 * double(strLen.size()) * lxFNTSW, (sbh + sbt + 1.0) * this->m_indRes, strLen);
 
 }
 

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -867,7 +867,7 @@ void lxRenderFile::RenderPDFHeader()
 
   pdf_obj[4] = ftell(this->m_file);
   const auto tmp_buff = fmt::sprintf("q\n%.4f 0 0 %.4f 0 0 cm\n/Im1 Do\nQ\n", imw, imh);
-  fprintf(this->m_file,"4 0 obj <<\n/Length %lu\n>>\nstream\n%sendstream\nendobj\n", tmp_buff.size(), tmp_buff.c_str());
+  fprintf(this->m_file,"4 0 obj <<\n/Length %u\n>>\nstream\n%sendstream\nendobj\n", static_cast<unsigned>(tmp_buff.size()), tmp_buff.c_str());
 
   pdf_obj[3] = ftell(this->m_file);
   fprintf(this->m_file,"3 0 obj <<\n/Type /Page\n/Contents 4 0 R\n/Resources 2 0 R\n/MediaBox [0 0 %.4f %.4f]\n/Parent 5 0 R\n>> endobj\n", imw, imh);

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -39,6 +39,8 @@
 #include "lxGUI.h"
 #include "lxFile.h"
 
+#include <fmt/printf.h>
+
 #define lxRENDERBORDER this->m_glc->TRCGet(TR_TILE_BORDER)
 
 //#ifdef LXLINUX
@@ -860,14 +862,12 @@ void lxRenderFile::RenderPDFHeader()
   double imw, imh;
   imw = 72.0 * this->m_imgWidth / imgRes;
   imh = 72.0 * this->m_imgHeight / imgRes;
-  char tmp_buff[256];
-
 
   fprintf(this->m_file,"%%PDF-1.4\n");
 
   pdf_obj[4] = ftell(this->m_file);
-  sprintf(tmp_buff, "q\n%.4f 0 0 %.4f 0 0 cm\n/Im1 Do\nQ\n", imw, imh);
-  fprintf(this->m_file,"4 0 obj <<\n/Length %u\n>>\nstream\n%sendstream\nendobj\n", (unsigned)strlen(tmp_buff), tmp_buff);
+  const auto tmp_buff = fmt::sprintf("q\n%.4f 0 0 %.4f 0 0 cm\n/Im1 Do\nQ\n", imw, imh);
+  fprintf(this->m_file,"4 0 obj <<\n/Length %lu\n>>\nstream\n%sendstream\nendobj\n", tmp_buff.size(), tmp_buff.c_str());
 
   pdf_obj[3] = ftell(this->m_file);
   fprintf(this->m_file,"3 0 obj <<\n/Type /Page\n/Contents 4 0 R\n/Resources 2 0 R\n/MediaBox [0 0 %.4f %.4f]\n/Parent 5 0 R\n>> endobj\n", imw, imh);

--- a/thattr.cxx
+++ b/thattr.cxx
@@ -254,12 +254,11 @@ std::string expdbf_field_name(std::string name, std::set<std::string> & fset)
   std::string nn;
   nn = name;
   int i;
-  char x[20];
   if (nn.length() > 11) {
     do {
       i = 0;
-      sprintf(x, "%d", i);
-      nn = name.substr(0, 10 - strlen(x));
+      const auto x = std::to_string(i);
+      nn = name.substr(0, 10 - x.size());
       nn += "_";
       nn += x;
       i++;
@@ -302,7 +301,6 @@ void thattr::analyze_fields()
   double cvald;
   size_t cslen;
   int ctype;
-  char b[64];
   thattr_attr * ca;
   thattr_obj_list::iterator oi;
   thattr_id2attr_map::iterator ai;
@@ -315,14 +313,12 @@ void thattr::analyze_fields()
         case THATTR_INTEGER:
           cvall = ca->m_val_long;
           ca->m_val_double = double(cvall);
-          sprintf(b,"%ld", cvall);
-          ca->m_val_string = b;
+          ca->m_val_string = std::to_string(cvall);
           break;
         case THATTR_DOUBLE:
           cvald = ai->second.m_val_double;
           ca->m_val_long = long(cvald);
-          sprintf(b,"%f", cvald);
-          ca->m_val_string = b;
+          ca->m_val_string = std::to_string(cvald);
           if (cf->m_type == THATTR_INTEGER)
             cf->m_type = THATTR_DOUBLE;
           break;

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -906,7 +906,7 @@ void thexpmap::export_th2(class thdb2dprj * prj)
               }
               if (pt->type == TT_POINT_TYPE_STATION) {
                 if (pt->station_name.id != 0) {
-                  fprintf(pltf," -name %s", pt->station_name.print_name());
+                  fprintf(pltf," -name %s", pt->station_name.print_name().c_str());
                 }
               }
               if (strlen(pt->name) > 0) {
@@ -1111,8 +1111,7 @@ void thexpmap::export_pdf(thdb2dxm * maps, thdb2dprj * prj) {
   thdb2dxm * cmap = maps;
   thdb2dxs * cbm;
   thdb2dmi * cmi;
-  thbuffer encb, texb;
-  texb.guarantee(128);
+  thbuffer encb;
   thscrap * cs;
 
   thini.copy_fonts();
@@ -1577,8 +1576,7 @@ if (ENC_NEW.NFSS==0) {
                   // pred orezanim
                   if (exps.F > 0) {
                     fprintf(plf,"\t\t F => \"data.%ld\",\n",exps.F);
-                    sprintf(texb.get_buffer(),"data.%ld",exps.F);
-                    SCRAPITEM->F = texb.get_buffer();
+                    SCRAPITEM->F = fmt::sprintf("data.%ld",exps.F);
                   }
 //                  else
 //                    fprintf(plf,"\t\t F => \"data.0\",\n");
@@ -1586,14 +1584,11 @@ if (ENC_NEW.NFSS==0) {
                   // orezavacia cesta a outlines
                   if (exps.B > 0) {
                     fprintf(plf,"\t\t B => \"data.%ld\",\n",exps.B);
-                    sprintf(texb.get_buffer(),"data.%ld",exps.B);
-                    SCRAPITEM->B = texb.get_buffer();
+                    SCRAPITEM->B = fmt::sprintf("data.%ld",exps.B);
                     fprintf(plf,"\t\t I => \"data.%ldbg\",\n",exps.B);
-                    sprintf(texb.get_buffer(),"data.%ldbg",exps.B);
-                    SCRAPITEM->I = texb.get_buffer();
+                    SCRAPITEM->I = fmt::sprintf("data.%ldbg",exps.B);
                     fprintf(plf,"\t\t C => \"data.%ldclip\",\n",exps.B);
-                    sprintf(texb.get_buffer(),"data.%ldclip",exps.B);
-                    SCRAPITEM->C = texb.get_buffer();
+                    SCRAPITEM->C = fmt::sprintf("data.%ldclip",exps.B);
                   }
 //                  else {
 //                    fprintf(plf,"\t\t B => \"data.0\",\n");
@@ -1604,19 +1599,16 @@ if (ENC_NEW.NFSS==0) {
                   // po orezani
                   if (exps.E > 0) {
                     fprintf(plf,"\t\t E => \"data.%ld\",\n",exps.E);
-                    sprintf(texb.get_buffer(),"data.%ld",exps.E);
-                    SCRAPITEM->E = texb.get_buffer();
+                    SCRAPITEM->E = fmt::sprintf("data.%ld",exps.E);
                   }
 //                  else
 //                    fprintf(plf,"\t\t E => \"data.0\",\n");
     
                   if (exps.X > 0) {
                     fprintf(plf,"\t\t X => \"data.%ld\",\n",exps.X);
-                    sprintf(texb.get_buffer(),"data.%ld",exps.X);
-                    SCRAPITEM->X = texb.get_buffer();
+                    SCRAPITEM->X = fmt::sprintf("data.%ld",exps.X);
                     fprintf(plf,"\t\t P => \"data.%ldbbox\",\n",exps.X);
-                    sprintf(texb.get_buffer(),"data.%ldbbox",exps.X);
-                    SCRAPITEM->P = texb.get_buffer();
+                    SCRAPITEM->P = fmt::sprintf("data.%ldbbox",exps.X);
                   }
 
                   if (export_outlines_only) {
@@ -1650,14 +1642,11 @@ if (ENC_NEW.NFSS==0) {
                     active_clr.set_color(this->layout->color_model, SCRAPITEM->col_scrap);
       
                     fprintf(plf,"\t\t B => \"data.%ld\",\n",exps.B);
-                    sprintf(texb.get_buffer(),"data.%ld",exps.B);
-                    SCRAPITEM->B = texb.get_buffer();
+                    SCRAPITEM->B = fmt::sprintf("data.%ld",exps.B);
                     fprintf(plf,"\t\t I => \"data.%ldbg\",\n",exps.B);
-                    sprintf(texb.get_buffer(),"data.%ldbg",exps.B);
-                    SCRAPITEM->I = texb.get_buffer();
+                    SCRAPITEM->I = fmt::sprintf("data.%ldbg",exps.B);
                     fprintf(plf,"\t\t C => \"data.%ldclip\",\n",exps.B);
-                    sprintf(texb.get_buffer(),"data.%ldclip",exps.B);
-                    SCRAPITEM->C = texb.get_buffer();
+                    SCRAPITEM->C = fmt::sprintf("data.%ldclip",exps.B);
                     //fprintf(plf,"\t\t B => \"data.%ld\",\n",exps.B);
                     //fprintf(plf,"\t\t I => \"data.%ldbg\",\n",exps.B);
                     //fprintf(plf,"\t\t C => \"data.%ldclip\",\n",exps.B);
@@ -1706,12 +1695,10 @@ if (ENC_NEW.NFSS==0) {
   	  break;
   }
 
-  sprintf(texb.get_buffer(),"data.%d",sfig);
-  LAYOUT.northarrow = texb.get_buffer();
+  LAYOUT.northarrow = fmt::sprintf("data.%d",sfig);
   fprintf(mpf,"beginfig(%d);\ns_northarrow(%g);\nendfig;\n",sfig++,this->layout->rotate + rotate_plus);
 
-  sprintf(texb.get_buffer(),"data.%d",sfig);
-  LAYOUT.scalebar = texb.get_buffer();
+  LAYOUT.scalebar = fmt::sprintf("data.%d",sfig);
   //std::snprintf(prevbf,127,"%g",sblen);
   fprintf(mpf,"beginfig(%d);\ns_scalebar(%g, %g, \"%s\");\nendfig;\n",
     sfig++, sblen, 1.0 / this->layout->units.convert_length(1.0), utf2tex(this->layout->units.format_i18n_length_units()));
@@ -1725,8 +1712,7 @@ if (ENC_NEW.NFSS==0) {
     switch (this->layout->color_crit) {
       case TT_LAYOUT_CCRIT_ALTITUDE:
       case TT_LAYOUT_CCRIT_DEPTH:
-    	  sprintf(texb.get_buffer(),"data.%d",sfig);
-    	  LAYOUT.altitudebar = texb.get_buffer();
+    	  LAYOUT.altitudebar = fmt::sprintf("data.%d",sfig);
     	  sv_min = this->layout->m_lookup->m_table.begin()->m_valueDbl;
     	  for(const auto& ti : this->layout->m_lookup->m_table) {
     		  sv_max = ti.m_valueDbl;
@@ -1939,8 +1925,7 @@ if (ENC_NEW.NFSS==0) {
   if (this->layout->grid != TT_LAYOUT_GRID_OFF) {
 
 #define expgridscrap(varname,Xpos,Ypos) \
-    sprintf(texb.get_buffer(),"data.%d",sfig); \
-    LAYOUT.varname = texb.get_buffer(); \
+    LAYOUT.varname = fmt::sprintf("data.%d",sfig); \
     fprintf(mpf,"beginfig(%d);\n%s(%d, %d, %.5f, %.5f);\nendfig;\n", \
     sfig++, grid_macro, Xpos, Ypos, ghs, gvs);
     
@@ -2007,7 +1992,8 @@ if (ENC_NEW.NFSS==0) {
       if (anyprev)
             fprintf(plf,"\",\n");      
       
-
+      thbuffer texb;
+      texb.guarantee(128);
       thdecode(& texb,TT_ISO8859_2,(strlen(cmap->map->title) > 0 ? cmap->map->title : cmap->map->name));      
       thdecode_tex(& encb, texb.get_buffer());
       fprintf(plf,"\t\tN => '%s',\n",encb.get_buffer());
@@ -2797,7 +2783,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
           tmps = &(thdb.db1d.station_vec[slp->station_name.id - 1]);
           out->symset->export_mp_symbol_options(dbg_stnms, SYMP_STATIONNAME);
           dbg_stnms.push_back(fmt::sprintf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, p_label_mode_debugstation);",
-            (const char *) utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
+            utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
             thxmmxst(out, slp->stx, slp->sty)));
         }
       }
@@ -2876,7 +2862,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
                 if (out->layout->is_debug_stationnames() && (tmps != NULL)) {
                       out->symset->export_mp_symbol_options(dbg_stnms, SYMP_STATIONNAME);
                       dbg_stnms.push_back(fmt::sprintf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, p_label_mode_debugstation);",
-                      (const char *) utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
+                      utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
                       thxmmxst(out, ptp->point->xt, ptp->point->yt)));
                 }
               }
@@ -3000,9 +2986,9 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
     thdb2dpt tmppt;
     tmppt.xt = (scrap->lxmin + scrap->lxmax) / 2.0;
     tmppt.yt = (scrap->lymin + scrap->lymax) / 2.0;
-    thdb.buff_tmp = utf2tex(thobjectname_print_full_name(scrap->name, scrap->fsptr, layout->survey_level));
+    const auto name = utf2tex(thobjectname_print_full_name(scrap->name, scrap->fsptr, layout->survey_level));
     fprintf(out->file,"drawoptions();\n");
-    fprintf(out->file,"p_label(btex \\thlargesize %s etex,",thdb.buff_tmp.get_buffer());
+    fprintf(out->file,"p_label(btex \\thlargesize %s etex,", name.c_str());
     tmppt.export_mp(out);
     fprintf(out->file,",0.0,p_label_mode_debugscrap);\n");
   }

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -50,6 +50,8 @@
 #include <filesystem>
 #include <thread>
 
+#include <fmt/printf.h>
+
 thexpmodel::thexpmodel() {
   this->format = TT_EXPMODEL_FMT_UNKNOWN;
   this->items = TT_EXPMODEL_ITEM_ALL;
@@ -760,10 +762,8 @@ void thexpmodel::export_vrml_file(class thdatabase * dbp) {
               "Shape {\nappearance Appearance {\n" \
               "\tmaterial Material {\n\t\tdiffuseColor 0.3 1.0 0.1\n\t\ttransparency 0.5\n\t}\n");
             if (has_texture) {
-              thbuffer tifn;
-              tifn.guarantee(2048);
-              sprintf(tifn.get_buffer(), "%s.img%d.%s", fnm, imgn++, srfc->pict_type == TT_IMG_TYPE_JPEG ? "jpg" : "png");
-              auto texf = thopen_file(tifn.get_buffer(), "wb");
+              const auto tifn = fmt::sprintf("%s.img%d.%s", fnm, imgn++, srfc->pict_type == TT_IMG_TYPE_JPEG ? "jpg" : "png");
+              auto texf = thopen_file(tifn, "wb");
               auto xf = thopen_file(srfc->pict_name, "rb");
               if (texf != NULL) {
                 if (xf != NULL) {
@@ -778,7 +778,7 @@ void thexpmodel::export_vrml_file(class thdatabase * dbp) {
                   }
                 }
                 fprintf(pltf,
-                  "\ttexture ImageTexture {\n\t\turl [\"%s\"]\n\t}\n", tifn.get_buffer());
+                  "\ttexture ImageTexture {\n\t\turl [\"%s\"]\n\t}\n", tifn.c_str());
               }
             }
             fprintf(pltf,

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -39,6 +39,8 @@
 #include <list>
 #include <filesystem>
 
+#include <fmt/printf.h>
+
 struct thsst {
   std::string name, fullname;
   thsurvey * survey;  
@@ -435,10 +437,7 @@ void thimport::import_file_img()
   if (this->filter != NULL)
     filterl = strlen(this->filter);
   thbuffer n1, n2;
-  thbuffer xb, yb, zb;
-    xb.guarantee(128);
-    yb.guarantee(128);
-    zb.guarantee(128);
+  std::string xb, yb, zb;
   std::string orig_name, new_name;  
   img* pimg = img_open(this->fname);
   if (pimg == NULL) {	
@@ -479,9 +478,9 @@ void thimport::import_file_img()
         if (strlen(stnm) < 1)
           break;
         if (svxs2ths.find(orig_name) == svxs2ths.end()) {
-          sprintf(xb.get_buffer(), "%.16g", imgpt.x + this->calib_x);
-          sprintf(yb.get_buffer(), "%.16g", imgpt.y + this->calib_y);
-          sprintf(zb.get_buffer(), "%.16g", imgpt.z + this->calib_z);
+          xb = fmt::sprintf("%.16g", imgpt.x + this->calib_x);
+          yb = fmt::sprintf("%.16g", imgpt.y + this->calib_y);
+          zb = fmt::sprintf("%.16g", imgpt.z + this->calib_z);
           tmpsurvey = this->db->csurveyptr;
           new_name = this->station_name(stnm, pimg->separator, &tmpsst);
           // thprintf("%s -> %s\n", pimg->label, new_name.c_str());
@@ -508,9 +507,9 @@ void thimport::import_file_img()
           tmpsst.fullname = new_name;
           svxpos2ths[tmppos] = tmpsst;
           svxs2ths[orig_name] = new_name;
-          args[1] = xb.get_buffer();
-          args[2] = yb.get_buffer();
-          args[3] = zb.get_buffer();
+          args[1] = xb.data();
+          args[2] = yb.data();
+          args[3] = zb.data();
           args[0] = n1.get_buffer();
           tmpdata->cs = this->cs;
           tmpdata->set_data_fix(4, args);

--- a/thobjectname.h
+++ b/thobjectname.h
@@ -32,6 +32,8 @@
 #include "thmbuffer.h"
 #include "therion.h"
 
+#include <string>
+
 /**
  * Survey station class.
  */
@@ -78,20 +80,20 @@ class thobjectname {
    * Print object name with survey into str.
    */
 
-  char * print_name();
+  std::string print_name();
   
 
   /**
    * Print object name with survey up to given level into str.
    */
 
-  char * print_full_name(int slevel = -1);
+  std::string print_full_name(int slevel = -1);
     
 };
 
 void thparse_objectname(thobjectname & ds, thmbuffer * sstore, char * src, class thdataobject * psobj = NULL);
 
-char * thobjectname_print_full_name(const char * oname, class thsurvey * psrv, int slevel = -1);
+std::string thobjectname_print_full_name(const char * oname_ptr, class thsurvey * psrv, int slevel = -1);
 
 void fprintf(FILE * fh, thobjectname & ds);
 

--- a/thpic.cxx
+++ b/thpic.cxx
@@ -35,6 +35,8 @@
 #include "thconfig.h"
 #include <filesystem>
 
+#include <fmt/printf.h>
+
 namespace fs = std::filesystem;
 
 long thpic_convert_number(1);
@@ -150,9 +152,8 @@ const char * thpic::convert(const char * type, const char * ext, const std::stri
   thbuffer ccom;
   int retcode;
   bool isspc;
-  char tmpfn[255];
   const char * tmpf;
-  sprintf(tmpfn, "pic%04ld.%s", thpic_convert_number++, ext);
+  const auto tmpfn = fmt::sprintf("pic%04ld.%s", thpic_convert_number++, ext);
   isspc = (strcspn(thini.get_path_convert()," \t") < strlen(thini.get_path_convert()));
   ccom = "";
   if (isspc) ccom += "\"";
@@ -168,7 +169,7 @@ const char * thpic::convert(const char * type, const char * ext, const std::stri
   if (isspc) ccom += "\"";
   ccom += " ";
 
-  tmpf = thtmp.get_file_name(tmpfn);
+  tmpf = thtmp.get_file_name(tmpfn.c_str());
   isspc = (strcspn(tmpf," \t") < strlen(tmpf));
   if (isspc) ccom += "\"";
   ccom += type;
@@ -178,7 +179,7 @@ const char * thpic::convert(const char * type, const char * ext, const std::stri
 
   retcode = system(ccom.get_buffer());
   if (retcode == EXIT_SUCCESS) {
-    ccom = thtmp.get_file_name(tmpfn);
+    ccom = thtmp.get_file_name(tmpfn.c_str());
     size_t x, l;
     l = strlen(ccom);
     for (x = 0; x < l; x++) if (ccom.get_buffer()[x] == '\\') ccom.get_buffer()[x] = '/';
@@ -248,9 +249,8 @@ void thpic::rgba_save(const char * type, const char * ext, int colors)
   thpic tmp;
   tmp.width = this->width;
   tmp.height = this->height;
-  char tmpfn[255];
-  sprintf(tmpfn, "pic%04ld.rgba", thpic_convert_number++);
-  tmp.fname = thdb.strstore(thtmp.get_file_name(tmpfn));
+  auto tmpfn = fmt::sprintf("pic%04ld.rgba", thpic_convert_number++);
+  tmp.fname = thdb.strstore(thtmp.get_file_name(tmpfn.c_str()));
   this->rgbafn = tmp.fname;
   FILE * f;
   f = fopen(tmp.fname,"wb");
@@ -260,8 +260,8 @@ void thpic::rgba_save(const char * type, const char * ext, int colors)
     this->fname = tmp.convert(type, ext, fmt::format("-define png:exclude-chunks=date,time -depth 8 -size {}x{} -density 300 +dither -colors {}", this->width, this->height, colors));
   else
     this->fname = tmp.convert(type, ext, fmt::format("-define png:exclude-chunks=date,time -depth 8 -size {}x{} -density 300", this->width, this->height));
-  sprintf(tmpfn, "pic%04ld.%s", thpic_convert_number - 1, ext);
-  this->texfname = thdb.strstore(tmpfn);
+  tmpfn = fmt::sprintf("pic%04ld.%s", thpic_convert_number - 1, ext);
+  this->texfname = thdb.strstore(tmpfn.c_str());
 }
 
 

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -447,7 +447,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         out->layout->export_mptex_font_size(out->file, this, true);
         fprintf(out->file,"%s etex,",
           ((this->type == TT_POINT_TYPE_STATION_NAME) && (!this->station_name.is_empty()))
-          ? (const char *) utf2tex(thobjectname_print_full_name(this->station_name.name, this->station_name.psurvey, out->layout->survey_level))
+          ? utf2tex(thobjectname_print_full_name(this->station_name.name, this->station_name.psurvey, out->layout->survey_level)).c_str()
           : ths2tex(this->text, out->layout->lang).c_str());
         if (this->type == TT_POINT_TYPE_STATION_NAME)
           postprocess_label = "p_label_mode_station";

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include "thmap.h"
 
+#include <fmt/printf.h>
 
 thselector::thselector() {
   this->number = 0;
@@ -379,18 +380,16 @@ void thselector::dump_selection_db (FILE * cf, thdatabase * db)
   fprintf(cf,"set xth(ctrl,cp,maplist) {}\n");
   // exportuje vsetky projekcie
   thdb2dprj_list::iterator prjli = db->db2d.prj_list.begin();
-	thbuffer projdir;
-	projdir.guarantee(32);
   while (prjli != db->db2d.prj_list.end()) {
-		projdir.strcpy("");
+	  std::string projdir;
 		if ((prjli->type == TT_2DPROJ_ELEV) && (prjli->pp1 != 0.0)) {
-			sprintf(projdir.get_buffer(), "\\[%.1f\\]", prjli->pp1);
+			projdir = fmt::sprintf("\\[%.1f\\]", prjli->pp1);
 		}
     fprintf(cf,"xth_cp_map_tree_insert projection 0 p%d {} 0",prjli->id); 
     if (strlen(prjli->index) > 0)
-      fprintf(cf," %s%s:%s",thmatch_string(prjli->type,thtt_2dproj), projdir.get_buffer(), prjli->index);
+      fprintf(cf," %s%s:%s",thmatch_string(prjli->type,thtt_2dproj), projdir.c_str(), prjli->index);
     else
-      fprintf(cf," %s%s",thmatch_string(prjli->type,thtt_2dproj), projdir.get_buffer());
+      fprintf(cf," %s%s",thmatch_string(prjli->type,thtt_2dproj), projdir.c_str());
     fprintf(cf," {} {} {}\n");
     prjli++;
   }

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -45,6 +45,8 @@
 #include <string>
 #include <fstream>
 
+#include <fmt/printf.h>
+
 #define THPI 3.1415926535898
 
 thsvxctrl::thsvxctrl()
@@ -569,7 +571,7 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
   thbuffer tsbuff;
   thdb1ds * stp;
   char * lnbuff = new char [4097];
-  char * numbuff = &(lnbuff[2049]);
+  std::string numbuff;
   unsigned long lnum = 0;
   thlog.printf("\n####################### cavern log file ########################\n");
   std::ifstream clf(lfnm);
@@ -653,24 +655,24 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
                   fonline = true;
                   tsbuff.strcat("\n");
                 }
-                sprintf(numbuff,"%2ld> input:%ld -- %s [%ld]\n",lnum,csn,srcmi->second->name,srcmi->second->line);
-                tsbuff.strcat(numbuff);
+                numbuff = fmt::sprintf("%2ld> input:%ld -- %s [%ld]\n",lnum,csn,srcmi->second->name,srcmi->second->line);
+                tsbuff.strcat(numbuff.c_str());
               }
               break;
             case THSVXLOGNUM_STATION:
               csn--;
               if ((csn >= 0) && (csn < long(lsid))) {
                 if (fonline) {
-                  sprintf(numbuff,"%2ld> ",lnum);
-                  tsbuff.strcat(numbuff);
+                  numbuff = fmt::sprintf("%2ld> ",lnum);
+                  tsbuff.strcat(numbuff.c_str());
                   fonline = false;
                 }
                 else {
                   tsbuff.strcat(" -- ");
                 }
-                sprintf(numbuff,"%ld : ",(csn+1));
+                numbuff = fmt::sprintf("%ld : ",(csn+1));
                 stp = & (dbp->db1d.station_vec[(unsigned int)csn]);
-                tsbuff.strcat(numbuff);
+                tsbuff.strcat(numbuff.c_str());
                 tsbuff.strcat(stp->name);
                 tsbuff.strcat("@");
                 tsbuff.strcat(stp->survey->get_full_name());

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -983,8 +983,6 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   std::list<legendrecord>::iterator LEGENDITEM;
   legendrecord dummlr;
   LEGENDLIST.clear();
-  thbuffer texb;
-  texb.guarantee(128);
   unsigned symn = 0;
 
   for(int i = 0; i < thsymbolset_size; i++)
@@ -1012,11 +1010,10 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
     LEGENDITEM = LEGENDLIST.insert(LEGENDLIST.end(),dummlr); \
     fprintf(mpf,"beginfig(%d);\n",sfig); \
     fprintf(mpf,"clean_legend_box;\n"); \
-    sprintf(texb.get_buffer(),"data.%d",sfig); \
     LEGENDITEM->idfig = (unsigned) sfig; \
     LEGENDITEM->idsym = (unsigned) mid; \
     LEGENDITEM->idnum = (unsigned) symn; \
-    LEGENDITEM->fname = texb.get_buffer(); \
+    LEGENDITEM->fname = fmt::sprintf("data.%d",sfig); \
     LEGENDITEM->name = thlegend_u2string(unsigned(symn++)); \
     LEGENDITEM->descr = txt; \
     sfig++;
@@ -1792,7 +1789,7 @@ void export_all_symbols()
   }
   hf << "</tr>\n";
   unsigned sx, fx;
-  char fname[100];
+  std::string fname;
   converted_data svgpict;
   double a,b,c,d;
   for(isym = 0; isym < thsymbolset_size; isym++) {
@@ -1808,8 +1805,8 @@ void export_all_symbols()
           if (thsymsets_count[iset] > 0) {
             fx = thsymsets_figure[sx][iset];
             if (fx > 0) {
-              sprintf(fname, "%s/data.%d", thtmp.get_dir_name(),fx);
-                    parse_eps(fname,"",0,0,a,b,c,d,svgpict,30);
+              fname = fmt::sprintf("%s/data.%d", thtmp.get_dir_name(),fx);
+              parse_eps(fname,"",0,0,a,b,c,d,svgpict,30);
               hf << "<td>\n";
          	    svgpict.print_svg(hf);
               hf << "</td>\n";
@@ -1819,7 +1816,7 @@ void export_all_symbols()
           }
         }
       } else {
-        sprintf(fname, "%s/data.%d", thtmp.get_dir_name(),thsymsets_figure[sx][thsymsets_size]);
+        fname = fmt::sprintf("%s/data.%d", thtmp.get_dir_name(),thsymsets_figure[sx][thsymsets_size]);
         parse_eps(fname,"",0,0,a,b,c,d,svgpict,30);
         hf << "<td bgcolor=\"#cccccc\" colspan=\"" << thsymsets_size << "\">";
         svgpict.print_svg(hf);

--- a/thwarpp.cxx
+++ b/thwarpp.cxx
@@ -32,6 +32,7 @@
 #include "thpoint.h"
 #include "thconfig.h"
 
+#include <fmt/printf.h>
 
 thwarpp::~thwarpp() {}
 
@@ -99,17 +100,13 @@ thpic * thwarpp::morph(thsketch * sketch, double scale) {
 
   thscrap	*	scrap	=	this->get_scrap();
   thdb2dcp *ccp;
-  thbuffer n2sb, n2sb2;
-  n2sb.guarantee(128);
-  n2sb2.guarantee(128);
   std::string s, s2;
   std::map <unsigned long, thdb1ds*> ssm;
   //std::map <unsigned long, thdb1ds*>::iterator ssmi;
   ccp = scrap->fcpp;
   while (ccp != NULL) {
     if ((ccp->point != NULL) && (ccp->st != NULL)) {
-      sprintf(n2sb.get_buffer(),"%ld",ccp->st->uid);
-      s = n2sb.get_buffer();
+      s = std::to_string(ccp->st->uid);
       TW.insert_point( THMORPH_STATION,	s,	
         thvec2(ccp->pt->x - sketch->m_x, sketch->m_y + double(sketch->m_pic.height) - ccp->pt->y),
         thvec2(ccp->tx + sketch->m_scrap->proj->rshift_x,- (ccp->ty + sketch->m_scrap->proj->rshift_y)));
@@ -125,10 +122,8 @@ thpic * thwarpp::morph(thsketch * sketch, double scale) {
     thdataleg	*	dlg	=	lg->leg;
     fuid = thdb.db1d.station_vec[dlg->from.id - 1].uid;
     tuid = thdb.db1d.station_vec[dlg->to.id - 1].uid;
-    sprintf(n2sb.get_buffer(),"%ld",fuid);
-    sprintf(n2sb2.get_buffer(),"%ld",tuid);
-    s = n2sb.get_buffer();
-    s2 = n2sb2.get_buffer();
+    s = std::to_string(fuid);
+    s2 = std::to_string(tuid);
     if ((ssm.find(fuid) != ssm.end()) && (ssm.find(tuid) != ssm.end())) {
       // thprintf("insert	leg	%s %s\n",	dlg->from.name,	dlg->to.name );
       TW.insert_line(	THMORPH_STATION, s, s2);
@@ -149,10 +144,8 @@ thpic * thwarpp::morph(thsketch * sketch, double scale) {
 	    thprintf("warning: extra point from %s but no station\n",
 	      pointp->from_name.name );
 	  } else {
-            sprintf(n2sb2.get_buffer(),"%ld",fuid);
-            sprintf(n2sb.get_buffer(),"%ld_E_%d",fuid, ++n_extra);
-            s  = n2sb.get_buffer(); 
-            s2 = n2sb2.get_buffer();
+            s  = fmt::sprintf("%ld_E_%d",fuid, ++n_extra);
+            s2 = std::to_string(fuid);
 	    thdb2dpt * pt = pointp->point;
 	    // assert( pt != NULL );
 	    double x = pt->x - sketch->m_x;


### PR DESCRIPTION
Function `sprintf` is deprecated on macOS, let's replace it with `fmt`.