### PR TITLE
Nss symbols

### DIFF
--- a/mpost/thArea.mp
+++ b/mpost/thArea.mp
@@ -356,3 +356,16 @@ def a_u (expr p) =
     thfill p withcolor red;
 enddef;
 
+beginpattern(pattern_mud_NSS);
+    pickup PenC;
+    draw (-.7u, .2u) -- (-.2u, .2u);
+    draw (-.3u, -.2u) -- (.3u, -.2u);
+    draw (.2u, .2u) -- (.7u, .2u);
+    patternbbox(-1u,-1u, 1u, 1u);
+endpattern;
+
+def a_clay_NSS (expr P) = 
+	T:=identity;
+	thclean P;
+	thfill P withpattern pattern_mud_NSS;
+enddef;

--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -1213,6 +1213,23 @@ def l_wall_pit_NSS (expr P) =
   thdraw P;
 enddef;
 
+def l_wall_chimney_NSS (expr P) =
+  T:=identity;
+  cas := 0;
+  dlzka := arclength P;
+  mojkrok:=adjust_step(dlzka, 0.5u);
+  pickup PenC;
+  forever:
+    t := arctime cas of P;
+    mark_ (P,t,-0.2u);
+    cas := cas + mojkrok;
+    exitif cas > dlzka + (mojkrok / 3); % for rounding errors
+  endfor;
+  pickup PenA;
+  thdraw P;
+enddef;
+
+
 
 def l_pitchimney_NSS (expr P) = % this is the nss ceiling step with a second tick)
   T:=identity;
@@ -1478,4 +1495,3 @@ def l_slope_NSS (expr P,S)(text Q) =
 %pickup pencircle scaled 3pt;
 %for i=0 upto li: draw point i of P; endfor;
 enddef;
-

--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -1478,11 +1478,11 @@ def l_slope_NSS (expr P,S)(text Q) =
 
     if par:
       thdraw (point t of P) + mojkrok/3 * unitvector(dir(a-90))--
-        ((point t of P) + l * .8 * unitvector(dir(a-30)));
+        ((point t of P) + l * .8 * unitvector(dir(a-50)));
 
       thdraw
         (point t of P) + mojkrok/3 * unitvector(dir(a+90)) --
-        ((point t of P) + l *.8 * unitvector(dir(a+30)));
+        ((point t of P) + l *.8 * unitvector(dir(a+50)));
 
       thdraw (point t of P) + .1 * l * unitvector(dir(a)) -- ((point t of P) + 
         l * unitvector(dir(a)));

--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -1214,21 +1214,124 @@ def l_wall_pit_NSS (expr P) =
 enddef;
 
 
-def l_pitchimney_NSS (expr P) =
+def l_pitchimney_NSS (expr P) = % this is the nss ceiling step with a second tick)
   T:=identity;
-  cas := 0;
+  cas := 0;                            % cursor to step along path
   dlzka := arclength P;
-  mojkrok:=adjust_step(dlzka, 0.5u);
+  mojkrok:=adjust_step(dlzka, 0.8u);   % symbol length nudged to be multiple of path length
+  pickup PenC;
+  forever:
+    t1 := arctime (cas + mojkrok*1/5) of P;
+    t  := arctime (cas + mojkrok/2) of P;
+    t2 := arctime (cas + mojkrok*4/5) of P;
+    thdraw (subpath (t1,t2) of P);
+    mark_ (P,t,-0.2u);                  % change sign to -0.2u
+    mark_ (P,t,0.2u);
+    cas := cas + mojkrok;
+    exitif cas > dlzka - (2*mojkrok/3); % for rounding errors
+  endfor;
+enddef;
+
+% this is slightly modified pit_UIS
+% should never have tick at end.
+def l_floormeander_NSS (expr P) = 
+  T:=identity;
+  dlzka := arclength P;
+  mojkrok:=adjust_step(dlzka, 0.25u);
+  cas := mojkrok; %start 1 step along
   pickup PenD;
   forever:
     t := arctime cas of P;
-    mark_ (P,t,0.2u);
-    mark_ (P,t,-0.2u);
+    mark_ (P,t,0.1u);
+    mark_ (P,t,-0.1u);
     cas := cas + mojkrok;
-    exitif cas > dlzka + (mojkrok / 3); % for rounding errors
+    exitif cas > dlzka - (mojkrok/3); % for rounding errors
   endfor;
   pickup PenC;
   thdraw P;
 enddef;
 
