### PR TITLE
Fix missing includes

### DIFF
--- a/extern/quickhull/Structs/Mesh.hpp
+++ b/extern/quickhull/Structs/Mesh.hpp
@@ -7,6 +7,7 @@
 #include "Pool.hpp"
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include "VertexDataSource.hpp"

--- a/loch/lxFile.h
+++ b/loch/lxFile.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <string>
 #include <cstdio>
+#include <cstdint>
 #include <vector>
 #endif  
 //LXDEPCHECK - standard libraries


### PR DESCRIPTION
New GCC 13.1 probably reorganized headers and we need to include `cstdint`.