### PR TITLE
Removed utf2tex overload

### DIFF
--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -1701,7 +1701,7 @@ if (ENC_NEW.NFSS==0) {
   LAYOUT.scalebar = fmt::sprintf("data.%d",sfig);
   //std::snprintf(prevbf,127,"%g",sblen);
   fprintf(mpf,"beginfig(%d);\ns_scalebar(%g, %g, \"%s\");\nendfig;\n",
-    sfig++, sblen, 1.0 / this->layout->units.convert_length(1.0), utf2tex(this->layout->units.format_i18n_length_units()));
+    sfig++, sblen, 1.0 / this->layout->units.convert_length(1.0), utf2tex(this->layout->units.format_i18n_length_units()).c_str());
 
 
   // print altitudebar
@@ -2096,7 +2096,7 @@ if (ENC_NEW.NFSS==0) {
   //  tit.strcpy(LAYOUT.doc_title.c_str());
     
   tf = fopen(thtmp.get_file_name("th_texts.tex"),"w");
-  fprintf(tf,"\\legendtitle={%s}\n",utf2tex(thT("title legend",this->layout->lang)));
+  fprintf(tf,"\\legendtitle={%s}\n",utf2tex(thT("title legend",this->layout->lang)).c_str());
   ldata.legendtitle = thT("title legend",this->layout->lang);
 
   ldata.colorlegendtitle = "";
@@ -2129,7 +2129,7 @@ if (ENC_NEW.NFSS==0) {
     if ((this->layout->m_lookup != NULL) && (strlen(this->layout->m_lookup->m_title) > 0)) {
       ldata.colorlegendtitle = this->layout->m_lookup->m_title;
     }
-    fprintf(tf,"\\colorlegendtitle={%s}\n", utf2tex(ldata.colorlegendtitle.c_str()));
+    fprintf(tf,"\\colorlegendtitle={%s}\n", utf2tex(ldata.colorlegendtitle.c_str()).c_str());
   }
 
   // ak neni atlas, tak nastavi legendcavename
@@ -2939,7 +2939,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
                 lp->export_nextcp_mp(out);
                 thdb.buff_enc.guarantee(4096);
                 //sprintf(thdb.buff_enc.get_buffer(),"%.0f",lp->rsize - out->layout->goz);
-                fprintf(out->file,",btex \\thwallaltitude %s etex);\n",utf2tex(out->layout->units.format_length(lp->rsize - out->layout->goz)));
+                fprintf(out->file,",btex \\thwallaltitude %s etex);\n",utf2tex(out->layout->units.format_length(lp->rsize - out->layout->goz)).c_str());
 //                fprintf(out->file,",\"%.0f\");\n",lp->rsize);
               }
               lp = lp->nextlp;

--- a/thmapstat.cxx
+++ b/thmapstat.cxx
@@ -435,17 +435,17 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
   b.guarantee(256);
 
   if (!thcfg.reproducible_output)
-    fprintf(f,"\\thversion={%s}\n",utf2tex(THVERSION));
+    fprintf(f,"\\thversion={%s}\n",utf2tex(THVERSION).c_str());
   else
-    fprintf(f,"\\thversion={%s}\n",utf2tex("..."));
+    fprintf(f,"\\thversion={%s}\n",utf2tex("...").c_str());
   thdate dt;
   dt.reset_current();
   double cy = dt.get_start_year();
   dt.shour = -1;
   if (!thcfg.reproducible_output)
-    fprintf(f,"\\currentdate={%s}\n",utf2tex(dt.get_str(TT_DATE_FMT_LOCALE)));
+    fprintf(f,"\\currentdate={%s}\n",utf2tex(dt.get_str(TT_DATE_FMT_LOCALE)).c_str());
   else
-    fprintf(f,"\\currentdate={%s}\n",utf2tex("1981-09-27"));
+    fprintf(f,"\\currentdate={%s}\n",utf2tex("1981-09-27").c_str());
   fprintf(f,"\\northdir={%s}\n",layout->north == TT_LAYOUT_NORTH_GRID ? "grid" : "true");
 
 
