### PR TITLE
CMake Improvements

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-20.04, toolchain: gcc.cmake,              args: ""                                                }
-          - { os: ubuntu-22.04, toolchain: clang-sanitizers.cmake, args: ""                                                }
+          - { os: ubuntu-22.04, toolchain: clang-sanitizers.cmake, args: "-DENABLE_PROJ_CMAKE=ON"                          }
           - { os: ubuntu-22.04, toolchain: gcc.cmake,              args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug" }
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install dependencies
         run: |
-          # brew update  # commented out because of conflicting python versions
+          brew update  # try to comment out in case of package problems
           brew tap homebrew/core
           rm /usr/local/bin/2to3
           brew install wxwidgets vtk proj xquartz ninja basictex fmt pkgconfig

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-20.04, toolchain: gcc.cmake,              args: ""                                                }
-          - { os: ubuntu-22.04, toolchain: clang-sanitizers.cmake, args: "-DENABLE_PROJ_CMAKE=ON"                          }
+          - { os: ubuntu-22.04, toolchain: clang-sanitizers.cmake, args: ""                                                }
           - { os: ubuntu-22.04, toolchain: gcc.cmake,              args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug" }
     steps:
       - uses: actions/checkout@v3
@@ -78,8 +78,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - { msystem: MINGW32, arch: i686,       args: "-DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror"           }
-          - { msystem: CLANG32, arch: clang-i686, args: "-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/sanitizers.cmake" }
+          - { msystem: MINGW32, arch: i686,       args: "-DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror"                                  }
+          - { msystem: CLANG32, arch: clang-i686, args: "-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/sanitizers.cmake -DENABLE_PROJ_CMAKE=ON" }
     defaults:
       run:
         shell: msys2 {0}
@@ -92,7 +92,7 @@ jobs:
           msystem: ${{ matrix.config.msystem }}
           update: true
           install: make git python mingw-w64-${{ matrix.config.arch }}-freetype mingw-w64-${{ matrix.config.arch }}-cmake mingw-w64-${{ matrix.config.arch }}-proj mingw-w64-${{ matrix.config.arch }}-shapelib mingw-w64-${{ matrix.config.arch }}-vtk mingw-w64-${{ matrix.config.arch }}-wxWidgets mingw-w64-${{ matrix.config.arch }}-gcc mingw-w64-${{ matrix.config.arch }}-make mingw-w64-${{ matrix.config.arch }}-bwidget mingw-w64-${{ matrix.config.arch }}-fmt mingw-w64-${{ matrix.config.arch }}-catch
-      - run: mkdir build && cd build && cmake -G "MSYS Makefiles" -DUSE_BUNDLED_SHAPELIB=OFF -DBUILD_THBOOK=OFF ${{ matrix.config.args }} ..
+      - run: mkdir build && cd build && cmake -G "MSYS Makefiles" -DBUILD_THBOOK=OFF ${{ matrix.config.args }} ..
       - run: cmake --build build -t therion loch utest -- -j 4
       - name: Build samples
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
-include(cmake/PreventInSourceBuilds.cmake)
+
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(PreventInSourceBuilds)
 
 project(therion)
 set(CMAKE_CXX_STANDARD 17)
@@ -12,11 +14,11 @@ option(BUILD_THBOOK "Build thbook.pdf." ON)
 option(BUILD_XTHERION "Build xtherion." ON)
 
 include(GNUInstallDirs)
-include(cmake/BuildType.cmake)
-include(cmake/Dependencies.cmake)
-include(cmake/TherionSources.cmake)
-include(cmake/ECMEnableSanitizers.cmake)
-include(cmake/Warnings.cmake)
+include(BuildType)
+include(Dependencies)
+include(TherionSources)
+include(ECMEnableSanitizers)
+include(Warnings)
 
 # strip binaries in release build
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -s")
@@ -145,8 +147,8 @@ if (BUILD_THERION)
     # therion lib
     add_library(therion-common STATIC ${THERION_HEADERS} ${THERION_SOURCES})
     target_include_directories(therion-common BEFORE PUBLIC "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
-    target_link_libraries(therion-common PUBLIC PkgConfig::PROJ shp poly2tri common-utils QuickHull)
-    target_compile_definitions(therion-common PUBLIC PROJ_VER=${PROJ_MVER} "TH${THPLATFORM}" $<$<BOOL:${ENABLE_THDEBUG}>:THDEBUG>)
+    target_link_libraries(therion-common PUBLIC proj-interface shp-interface poly2tri common-utils QuickHull)
+    target_compile_definitions(therion-common PUBLIC "TH${THPLATFORM}" $<$<BOOL:${ENABLE_THDEBUG}>:THDEBUG>)
     add_dependencies(therion-common 
         version
         generate_thsymbolsetlist
@@ -182,7 +184,7 @@ if (BUILD_THERION)
 
     # unit tests
     add_executable(utest utest-proj.cxx utest-icase.cxx utest-thdouble.cxx utest-main.cxx)
-    target_link_libraries(utest PUBLIC therion-common Catch2::Catch2)
+    target_link_libraries(utest PUBLIC therion-common catch2-interface)
     enable_testing()
     if (NOT WIN32)
         add_test(NAME utest COMMAND $<TARGET_FILE:utest> WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -1,0 +1,16 @@
+#
+# Set how to find dependency Catch2.
+# Option USE_BUNDLED_CATCH2:
+# * ON - use Catch2 header from extern subdirectory
+# * OFF - use Catch2 installed in the system
+#
+option(USE_BUNDLED_CATCH2 "Use bundled version of Catch2." ON)
+
+add_library(catch2-interface INTERFACE)
+
+if (USE_BUNDLED_CATCH2)
+    target_include_directories(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/extern)
+else()
+    find_package(Catch2 REQUIRED)
+    target_link_libraries(catch2-interface INTERFACE Catch2::Catch2)
+endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -10,31 +10,9 @@ endif()
 
 # therion dependencies
 if (BUILD_THERION)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)
-    string(FIND ${PROJ_VERSION} "." MVER_SEP)
-    string(SUBSTRING ${PROJ_VERSION} 0 ${MVER_SEP} PROJ_MVER)
-    set(PROJ_UNSUPPORTED 5.0.0 5.0.1 6.0.0 6.1.0 6.1.1 6.2.0)
-    if (PROJ_VERSION IN_LIST PROJ_UNSUPPORTED) # check if proj version is unsupported
-        message(FATAL_ERROR "Unsupported proj version: ${PROJ_VERSION}")
-    endif()
-
-    option(USE_BUNDLED_CATCH2 "Use bundled version of Catch2." ON)
-    if (USE_BUNDLED_CATCH2)
-        add_library(Catch2 INTERFACE)
-        target_include_directories(Catch2 INTERFACE ${CMAKE_SOURCE_DIR}/extern)
-        add_library(Catch2::Catch2 ALIAS Catch2) # to be compatible with Catch2's exported target
-    else()
-        find_package(Catch2 REQUIRED)
-    endif()
-
-    option(USE_BUNDLED_SHAPELIB "Use bundled version of shapelib." ON)
-    if (USE_BUNDLED_SHAPELIB)
-        add_subdirectory(extern/shapelib)
-    else()
-        pkg_check_modules(SHAPELIB REQUIRED IMPORTED_TARGET shapelib)
-        add_library(shp ALIAS PkgConfig::SHAPELIB)
-    endif()
+    include(PROJ)
+    include(Catch2)
+    include(Shapelib)
 endif()
 
 # loch dependencies

--- a/cmake/PROJ.cmake
+++ b/cmake/PROJ.cmake
@@ -1,0 +1,28 @@
+#
+# Set how to find dependency PROJ.
+# Option ENABLE_PROJ_CMAKE:
+# * ON - use CMake to find PROJ's exported targets
+# * OFF - find PROJ with pkg-config
+#
+option(ENABLE_PROJ_CMAKE "Use CMake to find PROJ library." OFF)
+
+add_library(proj-interface INTERFACE)
+
+if (ENABLE_PROJ_CMAKE)
+    find_package(PROJ REQUIRED)
+    target_link_libraries(proj-interface INTERFACE PROJ::proj)
+else()
+    if (NOT PKG_CONFIG_FOUND)
+        find_package(PkgConfig REQUIRED)
+    endif()
+    pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)
+    target_link_libraries(proj-interface INTERFACE PkgConfig::PROJ)
+endif()
+
+string(FIND ${PROJ_VERSION} "." MVER_SEP)
+string(SUBSTRING ${PROJ_VERSION} 0 ${MVER_SEP} PROJ_MVER)
+set(PROJ_UNSUPPORTED 5.0.0 5.0.1 6.0.0 6.1.0 6.1.1 6.2.0)
+if (PROJ_VERSION IN_LIST PROJ_UNSUPPORTED) # check if proj version is unsupported
+    message(FATAL_ERROR "Unsupported proj version: ${PROJ_VERSION}")
+endif()
+target_compile_definitions(proj-interface INTERFACE PROJ_VER=${PROJ_MVER})

--- a/cmake/Shapelib.cmake
+++ b/cmake/Shapelib.cmake
@@ -1,0 +1,20 @@
+#
+# Set how to find dependency shapelib.
+# Option USE_BUNDLED_SHAPELIB:
+# * ON - use shapelib from extern subdirectory
+# * OFF - use shapelib installed in the system
+#
+option(USE_BUNDLED_SHAPELIB "Use bundled version of shapelib." ON)
+
+add_library(shp-interface INTERFACE)
+
+if (USE_BUNDLED_SHAPELIB)
+    add_subdirectory(extern/shapelib)
+    target_link_libraries(shp-interface INTERFACE shp)
+else()
+    if (NOT PKG_CONFIG_FOUND)
+        find_package(PkgConfig REQUIRED)
+    endif()
+    pkg_check_modules(SHAPELIB REQUIRED IMPORTED_TARGET shapelib)
+    target_link_libraries(shp-interface INTERFACE PkgConfig::SHAPELIB)
+endif()

--- a/loch/CMakeLists.txt
+++ b/loch/CMakeLists.txt
@@ -47,7 +47,7 @@ if (WIN32)
     add_custom_target(generate_resource DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/loch.res)
 endif()
 
-include(${CMAKE_SOURCE_DIR}/cmake/LochSources.cmake)
+include(LochSources)
 # loch executable
 add_executable(loch WIN32 ${LOCH_HEADERS} ${LOCH_SOURCES})
 # we need to filter out include directories from wxWidgets cxx flags list, because we have to set them only as system headers to ignore warnings


### PR DESCRIPTION
* **New feature:** use CMake option `-DENABLE_PROJ_CMAKE=ON` to find PROJ library with CMake.
* CMake modules can now be imported by name.
*  Uncommented `brew update`, old `basictex` version was not available anymore.