### PR TITLE
Remove qsort

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-integer-division,-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings,-bugprone-suspicious-include,-bugprone-unhandled-self-assignment,-bugprone-branch-clone,-bugprone-sizeof-expression,performance-for-range-copy,cppcoreguidelines-no-malloc'
+Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-integer-division,-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings,-bugprone-suspicious-include,-bugprone-unhandled-self-assignment,-bugprone-branch-clone,-bugprone-assignment-in-if-condition,performance-for-range-copy,cppcoreguidelines-no-malloc'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -2564,15 +2564,6 @@ struct thdb1d_lpr {
   double err;
 };
 
-int comp_lpr(const void * l1, const void * l2) {
-  if (((thdb1d_lpr*)l1)->err > ((thdb1d_lpr*)l2)->err)
-    return -1;
-  else if (((thdb1d_lpr*)l1)->err < ((thdb1d_lpr*)l2)->err)
-    return 1;
-  else return 0;
-}
-
-
 
 void thdb1d::print_loops() {
   thdb1d_loop_list_type::iterator lii = this->loop_list.begin();
@@ -2581,7 +2572,7 @@ void thdb1d::print_loops() {
   unsigned long i, nloops;
   thdb1d_loop * li;
   nloops = this->loop_list.size();
-  thdb1d_lpr * lpr = new thdb1d_lpr [nloops];
+  std::vector<thdb1d_lpr> lpr(nloops);
   i = 0; 
   while (lii != this->loop_list.end()) {
     lpr[i].li = &(*lii);
@@ -2593,7 +2584,7 @@ void thdb1d::print_loops() {
     lii++;
   }  
   
-  qsort(lpr,nloops,sizeof(thdb1d_lpr),comp_lpr);
+  std::sort(lpr.begin(), lpr.end(), [](const auto& a, const auto& b){ return a.err >= b.err; });
   
   thdb1d_loop_leg * ll;
   thsurvey * ss;   
@@ -2672,7 +2663,6 @@ void thdb1d::print_loops() {
     thlog.printf("]\n");
   }
   thlog.printf("##################### end of loop errors #######################\n");
-  delete [] lpr;
 }
 
 thdb3ddata * thdb1d::get_3d_surface() {

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -1096,19 +1096,10 @@ void thdb2d::process_scrap_references(thscrap * sptr)
   }
 }
 
-int comp_dist(const void * s1, const void * s2) {
-  if ((*((thscrap**)s1))->maxdist > (*((thscrap**)s2))->maxdist)
-    return -1;
-  else if ((*((thscrap**)s1))->maxdist < (*((thscrap**)s2))->maxdist)
-    return 1;
-  else return 0;
-}
-
 void thdb2d::log_distortions() {
   thdb2dprj * prj;
   thdb2dprj_list::iterator prjli;
   prjli = this->prj_list.begin();
-  thscrap ** ss;
   thscrap * ps;
   unsigned long ns = 0, i;
   
@@ -1121,7 +1112,7 @@ void thdb2d::log_distortions() {
       ns++;
     }
     if ((ns > 0) && (prj->processed) && (prj->type != TT_2DPROJ_NONE)) {
-      ss = new thscrap* [ns];
+      std::vector<thscrap*> ss(ns);
       ps = prj->first_scrap;
       i = 0;
       while(ps != NULL) {
@@ -1130,7 +1121,7 @@ void thdb2d::log_distortions() {
         i++;
       }
       
-      qsort(ss,ns,sizeof(thscrap*),comp_dist);
+      std::sort(ss.begin(), ss.end(), [](const auto* s1, const auto* s2){ return s1->maxdist >= s2->maxdist; });
       thlog.printf("\n\n###################### scrap distortions #######################\n");
       thlog.printf(" PROJECTION: %s%s%s\n", 
         thmatch_string(prj->type,thtt_2dproj), 
@@ -1140,7 +1131,6 @@ void thdb2d::log_distortions() {
       for(i = 0; i < ns; i++)
         thlog.printf(" %6.2f%%  %6.2f%%  %s@%s\n",ss[i]->avdist, ss[i]->maxdist, ss[i]->name, ss[i]->fsptr->full_name);
       thlog.printf("################### end of scrap distortions ###################\n");
-      delete [] ss;
     }
     prjli++;
   }

--- a/thtfpwf.h
+++ b/thtfpwf.h
@@ -28,8 +28,8 @@
  
 #ifndef thtfpwf_h
 #define thtfpwf_h
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstddef>
+#include <vector>
 
 
 /**
@@ -53,10 +53,7 @@ class thtfpwf {
   double a,  ///< Multiplier.
     b;  ///< Addition.
     
-  size_t valn;
-  thtfpwfxy * valp;
-  
-  void clear(); ///< Clear the value array.
+  std::vector<thtfpwfxy> values;
 
   public:
   
@@ -64,14 +61,14 @@ class thtfpwf {
    * Standard constructor.
    */
   
-  thtfpwf() : a(1.0), b(0.0), valn(0), valp(NULL) {}
+  thtfpwf() : a(1.0), b(0.0) {}
   
   
   /**
    * Standard destructor.
    */
    
-  virtual ~thtfpwf();
+  virtual ~thtfpwf() = default;
   
   
   /**


### PR DESCRIPTION
I have replaced `qsort` with C++ `std::sort`, because it is faster and type-safe. I have also replaced some manual memory management with `std::vector`, which is a better fit for standard algorithms.

Changed `clang-tidy` checks:
* enabled `bugprone-sizeof-expression` - warned when `qsort` was used on pointers, because `sizeof(pointer)` is suspicious
* disabled `bugprone-assignment-in-if-condition` - new check, would cause problems on CI in the future