### PR TITLE
Fix missing null check

### DIFF
--- a/thinput.cxx
+++ b/thinput.cxx
@@ -490,8 +490,12 @@ char * thinput::get_cif_path()
   return cifpath.get_buffer();
 }
 
-std::string thinput::get_cif_abspath(const char * fname)
+std::string thinput::get_cif_abspath(const char * fname_ptr)
 {
+  std::string_view fname;
+  if (fname_ptr)
+    fname = fname_ptr;
+
   std::error_code ec;
   auto pict_path = std::filesystem::current_path(ec);
   thassert(!ec);
@@ -504,7 +508,7 @@ std::string thinput::get_cif_abspath(const char * fname)
   
   pict_path = pict_path.parent_path();
 
-  if (fname != NULL && strlen(fname) > 0) {
+  if (!fname.empty()) {
     if (fs::path(fname).is_absolute())
       pict_path = fname;
     else
@@ -513,7 +517,7 @@ std::string thinput::get_cif_abspath(const char * fname)
 
   auto pict_path_str = pict_path.string();
   std::replace(pict_path_str.begin(), pict_path_str.end(), '\\', '/');
-  if ((strlen(fname) == 0) && ((pict_path_str.length() == 0) || (pict_path_str.back() != '/'))) {
+  if (fname.empty() && (pict_path_str.empty() || (pict_path_str.back() != '/'))) {
 	  pict_path_str += "/";
   }
   return pict_path_str;

--- a/thinput.h
+++ b/thinput.h
@@ -285,7 +285,7 @@ class thinput {
    * Return current absolute input file path.
    */  
    
-  std::string get_cif_abspath(const char * fname = "");
+  std::string get_cif_abspath(const char * fname_ptr = "");
   
   /**
    * Return current input line number.


### PR DESCRIPTION
There is a missing null check, so I have fixed it by introducing early conversion from `const char*` to `std::string_view`. It would be better to do the change at the API level, but that would take lots of work.

This issue was found by Coverity as [Dereference after null check](https://scan6.scan.coverity.com/doc/en/cov_checker_ref.html#static_checker_FORWARD_NULL).