### PR TITLE
Fix incorrect printf arguments

### DIFF
--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -309,7 +309,7 @@ void thdb1d::scan_data()
                   else
                 	  length_sd = lei->length_sd;
 				  if (abs(lei->backlength - lei->length) > (3.0 * length_sd))
-					thwarning(("%s [%d] -- forwards and backwards length readings do not match", lei->srcf.name, lei->srcf.line));
+					thwarning(("%s [%lu] -- forwards and backwards length readings do not match", lei->srcf.name, lei->srcf.line));
                   lei->length += lei->backlength;
                   lei->length /= 2.0;
                 }

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -410,7 +410,7 @@ char * thinput::read_line()
         case TT_INPUT:
           if (this->input_sensitivity) {
             if (this->tmpmb.get_size() != 1)
-              therror(("%s [%d] -- one input file name expected -- %s", \
+              therror(("%s [%lu] -- one input file name expected -- %s", \
                 this->get_cif_name(), this->get_cif_line_number(), \
                 this->valuebf.get_buffer()))
             else

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -487,7 +487,7 @@ void thselector::select_db(class thdatabase * db)
         nsrv = nms[1];
         break;
       default:
-        thwarning(("%s [%d] -- invalid object specification", 
+        thwarning(("%s [%lu] -- invalid object specification", 
           ii->src_name, ii->src_ln))
         to_cont = false;
     }


### PR DESCRIPTION
Fix wrong types of `printf()` arguments. Reported by Coverity, but accidentally omitted when I was fixing this type of problems in the past.