+% this should be redone at a higher density, but for now this will do.
+let l_ceilingmeander_NSS = l_pitchimney_NSS;
+
+def l_wall_flowstone_NSS (expr P) =
+  T:=identity;
+  cas := 0;
+  dlzka := arclength P;
+  mojkrok:=adjust_step(dlzka, .7u);
+  if (cycle P) and (dlzka < 3.5u):   % make at least 5 curls on a cyclic path
+    mojkrok := dlzka/5;
+  fi;
+  pickup PenC;
+  t1:=0;
+  % copied from uAUT wall_pit
+  samplingdistance:=max(0.15u,dlzka/1500);
+
+    path testcircle;
+    % testcircle, used to test, whether the path makes a 'v'-like bend,
+    % where normal sampling and offsetting gives poor results for the parallel line
+    % size of testcircle= size PenA/2 + 2* (distance between outer and inner line)
+    % + PenC (inner line)
+    testcircle := halfcircle scaled (.5*u/10+2*.125u+.5*u/10) shifted (0,.5*u/10);
+    cur:=samplingdistance/2;
+    count:=0;
+    forever:
+      t:= arctime cur of P;
+      inter:=P intersectiontimes (testcircle rotated (angle thdir(P,t)) shifted (point t of P));
+      if (xpart inter) >=0:
+        % we are at a 'sharp bend', so set next point to intersectionpoint
+        cur:=cur+samplingdistance;
+        t := max( xpart inter, arctime cur of P);
+        %thdraw point t of P withcolor 0.7*green;
+        forever:
+          t:= arctime cur of P;
+          inter:=P intersectiontimes (testcircle rotated (angle thdir(P,t)) shifted (point t of P));
+          exitif (xpart inter <0);
+          cur := cur + samplingdistance;
+          exitif (cur >=dlzka);
+        endfor;
+        if (cur <dlzka):
+          inner[count]:=(point t of P + .125u*unitvector(thdir(P,t) rotated 90) );
+          innerdir[count]:=unitvector(thdir(P,t));
+          count := count+1;
+        fi;
+      else:
+        inner[count]:= (point t of P + .125u*unitvector(thdir(P,t) rotated 90) );
+        innerdir[count]:=unitvector(thdir(P,t));
+        %thdraw inner[count] withpen PenD withcolor 0.5*red;
+        count:=count +1;
+        cur:= cur+ samplingdistance;
+      fi;
+      exitif (cur >=dlzka);
+    endfor;
+    if count>2:
+      % draw inner path
+      pickup PenC;
+      path innerpath;
+      innerpath =
+      for i=0 upto count-2:
+        inner[i]{(innerdir[i])} ..
+      endfor
+      if cycle P: cycle;
+      else:  inner[count-1];
+      fi;
+  forever:
+    t2 := arctime (cas + mojkrok) of innerpath;
+    thdraw (point t1 of innerpath){dir (angle(thdir(innerpath,t1)) + 60)} ..
+           {dir (angle(thdir(innerpath,t2)) - 60)}(point t2 of innerpath);
+    cas := cas + mojkrok;
+    exitif cas > dlzka + (mojkrok / 3); % for rounding errors
+    t1:=t2;
+  endfor;
+  pickup PenA;
+  thdraw P;
+enddef;
+
+let l_wall_unsurveyed_NSS = l_wall_presumed_UIS;
+
+def l_wall_underlying_NSS (expr P) =
+  thdrawoptions(dashed withdots withpen PenA);
+  thdraw P;
+  thdrawoptions();
+enddef;
 

--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -1335,3 +1335,147 @@ def l_wall_underlying_NSS (expr P) =
   thdrawoptions();
 enddef;
 
