### PR TITLE
Require CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 include(cmake/PreventInSourceBuilds.cmake)
 
 project(therion)


### PR DESCRIPTION
CMake 3.16 is available on Ubuntu 20.04, our oldest supported platform. Part of #443.