### PR TITLE
Fix fmt 10 formatting

### DIFF
--- a/thimport.cxx
+++ b/thimport.cxx
@@ -442,7 +442,7 @@ void thimport::import_file_img()
   img* pimg = img_open(this->fname);
   if (pimg == NULL) {	
     imgerr = img_error();
-    ththrow("unable to open file {}, error code: {}", this->fname, imgerr);
+    ththrow("unable to open file {}, error code: {}", this->fname, static_cast<int>(imgerr));
   }
   do {
     result = img_read_item(pimg, &imgpt);


### PR DESCRIPTION
`{fmt}` version 10 no longer formats unscoped enums, which broke printing of img error code.