@@ -455,8 +455,8 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
 	  fprintf(f,"\\magdecl={N/A}\n");
 	  fprintf(f,"\\gridconv={N/A}\n");
   } else {
-	  fprintf(f,"\\outcscode={%s}\n",utf2tex(thcs_get_name(thcfg.outcs)));
-	  fprintf(f,"\\outcsname={%s}\n",utf2tex(thcs_get_data(thcfg.outcs)->prjname));
+	  fprintf(f,"\\outcscode={%s}\n",utf2tex(thcs_get_name(thcfg.outcs)).c_str());
+	  fprintf(f,"\\outcsname={%s}\n",utf2tex(thcs_get_data(thcfg.outcs)->prjname).c_str());
 	  double md;
 	  thcfg.get_outcs_mag_decl(cy, md);
 	  fprintf(f,"\\magdecl={%.2f}\n", md);
@@ -476,8 +476,8 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
     b += "<thsp>";
     //b += thT("units m",layout->lang);
     b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\cavelengthtitle={%s}\n",utf2tex(thT("title cave length",layout->lang)));
-    fprintf(f,"\\cavelength={%s}\n",utf2tex(b.get_buffer()));
+    fprintf(f,"\\cavelengthtitle={%s}\n",utf2tex(thT("title cave length",layout->lang)).c_str());
+    fprintf(f,"\\cavelength={%s}\n",utf2tex(b.get_buffer()).c_str());
     ldata->cavelength = thutf82xhtml(b.get_buffer());
     ldata->cavelengthtitle = thT("title cave length",layout->lang);
   }
@@ -492,18 +492,18 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
     b += "<thsp>";
     //b += thT("units m",layout->lang);
     b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\cavedepthtitle={%s}\n",utf2tex(thT("title cave depth",layout->lang)));
-    fprintf(f,"\\cavedepth={%s}\n",utf2tex(b.get_buffer()));
+    fprintf(f,"\\cavedepthtitle={%s}\n",utf2tex(thT("title cave depth",layout->lang)).c_str());
+    fprintf(f,"\\cavedepth={%s}\n",utf2tex(b.get_buffer()).c_str());
     ldata->cavedepth = thutf82xhtml(b.get_buffer());
     ldata->cavedepthtitle = thT("title cave depth",layout->lang);
 	b = layout->units.format_length(z_top);
     //b += "<thsp>";
     //b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\cavemaxz={%s}\n",utf2tex(b.get_buffer()));
+    fprintf(f,"\\cavemaxz={%s}\n",utf2tex(b.get_buffer()).c_str());
 	b = layout->units.format_length(z_bot);
     //b += "<thsp>";
     //b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\caveminz={%s}\n",utf2tex(b.get_buffer()));
+    fprintf(f,"\\caveminz={%s}\n",utf2tex(b.get_buffer()).c_str());
 
   }
   
@@ -518,17 +518,17 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
 
     if (cnt > 1) {
       fprintf(f,"\\explotitle={%s}\n",
-        utf2tex(thT("title explo (plural)",layout->lang)));
+        utf2tex(thT("title explo (plural)",layout->lang)).c_str());
       ldata->explotitle = thT("title explo (plural)",layout->lang);
     } else {
       fprintf(f,"\\explotitle={%s}\n",
-        utf2tex(thT("title explo",layout->lang)));
+        utf2tex(thT("title explo",layout->lang)).c_str());
       ldata->explotitle = thT("title explo",layout->lang);
     }
 
     if (discovered_date.is_defined()) {
       fprintf(f,"\\explodate={%s}\n",
-        utf2tex(discovered_date.get_str(TT_DATE_FMT_UTF8_Y)));
+        utf2tex(discovered_date.get_str(TT_DATE_FMT_UTF8_Y)).c_str());
       ldata->explodate = discovered_date.get_str(TT_DATE_FMT_UTF8_Y);
     }
   
@@ -546,17 +546,17 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
 
     if (cnt > 1) {
       fprintf(f,"\\topotitle={%s}\n",
-        utf2tex(thT("title topo (plural)",layout->lang)));
+        utf2tex(thT("title topo (plural)",layout->lang)).c_str());
       ldata->topotitle = thT("title topo (plural)",layout->lang);
     } else {
       fprintf(f,"\\topotitle={%s}\n",
-        utf2tex(thT("title topo",layout->lang)));
+        utf2tex(thT("title topo",layout->lang)).c_str());
       ldata->topotitle = thT("title topo",layout->lang);
     }
   
     if (surveyed_date.is_defined()) {
       fprintf(f,"\\topodate={%s}\n",
-        utf2tex(surveyed_date.get_str(TT_DATE_FMT_UTF8_Y)));
+        utf2tex(surveyed_date.get_str(TT_DATE_FMT_UTF8_Y)).c_str());
       ldata->topodate = surveyed_date.get_str(TT_DATE_FMT_UTF8_Y);
     }
   