+def l_slope_NSS (expr P,S)(text Q) =
+%show Q;
+  T:=identity;
+  numeric dirs[];
+  numeric lengths[];
+  for i=Q:
+    dirs[redpart i]:=greenpart i;
+    lengths[redpart i]:=bluepart i;
+  endfor;
+
+
+  li:=length(P); % last
+
+  alw_perpendicular:=true;
+
+  for i=0 upto li:
+    if unknown dirs[i]: dirs[i]:=-1;
+    else:
+      if dirs[i]>-1:
+        dirs[i]:=((90-dirs[i]) - angle(thdir(P,i))) mod 360;
+        alw_perpendicular:=false;
+      fi;
+    fi;
+    if unknown lengths[i]: lengths[i]:=-1; fi;
+  endfor;
+
+%for i=0 upto li: show dirs[i]; endfor;
+
+  ni:=0; % next
+  pi:=0; % previous
+
+  for i=0 upto li:
+    d:=dirs[i];
+    if d=-1:
+      if (i=0) or (i=li):
+        dirs[i] := angle(thdir(P,i) rotated 90) mod 360;
+	pi:=i;
+      else:
+        if ni<=i:
+	  for j=i upto li:
+            ni:=j;
+	    exitif dirs[j]>-1;
+	  endfor;
+	fi;
+	w:=arclength(subpath(pi,i) of P) /
+	   arclength(subpath(pi,ni) of P);
+	dirs[i]:=w[dirs[pi],dirs[ni]];
+%        if (dirs[i]-angle(thdir(P,i))) mod 360>180:
+%          dirs[i]:=w[dirs[ni],dirs[pi]];
+%	  message("*******");
+%        fi;
+     fi;
+    else:
+      pi:=i;
+    fi;
+  endfor;
+
+%for i=0 upto li: show dirs[i]; endfor;
+
+  ni:=0; % next
+  pi:=0; % previous
+
+  for i=0 upto li:
+    l:=lengths[i];
+    if l=-1:
+      if (i=0) or (i=li):
+        lengths[i] := 1cm; % should never happen!
+	thwarning("slope width at the end point not specified");
+	pi:=i;
+      else:
+        if ni<=i:
+	  for j=i+1 upto li:
+            ni:=j;
+	    exitif lengths[j]>-1;
+	  endfor;
+	fi;
+	w:=arclength(subpath(pi,i) of P) /
+	   arclength(subpath(pi,ni) of P);
+	lengths[i]:=w[lengths[pi],lengths[ni]];
+	pi:=i;
+      fi;
+    else:
+      pi:=i;
+    fi;
+  endfor;
+
+% for i=0 upto li: show lengths[i]; endfor;
+
+  T:=identity;
+  boolean par;
+  offset:=0;
+  dlzka := (arclength P);
+  if dlzka>3u:
+    offset := 0.3u;
+  elseif dlzka>u:
+    offset := 0.1u;
+  fi;
+  dlzka:=dlzka-2offset;
+  cas := offset;
+  mojkrok:=adjust_step(dlzka,1.4u) / 2;
+  pickup PenC;
+  par := false;
+  forever:
+    t := arctime cas of P;
+    if t mod 1>0:  % not a key point
+      w := (arclength(subpath(floor t,t) of P) /
+            arclength(subpath(floor t,ceiling t) of P));
+      if alw_perpendicular:
+        a := 90;
+      else:
+        a := w[dirs[floor t],dirs[ceiling t]];
+      fi;
+      l := w[lengths[floor t],lengths[ceiling t]];
+    else:
+      if alw_perpendicular:
+        a := 90;
+      else:
+        a:= dirs[t];
+      fi;
+      l:=lengths[t];
+    fi;
+
+    a := a + angle(thdir(P,t));
+
+    if par:
+      thdraw (point t of P) + mojkrok/3 * unitvector(dir(a-90))--
+        ((point t of P) + l * .8 * unitvector(dir(a-30)));
+
+      thdraw
+        (point t of P) + mojkrok/3 * unitvector(dir(a+90)) --
+        ((point t of P) + l *.8 * unitvector(dir(a+30)));
+
+      thdraw (point t of P) + .1 * l * unitvector(dir(a)) -- ((point t of P) + 
+        l * unitvector(dir(a)));
+    fi;
+
+    cas := cas + mojkrok;
+    par := not par;
+    exitif cas > dlzka + offset + 0.1mm;  % for rounding errors
+  endfor;
+%pickup pencircle scaled 3pt;
+%for i=0 upto li: draw point i of P; endfor;
+enddef;
+

--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -1195,3 +1195,40 @@ def l_viaferrata_SKBB (expr P) =
   draw P withcolor red;
 enddef;
 
