### PR TITLE
Remove malloc

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-integer-division,-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings,-bugprone-suspicious-include,-bugprone-unhandled-self-assignment,-bugprone-branch-clone,-bugprone-sizeof-expression,performance-for-range-copy'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-integer-division,-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings,-bugprone-suspicious-include,-bugprone-unhandled-self-assignment,-bugprone-branch-clone,-bugprone-sizeof-expression,performance-for-range-copy,cppcoreguidelines-no-malloc'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/loch/lxData.cxx
+++ b/loch/lxData.cxx
@@ -122,7 +122,7 @@ void lxData::Clear()
 
 void lxDataTexture::Clear()
 {
-  lxImageRGBFree(this->image);
+  this->image = {};
   this->ClearTexImages();
 }
 
@@ -194,17 +194,14 @@ void lxDataTexture::ClearTexImages()
 bool lxDataTexture::SetImage(lxImageRGB img)
 {
   this->Clear();
-  this->image = img;
-  if (this->image.data == NULL)
-    return false;
-  else
-    return true;
+  this->image = std::move(img);
+  return !this->image.data.empty();
 }
 
 void lxDataTexture::CreateTexImages(int sizeS, int sizeO)
 {
   this->ClearTexImages();
-  if (this->image.data == NULL)
+  if (this->image.data.empty())
     return;
 
   unsigned char * psrc, * pdst;
@@ -222,7 +219,7 @@ void lxDataTexture::CreateTexImages(int sizeS, int sizeO)
   this->texS = new unsigned char [3 * sizeS * sizeS];
   this->texSbw = new unsigned char [3 * sizeS * sizeS];
   gluScaleImage(GL_RGB, 
-  this->image.width, this->image.height, GL_UNSIGNED_BYTE, this->image.data,  
+  this->image.width, this->image.height, GL_UNSIGNED_BYTE, this->image.data.data(),  
   sizeS, sizeS, GL_UNSIGNED_BYTE, this->texS);
 
   pidn = 3L * sizeS * sizeS;
@@ -236,7 +233,7 @@ void lxDataTexture::CreateTexImages(int sizeS, int sizeO)
   this->texO = new unsigned char [3 * sizeO * sizeO];
   this->texObw = new unsigned char [3 * sizeO * sizeO];
   gluScaleImage(GL_RGB, 
-  this->image.width, this->image.height, GL_UNSIGNED_BYTE, this->image.data,  
+  this->image.width, this->image.height, GL_UNSIGNED_BYTE, this->image.data.data(),  
   sizeO, sizeO, GL_UNSIGNED_BYTE, this->texO);
 
   pidn = 3L * sizeO * sizeO;
@@ -500,7 +497,7 @@ void lxData::Rebuild()
   // rescale image if too large
   double * bnds, x1, y1, x2, y2, x3, x4, y3, y4, tmp1, tmp2;
   int ix1, iy1, ix2, iy2, nsx, nsy;
-  if ((this->surface != NULL) && (this->surface->GetNumberOfPoints() > 0) && (this->m_textureSurface.image.data != NULL)) {
+  if ((this->surface != NULL) && (this->surface->GetNumberOfPoints() > 0) && (!this->m_textureSurface.image.data.empty())) {
     bnds = this->surface->GetBounds();
     x1 = this->m_textureSurface.xx * bnds[0] + this->m_textureSurface.xy * bnds[2] + this->m_textureSurface.dx;
     x2 = this->m_textureSurface.xx * bnds[1] + this->m_textureSurface.xy * bnds[2] + this->m_textureSurface.dx;
@@ -528,21 +525,18 @@ void lxData::Rebuild()
     nsy = iy2 - iy1;
     if ((((ix2 - ix1) < this->m_textureSurface.image.width) || ((iy2 - iy1) < this->m_textureSurface.image.height)) && (nsx > 0) && (nsy > 0)) {
       // skopirujeme data
-      unsigned char * nd = (unsigned char *)malloc(3UL * nsx * nsy);
+      lxImageRGB new_image(nsx, nsy);
       int rr, rs, ors, dcs;
       rs = 3 * nsx;
       dcs = 3 * ix1;
       ors = 3 * this->m_textureSurface.image.width;
       for(rr = 0; rr < nsy; rr++) {
         memcpy(
-          nd + ((nsy-rr-1) * rs),
-          this->m_textureSurface.image.data + ((this->m_textureSurface.image.height - 1 - iy1 - rr) * ors + dcs),
+          new_image.data.data() + ((nsy-rr-1) * rs),
+          this->m_textureSurface.image.data.data() + ((this->m_textureSurface.image.height - 1 - iy1 - rr) * ors + dcs),
           rs);
       }
-      lxImageRGBFree(this->m_textureSurface.image);
-      this->m_textureSurface.image.data = nd;
-      this->m_textureSurface.image.width = nsx;
-      this->m_textureSurface.image.height = nsy;
+      this->m_textureSurface.image = std::move(new_image);
       this->m_textureSurface.iw = (double) nsx;
       this->m_textureSurface.ih = (double) nsy;
       this->m_textureSurface.dx -= (double) ix1;

--- a/loch/lxFile.h
+++ b/loch/lxFile.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <string>
 #include <cstdio>
+#include <vector>
 #endif  
 //LXDEPCHECK - standard libraries
 
@@ -80,13 +81,11 @@ struct lxFileDataPtr {
 
 struct lxFileData {
   
-  void * m_data;
-  lxFileSizeT m_size, m_buffSize;
+  std::vector<uint8_t> m_data;
 
-  lxFileData();
+  lxFileData() = default;
   void Clear();
   void Copy(lxFileSizeT size, const void * src);
-  void BuffResize(lxFileSizeT size);
   const void * GetData(lxFileDataPtr ptr);
   const char * GetString(lxFileDataPtr ptr);
   FILE * GetTmpFile(lxFileDataPtr ptr);

--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -300,7 +300,7 @@ void lxGLCanvas::UpdateRenderList()
 void lxGLCanvas::UpdateRenderContents()
 {
   this->setup->UpdateData();
-  if (this->data->m_textureSurface.image.data != NULL) {
+  if (!this->data->m_textureSurface.image.data.empty()) {
     GLint newTSizeO, newTSizeS;
     newTSizeO = this->m_maxTSizeO;
     newTSizeS = this->m_maxTSizeS;
@@ -897,7 +897,7 @@ void lxGLCanvas::RenderSurface() {
   clr[2] = 1.0;
   clr[3] = this->setup->m_srf_opacity;
 
-  bool srf_tex = (this->data->m_textureSurface.image.data != NULL) && (this->setup->m_srf_texture);
+  bool srf_tex = (!this->data->m_textureSurface.image.data.empty()) && (this->setup->m_srf_texture);
   glShadeModel(GL_SMOOTH);
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
   glColor4f(1.0,1.0,1.0,this->setup->m_srf_opacity);

--- a/loch/lxImgIO.cxx
+++ b/loch/lxImgIO.cxx
@@ -59,7 +59,7 @@ lxWrite_JPEG_file (const char * filename, int quality, lxImageRGB img) {
 
 	int image_width      = img.width;
 	int image_height     = img.height;
-	unsigned char* image = img.data;
+	unsigned char* image = img.data.data();
 
 	JSAMPLE * image_buffer = (JSAMPLE *) image;
   /* This struct contains the JPEG compression parameters and pointers to
@@ -378,8 +378,8 @@ lxRead_JPEG_file (const char * filename, FILE * infile)
 	img.height = cinfo.output_height;
 
 
-	img.data = (unsigned char*)malloc(static_cast<size_t>(cinfo.output_components) * img.width * img.height);
-	unsigned char* ptr = img.data;
+	img.data.resize(static_cast<size_t>(cinfo.output_components) * img.width * img.height);
+	unsigned char* ptr = img.data.data();
 
   /* Here we use the library's state variable cinfo.output_scanline as the
    * loop counter, so that we don't have to keep track ourselves.
@@ -418,7 +418,7 @@ lxRead_JPEG_file (const char * filename, FILE * infile)
    */
 
   if (cinfo.output_components == 1) {
-	  unsigned char * new_data = (unsigned char*)malloc(3UL * img.width * img.height);
+	  std::vector<unsigned char> new_data(3UL * img.width * img.height);
 	  for(int r = 0; r < img.height; r++) {
 		  for(int c = 0; c < img.width; c++) {
 			  new_data[r * 3 * img.width + 3 * c] = img.data[r * img.width + c];
@@ -426,8 +426,7 @@ lxRead_JPEG_file (const char * filename, FILE * infile)
 			  new_data[r * 3 * img.width + 3 * c + 2] = img.data[r * img.width + c];
 		  }
 	  }
-	  free(img.data);
-	  img.data = new_data;
+	  img.data = std::move(new_data);
   }
 
   /* And we're done! */
@@ -459,13 +458,6 @@ lxRead_JPEG_file (const char * filename, FILE * infile)
  * On some systems you may need to set up a signal handler to ensure that
  * temporary files are deleted if the program is interrupted.  See libjpeg.doc.
  */
-
-void lxImageRGBFree(lxImageRGB & img)
-{
-  if (img.data != NULL)
-    free(img.data);
-  img.data = NULL;
-}
 
 
 const char * lxImgIOError = "unknown";

--- a/loch/lxImgIO.h
+++ b/loch/lxImgIO.h
@@ -5,6 +5,7 @@
 #ifndef LXDEPCHECK
 #include <stdlib.h>
 #include <stdio.h>
+#include <vector>
 #endif  
 //LXDEPCHECK - standard libraries
 
@@ -12,9 +13,10 @@ extern const char * lxImgIOError;
 
 // struct for handling images
 struct lxImageRGB {
-	unsigned char * data; //pixel data in RGB format. sizeof(data) == 3 * width * height;
-	int width, height;
-	lxImageRGB() : data(NULL), width(0), height(0) {}
+	std::vector<unsigned char> data; //pixel data in RGB format. sizeof(data) == 3 * width * height;
+	int width = 0, height = 0;
+	lxImageRGB() = default;
+	lxImageRGB(int width, int height) : data(3UL * width * height), width(width), height(height) {}
 };
 
 /* Compress image into JPEG, and save it to disk
@@ -23,8 +25,6 @@ bool lxWrite_JPEG_file (const char * filename, int quality, lxImageRGB img);
 
 /* Load and decompress JPEG image from disk */
 lxImageRGB lxRead_JPEG_file (const char * filename, FILE * infile = NULL);
-
-void lxImageRGBFree(lxImageRGB & img);
 
 #endif
 

--- a/thwarppt.cxx
+++ b/thwarppt.cxx
@@ -660,12 +660,10 @@ therion::warp::plaquette_algo::map_image( const unsigned char * src, unsigned in
   // thprintf("U origin %6.2f %6.2f units %6.2f\n", mU0.m_x, mU0.m_y, mUUnit);
   // thprintf("UC origin %6.2f %6.2f units %6.2f\n", mUC.m_x, mUC.m_y, mUCUnit);
   // new way
-  warpp_t * pi = (warpp_t *)malloc( sizeof(warpp_t) * wd * hd );
-  if ( pi != NULL ) {
-    memset( pi, 0xff, sizeof(warpp_t)*wd*hd );
-    double * pf = (double *)calloc( static_cast<size_t>(wd) * hd, sizeof(double) );
-    if ( pf == NULL ) 
-      thprintf("warning: failed to allocate temporary distance image\n");
+  std::vector<warpp_t> pi_storage(static_cast<size_t>(wd) * hd, 0xff);
+  std::vector<double> pf_storage(static_cast<size_t>(wd) * hd, 0.0);
+  warpp_t * pi = pi_storage.data();
+  double * pf = pf_storage.data();
 
     for (size_t k=0; k<mPlaquettes.size(); ++k ) {
       assert( ( ( (warpp_t)k) & (~ngbh_mask)) == (warpp_t)k );
@@ -768,50 +766,6 @@ therion::warp::plaquette_algo::map_image( const unsigned char * src, unsigned in
 	dst1 += depth;
       }
     }
-    if ( pf ) free( pf );
-    free( pi );
-  } else { // old way (used if pi malloc failed ...
-    thprintf("warning: failed to allocate temporary index image\n");
-    for (size_t k=0; k<mPlaquettes.size(); ++k ) {
-      // thprintf("mapping plaquette %d\n", k );
-      thvec2 t1, t2;
-      mPlaquettes[k]->bounding_box_to( t1, t2 );
-      t1 = mUC + mUCUnit * t1;
-      t2 = mUC + mUCUnit * t2;
-      t1.maximize( thvec2(0,0) );
-      t2.minimize( thvec2(wd, hd) );
-      int i2 = (int)t2.m_x;
-      int j2 = (int)t2.m_y;
-      for (int j=(int)t1.m_y; j<j2; ++j) {
-        for (int i=(int)t1.m_x; i<i2; ++i) {
-          thvec2 u( i, j );
-          thvec2 z;
-          thvec2 w = (u - mUC) / mUCUnit;
-          if ( map_backward_plaquette( k, w, z ) ) {
-            thvec2 x = mX0 + z * mXUnit;
-            int ix1 = (int)x.m_x;
-            int ix2 = ix1 + 1;
-            int iy1 = (int)x.m_y;
-            int iy2 = iy1 + 1;
-            if ( ix1 >= 0 && ix2 < (int)ws && iy1 >= 0 && iy2 < (int)hs ) {
-              double dx = x.m_x - ix1;  // bilinear interpolation
-              double dy = x.m_y - iy1;
-              unsigned char * dst1 = dst + depth * (j * wd + i);
-              const unsigned char * src00 = src + depth * ( iy1*ws + ix1 );
-              const unsigned char * src01 = src00 + depth * ws;
-              const unsigned char * src10 = src00 + depth;
-              const unsigned char * src11 = src01 + depth;
-              for (int k=0; k<depth; ++k) {
-                double res = ( src00[k] * (1-dx) +  src10[k] * dx ) * (1-dy)
-                           + ( src01[k] * (1-dx) +  src11[k] * dx ) * dy;
-                dst1[k] = (unsigned char)(( res >= 255 ) ? 255 : res);
-              }
-            }
-          }
-        }
-      }
-    }
-  }
 
   return true;
 }


### PR DESCRIPTION
`malloc` should not be used in C++, because unlike `operator new()` it does not initialize allocated objects, it just allocates bytes. Manual memory management is also discouraged, so I have replaced `malloc`/`calloc`/`free` with `std::vector`.