@@ -574,17 +574,17 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
 
     if (cnt > 1) {
       fprintf(f,"\\cartotitle={%s}\n",
-        utf2tex(thT("title carto (plural)",layout->lang)));
+        utf2tex(thT("title carto (plural)",layout->lang)).c_str());
       ldata->cartotitle = thT("title carto (plural)",layout->lang);
     } else {
       fprintf(f,"\\cartotitle={%s}\n",
-        utf2tex(thT("title carto",layout->lang)));
+        utf2tex(thT("title carto",layout->lang)).c_str());
       ldata->cartotitle = thT("title carto",layout->lang);
     }
 
     if (drawn_date.is_defined()) {
       fprintf(f,"\\cartodate={%s}\n",
-        utf2tex(drawn_date.get_str(TT_DATE_FMT_UTF8_Y)));
+        utf2tex(drawn_date.get_str(TT_DATE_FMT_UTF8_Y)).c_str());
       ldata->cartodate = drawn_date.get_str(TT_DATE_FMT_UTF8_Y);
     }
   

--- a/thparse.cxx
+++ b/thparse.cxx
@@ -784,7 +784,7 @@ void thdecode_utf2tex(thbuffer * dest, const char * src)
         isutf8 = isutf8 || (*tmpp > 127);
       }
       if (isutf8) {
-        dest->strcat(utf2tex((char*) wsrcp));
+        dest->strcat(utf2tex((char*) wsrcp).c_str());
       } else {
         dest->strcat((char*) wsrcp);
       }

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -562,7 +562,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
 					thpoint_export_mp_align2mp(thdb2d_rotate_align(this->align, xrr)));
         out->layout->export_mptex_font_size(out->file, this, false);
         fprintf(out->file,"%s etex,",
-					utf2tex(out->layout->units.format_length(this->xsize - out->layout->goz)));
+					utf2tex(out->layout->units.format_length(this->xsize - out->layout->goz)).c_str());
         postprocess_label = "p_label_mode_altitude";
       }
       postprocess = false;
@@ -611,11 +611,11 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
           //  sprintf(buff,"%.1f",this->xsize);
           //else
           //  sprintf(buff,"%.0f",this->xsize);
-          fprintf(out->file,"%s",utf2tex(out->layout->units.format_human_length(this->xsize)));
+          fprintf(out->file,"%s",utf2tex(out->layout->units.format_human_length(this->xsize)).c_str());
         }
         this->db->buff_enc.strcpy((this->tags & (TT_POINT_TAG_HEIGHT_PQ |
             TT_POINT_TAG_HEIGHT_NQ | TT_POINT_TAG_HEIGHT_UQ)) != 0 ? "?" : "" );
-        fprintf(out->file,"%s etex,",utf2tex(this->db->buff_enc.get_buffer()));
+        fprintf(out->file,"%s etex,",utf2tex(this->db->buff_enc.get_buffer()).c_str());
         postprocess_label = "p_label_mode_height";
       }
       postprocess = false;
@@ -641,7 +641,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         out->layout->export_mptex_font_size(out->file, this, false);
 
         fprintf(out->file,"%s etex,",
-            utf2tex(((thdate *)this->text)->get_str(TT_DATE_FMT_LOCALE)));
+            utf2tex(((thdate *)this->text)->get_str(TT_DATE_FMT_LOCALE)).c_str());
         postprocess_label = "p_label_mode_date";
       }
       postprocess = false;
@@ -703,14 +703,14 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
           fprintf(out->file,"{");
           out->layout->export_mptex_font_size(out->file, this, false);
 
-          fprintf(out->file,"%s}", utf2tex(out->layout->units.format_human_length(this->xsize)));
+          fprintf(out->file,"%s}", utf2tex(out->layout->units.format_human_length(this->xsize)).c_str());
         }
 
         if (!thisnan(this->ysize)) {
           fprintf(out->file,"{");
           out->layout->export_mptex_font_size(out->file, this, false);
 
-          fprintf(out->file,"%s}", utf2tex(out->layout->units.format_human_length(this->ysize)));
+          fprintf(out->file,"%s}", utf2tex(out->layout->units.format_human_length(this->ysize)).c_str());
         }
 
         fprintf(out->file," etex,");

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -1087,7 +1087,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
 
   insfig(SYMP_STATIONNAME,thT("point station-name",layout->lang));
   this->export_mp_symbol_options(mpf, SYMP_STATIONNAME);