+let l_chimney_NSS = l_ceilingstep_UIS;
+
+def l_wall_pit_NSS (expr P) =
+  T:=identity;
+  cas := 0;
+  dlzka := arclength P;
+  mojkrok:=adjust_step(dlzka, 0.25u);
+  pickup PenC;
+  forever:
+    t := arctime cas of P;
+    mark_ (P,t,0.2u);
+    cas := cas + mojkrok;
+    exitif cas > dlzka + (mojkrok / 3); % for rounding errors
+  endfor;
+  pickup PenA;
+  thdraw P;
+enddef;
+
+
+def l_pitchimney_NSS (expr P) =
+  T:=identity;
+  cas := 0;
+  dlzka := arclength P;
+  mojkrok:=adjust_step(dlzka, 0.5u);
+  pickup PenD;
+  forever:
+    t := arctime cas of P;
+    mark_ (P,t,0.2u);
+    mark_ (P,t,-0.2u);
+    cas := cas + mojkrok;
+    exitif cas > dlzka + (mojkrok / 3); % for rounding errors
+  endfor;
+  pickup PenC;
+  thdraw P;
+enddef;
+
+

--- a/mpost/thPoint.mp
+++ b/mpost/thPoint.mp
@@ -583,6 +583,20 @@ def p_airdraught_summer_UIS (expr pos,theta,sc,al)=
   thdraw fullcircle scaled 0.2u shifted (0,0.05u);
 enddef;
 
+%bristol's symbol. Based on gypsum flower code.
+def p_airdraught_NSS (expr pos,theta,sc,al)=
+    U:=(.25u,u);
+    T:=identity aligned al rotated theta scaled sc shifted pos;
+    pickup PenC;
+    thdraw (.18u,0){left}..(0,.15u)..(.2u,.3u)..(.4u,0)..
+        (.15u,-.28u)..(-.25u,0)..{dir 100}(0,.8u)..(0,u);
+
+    p:=(-.2u,.65u){dir 20}..{dir 90}(0,u);
+    thdraw p;
+    thdraw p reflectedabout (origin,(0,u));
+enddef;
+
+
 
 def p_station_fixed_ASF (expr pos)=
     T:=identity shifted pos;

--- a/mpost/thPoint.mp
+++ b/mpost/thPoint.mp
@@ -270,7 +270,7 @@ def p_narrowend_UIS (expr pos,theta,sc,al)=
 enddef;
 
 def p_narrowend_NSS (expr pos,theta,sc,al)=
-	p_smartlabel ("TT", pos);
+	p_label ("TT", pos, theta, 0);
 enddef;
 % common passage ends in NSS:
 % TT too tight
@@ -280,7 +280,7 @@ enddef;
 % MF "mud flow" (clay choke)
 
 def p_claychoke_NSS (expr pos,theta,sc,al)=
-	p_smartlabel ("MF", pos);
+	p_label ("MF", pos, theta, 0);
 enddef;
 
 def p_lowend_UIS (expr pos,theta,sc,al)=

--- a/mpost/thPoint.mp
+++ b/mpost/thPoint.mp
@@ -858,4 +858,12 @@ def p_pillars_UIS(expr pos,theta,sc,al) =
     endfor;
 enddef;
 
+def p_mud_NSS(expr pos,theta,sc,al) =
+    U:=(.2u, .7u);
+    T:=identity aligned al rotated theta scaled sc shifted pos;
+    pickup PenC;
+    thdraw (-.7u, .2u) -- (-.2u, .2u);
+    thdraw (-.3u, -.2u) -- (.3u, -.2u);
+    thdraw (.2u, .2u) -- (.7u, .2u);
+enddef;
 

--- a/mpost/thPoint.mp
+++ b/mpost/thPoint.mp
@@ -269,6 +269,20 @@ def p_narrowend_UIS (expr pos,theta,sc,al)=
     thdraw (.1u,-.4u)--(.1u,.4u);
 enddef;
 
+def p_narrowend_NSS (expr pos,theta,sc,al)=
+	p_smartlabel ("TT", pos);
+enddef;
+% common passage ends in NSS:
+% TT too tight
+% TL too low
+% FS flowstone (choke)
+% BD breakdown choke
+% MF "mud flow" (clay choke)
+
+def p_claychoke_NSS (expr pos,theta,sc,al)=
+	p_smartlabel ("MF", pos);
+enddef;
+
 def p_lowend_UIS (expr pos,theta,sc,al)=
     U:=(.4u,.1u);
     T:=identity aligned al rotated theta scaled sc shifted pos;
