### PR TITLE
Fix use-after-close

### DIFF
--- a/thlogfile.cxx
+++ b/thlogfile.cxx
@@ -154,9 +154,8 @@ void thlogfile::printf(const char * format, ...)
 
 void thlogfile::log_error() {
 	this->close_file();
-	this->open_file();
 	this->logging_off();
-	fprintf(this->fileh,"error -- unable to write to log file (disk full?, insufficient permissions?)");
+	fprintf(stderr,"error -- unable to write to log file (disk full?, insufficient permissions?)\n");
 }
 
 thlogfile thlog;


### PR DESCRIPTION
When logger fails to write to a file, it probably does not make sense to try to reopen the file and log error there. Previous code flow even permitted to use already closed file handle, this has been found by Coverity and reported as `use-after-close` bug.