-  fprintf(mpf,"p_label.urt(btex \\thstationname %s etex,((0.3,0.3) inscale),0,p_label_mode_station);\n",utf2tex("173"));
+  fprintf(mpf,"p_label.urt(btex \\thstationname %s etex,((0.3,0.3) inscale),0,p_label_mode_station);\n",utf2tex("173").c_str());
   insert_station(0.3,0.3);
   endfig;
 
@@ -1127,12 +1127,12 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
     fprintf(mpf,"%s(((-.3,0.5) .. controls (.2,.6) and (.2,.6) .. (.3,.7) .. controls (.4,.8) and (.4,.8) .. (.5,1.4)) inscale);\n",thsymbolset_mp[SYML_WALL_BEDROCK]);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_WALLALTITUDE);
-  fprintf(mpf,"%s((0.2,0.6) inscale,(0.3,0.7) inscale,(0.4,0.8) inscale,btex \\thwallaltitude %s etex);\n",thsymbolset_mp[SYMP_WALLALTITUDE],utf2tex("1510"));
+  fprintf(mpf,"%s((0.2,0.6) inscale,(0.3,0.7) inscale,(0.4,0.8) inscale,btex \\thwallaltitude %s etex);\n",thsymbolset_mp[SYMP_WALLALTITUDE],utf2tex("1510").c_str());
   endfig;
 
   insfig(SYMP_ALTITUDE,thT("point altitude",layout->lang));
   this->export_mp_symbol_options(mpf, SYMP_ALTITUDE);
-  fprintf(mpf,"p_label.rt(btex \\thaltitude %s etex,((0.3,0.5) inscale),0,p_label_mode_altitude);\n",utf2tex("1510"));
+  fprintf(mpf,"p_label.rt(btex \\thaltitude %s etex,((0.3,0.5) inscale),0,p_label_mode_altitude);\n",utf2tex("1510").c_str());
   endfig;
 
   // thT("point section")
@@ -1174,26 +1174,26 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYMP_PASSAGEHEIGHT_UNSIGNED,thT("point passage-height:unsigned",layout->lang));
   //insert_big_passage
   this->export_mp_symbol_options(mpf, SYMP_PASSAGEHEIGHT_UNSIGNED);
-  fprintf(mpf,"p_label(btex \\thframed %s etex,((0.5,0.5) inscale),0,p_label_mode_passageheight);\n",utf2tex("5"));
+  fprintf(mpf,"p_label(btex \\thframed %s etex,((0.5,0.5) inscale),0,p_label_mode_passageheight);\n",utf2tex("5").c_str());
   endfig;
 
   insfig(SYMP_PASSAGEHEIGHT_POSITIVE,thT("point passage-height:positive",layout->lang));
   //insert_big_water_passage
   this->export_mp_symbol_options(mpf, SYMP_PASSAGEHEIGHT_POSITIVE);
-  fprintf(mpf,"p_label(btex \\thframed %s etex,((0.5,0.5) inscale),0,p_label_mode_passageheightpos);\n",utf2tex("3"));
+  fprintf(mpf,"p_label(btex \\thframed %s etex,((0.5,0.5) inscale),0,p_label_mode_passageheightpos);\n",utf2tex("3").c_str());
   endfig;
 
   insfig(SYMP_PASSAGEHEIGHT_NEGATIVE,thT("point passage-height:negative",layout->lang));
   //insert_big_water_passage
   this->export_mp_symbol_options(mpf, SYMP_PASSAGEHEIGHT_NEGATIVE);
-  fprintf(mpf,"p_label(btex \\thframed %s etex,((0.5,0.5) inscale),0,p_label_mode_passageheightneg);\n",utf2tex("2"));
+  fprintf(mpf,"p_label(btex \\thframed %s etex,((0.5,0.5) inscale),0,p_label_mode_passageheightneg);\n",utf2tex("2").c_str());
   endfig;
 
   insfig(SYMP_PASSAGEHEIGHT_BOTH,thT("point passage-height:both",layout->lang));
   //insert_big_water_passage
   this->export_mp_symbol_options(mpf, SYMP_PASSAGEHEIGHT_BOTH);