@@ -490,15 +504,13 @@ enddef;
 
 % by Philip Schuchardt
 def p_gradient_NSS (expr pos,theta,sc,al) =
-  U:=(.7u, .6u);
+  U:=(.4u, .6u);
   T:=identity aligned al rotated theta scaled sc shifted pos;
   pickup PenC;
 
-  thdraw (-.3u, -.5u) -- (-.7u, -.2u);
-  thdraw (-.2u, -.4u) -- (-.4u, .3u);
+  thdraw (-.2u, -.4u) -- (-.4u, .2u);
   thdraw (0u, -.3u) -- (0u, .6u);
-  thdraw (.3u, -.5u) -- (.7u, -.2u);
-  thdraw (.2u, -.4u) -- (.4u, .3u);
+  thdraw (.2u, -.4u) -- (.4u, .2u);
 enddef;
 
 def p_waterflow_permanent_UIS (expr pos,theta,sc,al)=

--- a/mpost/thTrans.mp
+++ b/mpost/thTrans.mp
@@ -144,6 +144,7 @@ let l_wall_pit = l_wall_pit_AUT;
 let l_wall_overlying = l_wall_overlying_AUT;
 let l_wall_flowstone = l_wall_flowstone_AUT;
 let l_wall_moonmilk = l_wall_moonmilk_AUT;
+let l_wall_chimney = l_wall_bedrock_UIS;
 
 let l_waterflow_permanent = l_waterflow_permanent_UIS;
 let l_waterflow_intermittent = l_waterflow_intermittent_SKBB;

--- a/thline.cxx
+++ b/thline.cxx
@@ -344,6 +344,7 @@ void thline::parse_subtype(char * ss)
         case TT_LINE_SUBTYPE_PIT:
         case TT_LINE_SUBTYPE_MOONMILK:
         case TT_LINE_SUBTYPE_FLOWSTONE:
+	case TT_LINE_SUBTYPE_CHIMNEY:
           tsok = true;
       }
       break;
@@ -724,6 +725,7 @@ bool thline::export_mp(class thexpmapmpxs * out)
             thline_type_export_mp(TT_LINE_SUBTYPE_UNSURVEYED, SYML_WALL_UNSURVEYED)
             thline_type_export_mp(TT_LINE_SUBTYPE_PRESUMED, SYML_WALL_PRESUMED)
             thline_type_export_mp(TT_LINE_SUBTYPE_PIT, SYML_WALL_PIT)
+            thline_type_export_mp(TT_LINE_SUBTYPE_CHIMNEY, SYML_WALL_CHIMNEY)
           }
           omacroid = macroid;
           if (this->context >= 0)