-  fprintf(mpf,"p_label(btex \\thframed \\updown{%s}",utf2tex("3"));
-  fprintf(mpf,"{%s} etex,((0.5,0.5) inscale),0,p_label_mode_passageheightposneg);\n",utf2tex("2"));
+  fprintf(mpf,"p_label(btex \\thframed \\updown{%s}",utf2tex("3").c_str());
+  fprintf(mpf,"{%s} etex,((0.5,0.5) inscale),0,p_label_mode_passageheightposneg);\n",utf2tex("2").c_str());
   endfig;
 
   legend_hpoint(SYMP_AIRDRAUGHT,thT("point air-draught",layout->lang));
@@ -1205,7 +1205,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   insfig(SYMP_DATE,thT("point date",layout->lang));
   //insert_big_water_passage
   this->export_mp_symbol_options(mpf, SYMP_DATE);
-  fprintf(mpf,"p_label(btex \\thdate %s etex,((0.5,0.5) inscale),0,p_label_mode_date);\n",utf2tex(d.get_str(TT_DATE_FMT_UTF8_ISO)));
+  fprintf(mpf,"p_label(btex \\thdate %s etex,((0.5,0.5) inscale),0,p_label_mode_date);\n",utf2tex(d.get_str(TT_DATE_FMT_UTF8_ISO)).c_str());
   endfig;
 
 
@@ -1285,7 +1285,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   }
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_HEIGHT_UNSIGNED);
-  fprintf(mpf,"p_label.rt(btex \\thheight %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("4"));
+  fprintf(mpf,"p_label.rt(btex \\thheight %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("4").c_str());
   endfig;
 
   insfig(SYMP_HEIGHT_POSITIVE,thT("point height:positive",layout->lang));
@@ -1294,7 +1294,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
     fprintf(mpf,"%s(%s);\n",thsymbolset_mp[SYML_CHIMNEY],legend_scline);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_HEIGHT_POSITIVE);
-  fprintf(mpf,"p_label.rt(btex \\thheightpos %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("15"));
+  fprintf(mpf,"p_label.rt(btex \\thheightpos %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("15").c_str());
   endfig;
 
   insfig(SYMP_HEIGHT_NEGATIVE,thT("point height:negative",layout->lang));
@@ -1303,7 +1303,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
     fprintf(mpf,"%s(%s);\n",thsymbolset_mp[SYML_PIT],legend_scline);
   endhelpsymbol;
   this->export_mp_symbol_options(mpf, SYMP_HEIGHT_NEGATIVE);
-  fprintf(mpf,"p_label.rt(btex \\thheightneg %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("30"));
+  fprintf(mpf,"p_label.rt(btex \\thheightneg %s etex,((0.5,0.5) inscale),0,p_label_mode_height);\n",utf2tex("30").c_str());
   endfig;
 
   insfig(SYML_CONTOUR,thT("line contour",layout->lang));

--- a/thtexfonts.cxx
+++ b/thtexfonts.cxx
@@ -48,8 +48,6 @@
 #include "thbuffer.h"
 #include "therion.h"
 
-thbuffer thtexfontsbuff;
-
 std::list<fontrecord> FONTS;
 typedef std::list<int> unistr;
 
@@ -627,12 +625,6 @@ int tex2uni(std::string font, int ch) {
     if (ch < 0) ch += 256;  // if string is based on signed char
     return ENC_NEW.get_uni(atoi(f_ind.c_str()),ch);
   }
-}
-
-const char * utf2tex (const char * s, bool b) {
-  std::string t = utf2tex(std::string(s),b);
-  thtexfontsbuff.strcpy(t.c_str());
-  return thtexfontsbuff.get_buffer();
 }
 
 // For simplicity we suppose that all characters which are set by TeX macros

--- a/thtexfonts.h
+++ b/thtexfonts.h
@@ -73,6 +73,4 @@ struct encodings_new {
 
 extern encodings_new ENC_NEW;
 
-const char * utf2tex (const char * s, bool b = false);
-
 #endif


### PR DESCRIPTION
Overloads taking and returning `std::string`/`const char*` are potentially dangerous, its users could by mistake mix pointers and string objects. And that static buffer is not necessary in C++. I have removed `const char*` overload, so we can move our APIs towards modern string formatting.