--- a/thline.h
+++ b/thline.h
@@ -281,6 +281,7 @@ enum {
   TT_LINE_SUBTYPE_PIT,
   TT_LINE_SUBTYPE_MOONMILK,
   TT_LINE_SUBTYPE_FLOWSTONE,
+  TT_LINE_SUBTYPE_CHIMNEY,
 };
 
 /**
@@ -292,6 +293,7 @@ static const thstok thtt_line_subtypes[] = {
   {"blocks",TT_LINE_SUBTYPE_BLOCKS},
   {"cave",TT_LINE_SUBTYPE_CAVE},
   {"clay",TT_LINE_SUBTYPE_CLAY},
+  {"chimney",TT_LINE_SUBTYPE_CHIMNEY},
   {"conjectural",TT_LINE_SUBTYPE_CONJECTURAL},
   {"debris",TT_LINE_SUBTYPE_DEBRIS},
   {"flowstone",TT_LINE_SUBTYPE_FLOWSTONE},

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -1566,15 +1566,15 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   legend_point(SYMP_HANDRAIL,thT("point handrail",layout->lang));
   legend_eqline(SYML_HANDRAIL,thT("line handrail",layout->lang));
   legend_point(SYMP_CAMP,thT("point camp",layout->lang));
-  legend_eqline(SYML_ABYSSENTRANCE,thT("line abyss-entrance",layout->lang));
-  legend_eqline(SYML_DRIPLINE,thT("line dripline",layout->lang));
-  legend_eqline(SYML_FAULT,thT("line fault",layout->lang));
+  legend_step(SYML_ABYSSENTRANCE,thT("line abyss-entrance",layout->lang));
+  legend_step(SYML_DRIPLINE,thT("line dripline",layout->lang));
+  legend_step(SYML_FAULT,thT("line fault",layout->lang));
   legend_eqline(SYML_JOINT,thT("line joint",layout->lang));
-  legend_eqline(SYML_LOWCEILING,thT("line low-ceiling",layout->lang));
-  legend_eqline(SYML_PITCHIMNEY,thT("line pit-chimney",layout->lang));
-  legend_eqline(SYML_RIMSTONEDAM,thT("line rimstone-dam",layout->lang));
-  legend_eqline(SYML_RIMSTONEPOOL,thT("line rimstone-pool",layout->lang));
-  legend_eqline(SYML_WALKWAY,thT("line walkway",layout->lang));
+  legend_step(SYML_LOWCEILING,thT("line low-ceiling",layout->lang));
+  legend_cycle(SYML_PITCHIMNEY,thT("line pit-chimney",layout->lang));
+  legend_step(SYML_RIMSTONEDAM,thT("line rimstone-dam",layout->lang));
+  legend_step(SYML_RIMSTONEPOOL,thT("line rimstone-pool",layout->lang));
+  legend_wall(SYML_WALKWAY,thT("line walkway",layout->lang));
 
   // thT("point remark")
   // thT("point label")

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -286,6 +286,7 @@ int thsymbolset_get_id(const char * symclass, const char * symbol)
             c2(TT_LINE_SUBTYPE_MOONMILK,SYML_WALL_MOONMILK)
             c2(TT_LINE_SUBTYPE_PIT,SYML_WALL_PIT)
             c2(TT_LINE_SUBTYPE_OVERLYING,SYML_WALL_OVERLYING)
+	    c2(TT_LINE_SUBTYPE_CHIMNEY,SYML_WALL_CHIMNEY)
           }
           break;
         case TT_LINE_TYPE_BORDER:
@@ -919,6 +920,7 @@ int thsymbolset_get_group(int group_id, int cid) {
     group(11,SYML_WALL_OVERLYING)
     group(12,SYML_WALL_MOONMILK)
     group(13,SYML_WALL_FLOWSTONE)
+    group(14,SYML_WALL_CHIMNEY)
     egroup
 
     bgroup(SYMX_LINE_WATERFLOW)
@@ -1120,6 +1122,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   legend_wall(SYML_WALL_ICE,thT("line wall:ice",layout->lang));
   legend_wall(SYML_WALL_FLOWSTONE,thT("line wall:flowstone",layout->lang));
   legend_wall(SYML_WALL_MOONMILK,thT("line wall:moonmilk",layout->lang));
+  legend_wall(SYML_WALL_CHIMNEY,thT("line wall:chimney",layout->lang));
 
   insfig(SYMP_WALLALTITUDE,thT("point wall-altitude",layout->lang));
   helpsymbol;


### PR DESCRIPTION
Just to make it clear that I'm working on these changes. Marked draft because it *does not work right now*!

Changes:
 - "NSS" Air draught symbol, based on Derek Bristol's cheat sheets (https://www.derekbristol.com/survey-efficiency). reflects common practice (not NSS standard)
 - narrow floor and ceiling meander variants. NSS standard
 - narrowed point gradient symbol. NSS standard
 - implement basic line-slope based on point gradient symbol. NSS standard
 - mud point and clay pattern. roughly NSS standard
 - add "Mud Fill" and "Too Tight" labels for clay choke and narrow end (respsectively). NSS common practice.
 - modify chimney symbol to NSS standard
 - pitchimney/aven symbol. NSS standard
 - wall:pit symbol. NSS standard
 - wall:unsurveyed and wall:underlying defined.

Things that don't work (but render with --print-symbols):
 - wall:flowstone. inspired (not NSS standard). loops endlessly. need to debug some.
 - wall:chimney. finding all the places to add a subtype have broken other subtypes. will need help!

Things I'd like to add or improve (likely in a future PR):
 - clay floor symbol should be better randomised.
 - intermittent flow (NSS) is a dash-dot format
 - clay wall based on NSS clay/mud symbol

Future work (complex, I don't intend to take it on):
 - datum-relative elevations instead of absolute. underlined (above datum), or overlined (below datum)
 - pitch depth that doesn't involve `p_label_mode_height:=6;` in my layout

feedback/testing/help would be appreciated, as the codebase is rather complex.