### PR TITLE
Reorganized includes

### DIFF
--- a/loch/CMakeLists.txt
+++ b/loch/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(img PRIVATE disable-warnings)
 
 # library common with therion
 add_library(common-utils STATIC icase.h lxFile.h lxFile.cxx lxMath.h lxMath.cxx)
-target_compile_definitions(common-utils PRIVATE ${LOCH_DEFINITIONS})
+target_compile_definitions(common-utils PUBLIC $<$<BOOL:${WIN32}>:WIN32_LEAN_AND_MEAN> PRIVATE ${LOCH_DEFINITIONS})
 target_link_libraries(common-utils PUBLIC img enable-warnings fmt::fmt)
 
 if (NOT BUILD_LOCH)

--- a/loch/lxAboutDlg.cxx
+++ b/loch/lxAboutDlg.cxx
@@ -5,6 +5,9 @@
 // Standard libraries
 #ifndef LXDEPCHECK
 #include <wx/panel.h>
+#include <wx/dialog.h>
+#include <wx/statbmp.h>
+#include <wx/stattext.h>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxAboutDlg.h
+++ b/loch/lxAboutDlg.h
@@ -16,7 +16,7 @@
 
 // Standard libraries
 #ifndef LXDEPCHECK
-#include <wx/wx.h>
+#include <wx/window.h>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxData.cxx
+++ b/loch/lxData.cxx
@@ -29,7 +29,6 @@
 // Standard libraries
 #ifndef LXDEPCHECK
 #include <stdlib.h>
-#include <wx/wx.h>
 #include <wx/txtstrm.h>
 #include <wx/strconv.h>
 #include <wx/wfstream.h>

--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -14,7 +14,8 @@
 #ifndef LXDEPCHECK
 #include <math.h>
 #include <stdlib.h>
-#include <wx/wx.h>
+#include <wx/dcclient.h>
+#include <wx/stattext.h>
 #include <stdio.h>
 #include <vtkVersionMacros.h>
 #include <vtkCellArray.h>
@@ -39,9 +40,7 @@
 #include "lxFNT6x13_bdf.h"
 #include "lxFNT10x20_bdf.h"
 #include "lxFNTFreeSans_ttf.h"
-#include "lxSetup.h"
 #include "lxRender.h"
-#include "lxGUI.h"
 #include "lxTR.h"
 
 #ifdef LXWIN32

--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -13,7 +13,6 @@
 // Standard libraries
 #ifndef LXDEPCHECK
 
-#include <wx/wx.h>
 #include <wx/utils.h>
 #include <wx/filedlg.h>
 #include <wx/toolbar.h>
@@ -24,6 +23,8 @@
 #include <wx/fs_zip.h>
 #include <wx/dnd.h>
 #include <wx/display.h>
+#include <wx/menu.h>
+#include <wx/msgdlg.h>
 
 #include <vtkObject.h>
 

--- a/loch/lxGUI.h
+++ b/loch/lxGUI.h
@@ -31,7 +31,6 @@
 
 // Standard libraries
 #ifndef LXDEPCHECK
-#include <wx/wx.h>
 #include <wx/fileconf.h>
 #include <wx/filename.h>
 #include <wx/docview.h>

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -25,7 +25,6 @@
 #ifndef LXDEPCHECK
 
 #ifndef OGLFT_NO_WX
-#include <wx/wx.h>
 #include <wx/colour.h>
 #else
 #include <windows.h>

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -27,7 +27,6 @@
 #ifndef OGLFT_NO_WX
 #include <wx/colour.h>
 #else
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -27,6 +27,8 @@
 #ifndef OGLFT_NO_WX
 #include <wx/colour.h>
 #else
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -28,7 +28,6 @@
 #include <wx/colour.h>
 #else
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/loch/lxOptDlg.cxx
+++ b/loch/lxOptDlg.cxx
@@ -5,6 +5,11 @@
 #ifndef LXDEPCHECK
 #include <wx/dirdlg.h>
 #include <wx/valgen.h>
+#include <wx/statbox.h>
+#include <wx/stattext.h>
+#include <wx/button.h>
+#include <wx/choice.h>
+#include <wx/valtext.h>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxOptDlg.h
+++ b/loch/lxOptDlg.h
@@ -16,7 +16,7 @@
 
 // Standard libraries
 #ifndef LXDEPCHECK
-#include <wx/wx.h>
+#include <wx/window.h>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxPres.cxx
+++ b/loch/lxPres.cxx
@@ -3,6 +3,9 @@
 #include <wx/statline.h>
 #include <wx/xml/xml.h>
 #include <wx/filedlg.h>
+#include <wx/msgdlg.h>
+#include <wx/listbox.h>
+#include <wx/button.h>
 #endif
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxPres.cxx
+++ b/loch/lxPres.cxx
@@ -6,6 +6,7 @@
 #include <wx/msgdlg.h>
 #include <wx/listbox.h>
 #include <wx/button.h>
+#include <cstdint>
 #endif
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxR2D.h
+++ b/loch/lxR2D.h
@@ -4,6 +4,8 @@ extern "C" {
 
 /*Standard libraries*/
 #ifndef LXDEPCHECK
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif  
 /*LXDEPCHECK - standard libraries*/

--- a/loch/lxR2D.h
+++ b/loch/lxR2D.h
@@ -5,7 +5,6 @@ extern "C" {
 /*Standard libraries*/
 #ifndef LXDEPCHECK
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #endif  
 /*LXDEPCHECK - standard libraries*/

--- a/loch/lxR2D.h
+++ b/loch/lxR2D.h
@@ -4,7 +4,6 @@ extern "C" {
 
 /*Standard libraries*/
 #ifndef LXDEPCHECK
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif  
 /*LXDEPCHECK - standard libraries*/

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -17,6 +17,9 @@
 #include <wx/intl.h>
 #include <wx/progdlg.h>
 #include <wx/valgen.h>
+#include <wx/stattext.h>
+#include <wx/statbox.h>
+#include <wx/button.h>
 
 #ifdef __cplusplus
  extern "C" {  // stupid JPEG library

--- a/loch/lxRender.h
+++ b/loch/lxRender.h
@@ -8,7 +8,7 @@
 
 // Standard libraries
 #ifndef LXDEPCHECK
-#include <wx/wx.h>
+#include <wx/window.h>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxSScene.cxx
+++ b/loch/lxSScene.cxx
@@ -1,6 +1,9 @@
 // Standard libraries
 #ifndef LXDEPCHECK
 #include <wx/statline.h>
+#include <wx/listbox.h>
+#include <wx/stattext.h>
+#include <wx/button.h>
 #endif  
 //LXDEPCHECK - standard libraries
 
@@ -8,6 +11,7 @@
 #include "lxSetup.h"
 #include "lxGUI.h"
 #include "lxGLC.h"
+#include "lxData.h"
 
 #ifndef LXGNUMSW
 #include "loch.xpm"

--- a/loch/lxSStats.cxx
+++ b/loch/lxSStats.cxx
@@ -2,6 +2,7 @@
 #ifndef LXDEPCHECK
 #include <wx/statline.h>
 #include <wx/busyinfo.h>
+#include <wx/button.h>
 #include <vtkMassProperties.h>
 #endif  
 //LXDEPCHECK - standard libraries
@@ -10,6 +11,7 @@
 #include "lxSetup.h"
 #include "lxGUI.h"
 #include "lxGLC.h"
+#include "lxData.h"
 
 #ifndef LXGNUMSW
 #include "loch.xpm"

--- a/loch/lxSTree.cxx
+++ b/loch/lxSTree.cxx
@@ -2,6 +2,7 @@
 #ifndef LXDEPCHECK
 #include <wx/statline.h>
 #include <wx/busyinfo.h>
+#include <wx/button.h>
 #endif  
 //LXDEPCHECK - standard libraries
 
@@ -9,6 +10,7 @@
 #include "lxSetup.h"
 #include "lxGUI.h"
 #include "lxGLC.h"
+#include "lxData.h"
 
 #ifndef LXGNUMSW
 #include "loch.xpm"

--- a/loch/lxSView.cxx
+++ b/loch/lxSView.cxx
@@ -1,7 +1,10 @@
 // Standard libraries
 #ifndef LXDEPCHECK
 #include <wx/choice.h>
-#include <math.h>
+#include <wx/listbox.h>
+#include <wx/stattext.h>
+#include <wx/button.h>
+#include <cmath>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/loch/lxSetup.h
+++ b/loch/lxSetup.h
@@ -20,9 +20,10 @@
 //LXDEPCHECK - standard libraries
 
 
-#include "lxData.h"
 #include "lxMath.h"
 #include <set>
+
+struct lxData;
 
 enum {
   lxSETUP_COLORMD_DEFAULT,

--- a/loch/lxTR.h
+++ b/loch/lxTR.h
@@ -78,7 +78,6 @@
 #include <stdio.h>
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/loch/lxTR.h
+++ b/loch/lxTR.h
@@ -77,7 +77,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/loch/lxTR.h
+++ b/loch/lxTR.h
@@ -77,6 +77,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/loch/lxWX.cxx
+++ b/loch/lxWX.cxx
@@ -5,6 +5,7 @@
 #include <wx/intl.h>
 #include <wx/msgdlg.h>
 #include <wx/textctrl.h>
+#include <wx/frame.h>
 #endif
 
 

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -3,10 +3,13 @@
 
 // Standard libraries
 #ifndef LXDEPCHECK
-#include <wx/wx.h>
 #include <wx/spinctrl.h>
 #include <wx/slider.h>
 #include <wx/gbsizer.h>
+#include <wx/radiobut.h>
+#include <wx/checkbox.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
 #endif  
 //LXDEPCHECK - standard libraries
 

--- a/th2ddataobject.cxx
+++ b/th2ddataobject.cxx
@@ -29,6 +29,7 @@
 #include "thexception.h"
 #include "thsymbolset.h"
 #include "thchenc.h"
+#include "thdatabase.h"
 
 th2ddataobject::th2ddataobject()
 {

--- a/tharea.cxx
+++ b/tharea.cxx
@@ -31,6 +31,7 @@
 #include "thchenc.h"
 #include "thexpmap.h"
 #include "thline.h"
+#include "thdatabase.h"
 
 tharea::tharea()
 {

--- a/tharea.h
+++ b/tharea.h
@@ -33,6 +33,8 @@
 #include "th2ddataobject.h"
 #include "thdb2dab.h"
 
+#include <memory>
+
 /**
  * Area command options tokens.
  */

--- a/thattr.cxx
+++ b/thattr.cxx
@@ -32,6 +32,7 @@
 #include "thchenc.h"
 #include <cctype>
 #include <cmath>
+#include <cstring>
 #include <set>
 
 thattr::thattr()

--- a/thbuffer.cxx
+++ b/thbuffer.cxx
@@ -28,6 +28,8 @@
  
 #include "thbuffer.h"
 
+#include <cstring>
+
 thbuffer::thbuffer()
 {
   this->size = 16;

--- a/thbuffer.h
+++ b/thbuffer.h
@@ -29,7 +29,7 @@
 #ifndef thbuffer_h
 #define thbuffer_h
 
-#include <string.h>
+#include <cstddef>
 
 /**
  * String buffer class.

--- a/thcomment.cxx
+++ b/thcomment.cxx
@@ -26,10 +26,10 @@
  */
  
 #include "thcomment.h"
-#include "thexception.h"
 #include "thchenc.h"
 #include "thdata.h"
 #include "thparse.h"
+#include "thdatabase.h"
 
 thcomment::thcomment()
 {

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -48,7 +48,6 @@
 #include "thsketch.h"
 #include "thcs.h"
 #ifdef THWIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -49,7 +49,6 @@
 #include "thcs.h"
 #ifdef THWIN32
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -48,6 +48,8 @@
 #include "thsketch.h"
 #include "thcs.h"
 #ifdef THWIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -37,7 +37,6 @@
 #include "thexception.h"
 #include "thdatabase.h"
 #include "thdatareader.h"
-#include "thdataobject.h"
 #include "thcsdata.h"
 #include "thproj.h"
 #include "thlogfile.h"

--- a/thdata.cxx
+++ b/thdata.cxx
@@ -34,6 +34,7 @@
 #include "thgrade.h"
 #include "thcsdata.h"
 #include "thdatareader.h"
+#include "thdatabase.h"
 #include "loch/icase.h"
 
 thdata::thdata()

--- a/thdatabase.h
+++ b/thdatabase.h
@@ -34,7 +34,6 @@
 #include <set>
 #include <memory>
 
-#include "thdataobject.h"
 #include "thmbuffer.h"
 #include "thbuffer.h"
 #include "thdb1d.h"
@@ -42,7 +41,7 @@
 #include "thobjectname.h"
 #include "thobjectsrc.h"
 #include "thattr.h"
-#include <stdio.h>
+#include <cstdio>
 
 /**
  * Input contexts.

--- a/thdataobject.cxx
+++ b/thdataobject.cxx
@@ -35,6 +35,7 @@
 #include "thdata.h"
 #include "thproj.h"
 #include "thcs.h"
+#include "thdatabase.h"
 
 thdataobject::thdataobject()
 {

--- a/thdataobject.h
+++ b/thdataobject.h
@@ -30,13 +30,12 @@
 #define thdataobject_h
 
 
-#include "thdatabase.h"
 #include "thperson.h"
 #include "thparse.h"
 #include "thdate.h"
-#include "thdataleg.h"
 #include "thlayoutclr.h"
-#include <stdio.h>
+#include "thobjectsrc.h"
+#include <cstdio>
 #include <map>
 
 /**

--- a/thdatareader.cxx
+++ b/thdatareader.cxx
@@ -28,6 +28,8 @@
 #include "thdatareader.h"
 #include "thexception.h"
 #include "thobjectsrc.h"
+#include "thdataobject.h"
+#include "thdatabase.h"
 
 unsigned long thdatareader_get_opos(bool inlineid, bool cfgid)
 {

--- a/thdatareader.h
+++ b/thdatareader.h
@@ -30,9 +30,9 @@
 #define thdatareader_h
 
 
-#include "thdatabase.h"
 #include "thinput.h"
 
+class thdatabase;
 
 /**
  * Main data reader class.

--- a/thdb2dji.cxx
+++ b/thdb2dji.cxx
@@ -30,7 +30,6 @@
 #include "thexception.h"
 #include "thdb2dpt.h"
 #include "thdb2dlp.h"
-#include "thdataobject.h"
 
 thdb2dji::thdb2dji()
 {

--- a/thendscrap.cxx
+++ b/thendscrap.cxx
@@ -28,6 +28,7 @@
 #include "thendscrap.h"
 #include "thexception.h"
 #include "thchenc.h"
+#include "thdatabase.h"
 
 thendscrap::thendscrap()
 {

--- a/thendsurvey.cxx
+++ b/thendsurvey.cxx
@@ -28,6 +28,7 @@
 #include "thendsurvey.h"
 #include "thexception.h"
 #include "thchenc.h"
+#include "thdatabase.h"
 
 thendsurvey::thendsurvey()
 {

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -37,6 +37,7 @@
 #include "thbezier.h"
 #include "thlogfile.h"
 #include "thproj.h"
+#include "thdatabase.h"
 
 extern const thstok thtt_texts [];
 

--- a/therion.cxx
+++ b/therion.cxx
@@ -32,7 +32,6 @@
 #include "thconfig.h"
 #include "thinput.h"
 #include "thchenc.h"
-#include "thdatabase.h"
 #include "thdatareader.h"
 #include "thexception.h"
 #include "thlibrary.h"

--- a/thexpsys.cxx
+++ b/thexpsys.cxx
@@ -26,8 +26,7 @@
  */
  
 #include "thexpsys.h"
-#include "thexception.h"
-#include "thdatabase.h"
+#include "therion.h"
 
 thexpsys::thexpsys() {
   this->cmd = "";

--- a/thgrade.cxx
+++ b/thgrade.cxx
@@ -30,6 +30,7 @@
 #include "thchenc.h"
 #include "thdata.h"
 #include "thparse.h"
+#include "thdatabase.h"
 
 thgrade::thgrade()
 {

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -32,6 +32,7 @@
 #include "thdata.h"
 #include "thsurvey.h"
 #include "thendsurvey.h"
+#include "thdatabase.h"
 #include "extern/img.h"
 #include <string.h>
 #include <string>

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -42,6 +42,8 @@
 #include <filesystem>
 
 #ifdef THWIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -43,7 +43,6 @@
 
 #ifdef THWIN32
 #define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -42,7 +42,6 @@
 #include <filesystem>
 
 #ifdef THWIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/thjoin.cxx
+++ b/thjoin.cxx
@@ -29,6 +29,7 @@
 #include "thexception.h"
 #include "thchenc.h"
 #include "thparse.h"
+#include "thdatabase.h"
 
 thjoin::thjoin()
 {

--- a/thlayout.cxx
+++ b/thlayout.cxx
@@ -39,6 +39,7 @@
 #include "thcsdata.h"
 #include "thconfig.h"
 #include "th2ddataobject.h"
+#include "thdatabase.h"
 #include <string.h>
 #include <filesystem>
 

--- a/thlayout.h
+++ b/thlayout.h
@@ -37,6 +37,8 @@
 #include "thlayoutclr.h"
 #include <list>
 
+class thdb2dprj;
+
 /**
  * layout command options tokens.
  */

--- a/thline.cxx
+++ b/thline.cxx
@@ -34,6 +34,7 @@
 #include "thtflength.h"
 #include "thtexfonts.h"
 #include "thscrap.h"
+#include "thdatabase.h"
 
 thline::thline()
 {

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -41,6 +41,7 @@
 #include "thmap.h"
 #include "thpdf.h"
 #include "thtexfonts.h"
+#include "thdatabase.h"
 #include <string.h>
 
 

--- a/thlookup.h
+++ b/thlookup.h
@@ -33,8 +33,11 @@
 #include "thdataobject.h"
 #include "thlocale.h"
 #include "thmapstat.h"
+#include "thinfnan.h"
 #include <list>
 #include <string>
+
+class thscrap;
 
 /**
  * lookup command options tokens.

--- a/thmap.cxx
+++ b/thmap.cxx
@@ -34,6 +34,7 @@
 #include "thdb2dmi.h"
 #include "thtflength.h"
 #include "thconfig.h"
+#include "thdatabase.h"
 
 
 thmap::thmap()

--- a/thmap.h
+++ b/thmap.h
@@ -33,6 +33,7 @@
 #include "thdataobject.h"
 #include "thlayoutclr.h"
 #include "thmapstat.h"
+#include "thobjectname.h"
 
 /**
  * map command options tokens.

--- a/thmapstat.cxx
+++ b/thmapstat.cxx
@@ -38,6 +38,8 @@
 #include "thdb1d.h"
 #include "thconfig.h"
 #include "thcs.h"
+#include "thdb2dmi.h"
+#include "thdatabase.h"
 #include <vector>
 #include <algorithm>
 #include <string.h>

--- a/thmbuffer.cxx
+++ b/thmbuffer.cxx
@@ -27,6 +27,7 @@
  
 #include "thmbuffer.h"
 
+#include <cstring>
 
 thmbuffer::mblock::mblock(size_t min_size, size_t last_size)
 {

--- a/thmbuffer.h
+++ b/thmbuffer.h
@@ -29,7 +29,7 @@
 #ifndef thmbuffer_h
 #define thmbuffer_h
 
-#include <string.h>
+#include <cstddef>
 
 /**
  * Multiple string buffer class.

--- a/thpdf.cxx
+++ b/thpdf.cxx
@@ -50,6 +50,7 @@
 #include "thlang.h"
 #include "thversion.h"
 #include "thdouble.h"
+#include "therion.h"
 
 #include "thchenc.h"
 #include "thbuffer.h"

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -35,7 +35,9 @@
 #include "thtexfonts.h"
 #include "thdate.h"
 #include "thscrap.h"
+#include "thobjectname.h"
 #include <string>
+#include <cstdio>
 
 
 thpoint::thpoint()

--- a/thpoint.h
+++ b/thpoint.h
@@ -33,6 +33,7 @@
 #include "th2ddataobject.h"
 #include "thparse.h"
 #include "thdb2dpt.h"
+#include "thobjectname.h"
 
 /**
  * point command options tokens.

--- a/thscrap.cxx
+++ b/thscrap.cxx
@@ -41,6 +41,7 @@
 #include "thsymbolset.h"
 #include "thsketch.h"
 #include "thcsdata.h"
+#include "thdatabase.h"
 
 #define EXPORT3D_INVISIBLE true
 

--- a/thscrap.h
+++ b/thscrap.h
@@ -43,6 +43,8 @@
 
 #include <set>
 
+class thdb2dprj;
+
 /**
  * scrap command options tokens.
  */

--- a/thscrapis.cxx
+++ b/thscrapis.cxx
@@ -40,6 +40,7 @@
 #include "thscrap.h"
 #include "thsurvey.h"
 #include <cmath>
+#include <cstring>
 
 struct pt2d {
   double x, y;

--- a/thscraplp.cxx
+++ b/thscraplp.cxx
@@ -28,6 +28,7 @@
 #include "thscraplp.h"
 #include "thscrap.h"
 #include "thexpmap.h"
+#include "thdatabase.h"
 #include "loch/lxMath.h"
 
 thscraplp::thscraplp() {

--- a/thsurvey.cxx
+++ b/thsurvey.cxx
@@ -32,6 +32,7 @@
 #include "thtfangle.h"
 #include "thinfnan.h"
 #include "thdata.h"
+#include "thdatabase.h"
 
 thsurvey::thsurvey()
 {

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -31,7 +31,6 @@
 #include "thtmpdir.h"
 #include "thdata.h"
 #include "thexception.h"
-#include "thdatabase.h"
 #include "thinfnan.h"
 #include "thinit.h"
 #include "thconfig.h"

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -43,6 +43,7 @@
 #include "thsymbolsets.h"
 #include "thlogfile.h"
 #include "thepsparse.h"
+#include "thdatabase.h"
 #include <fmt/printf.h>
 
 thsymbolset::thsymbolset()

--- a/thwarp.cxx
+++ b/thwarp.cxx
@@ -34,6 +34,7 @@
 #include "thpoint.h"
 #include "thconfig.h"
 #include "thdatabase.h"
+#include <cstring>
 
 thwarp::~thwarp() {}
    

--- a/thwarp.cxx
+++ b/thwarp.cxx
@@ -33,6 +33,7 @@
 #include "th2ddataobject.h"
 #include "thpoint.h"
 #include "thconfig.h"
+#include "thdatabase.h"
 
 thwarp::~thwarp() {}
    

--- a/thwarpp.cxx
+++ b/thwarpp.cxx
@@ -31,6 +31,7 @@
 #include "th2ddataobject.h"
 #include "thpoint.h"
 #include "thconfig.h"
+#include "thdatabase.h"
 
 #include <fmt/printf.h>
 

--- a/thwarpp.h
+++ b/thwarpp.h
@@ -33,7 +33,10 @@
 #include "thwarp.h"
 #include "thwarppme.h"
 #include "thwarppt.h"
-#include "thdataobject.h"
+#include "thobjectsrc.h"
+#include "thobjectname.h"
+
+class thscrap;
 
 /**
  * Sketch station structure.


### PR DESCRIPTION
I have reorganized includes based on build profile in #506. There should be no functional changes, just messing with includes. I had to define `WIN32_LEAN_AND_MEAN` so the order of including `Windows.h`  and  `wxWidgets` does not matter (there was a clash between `winsock.h` included in `Windows.h` and `winsock2.h` included in `wxWidgets`). For further improvements I will need to start doing (minor) code changes.

Current build profile (4 cores, 49s):

```
Analyzing build trace from './therion-clang-debug-github.data'...
**** Time summary:
Compilation (257 times):
  Parsing (frontend):          156.2 s
  Codegen & opts (backend):     26.5 s

**** Files that took longest to parse (compiler frontend):
  7090 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxGLC.cxx.o
  3862 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/utest.dir/utest-main.cxx.o
  3235 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxGUI.cxx.o
  3123 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxSScene.cxx.o
  3091 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxSTree.cxx.o
  3057 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxData.cxx.o
  2865 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxSStats.cxx.o
  2682 ms: /home/afforix/build/therion/Clang-Debug/loch/CMakeFiles/loch.dir/lxRender.cxx.o
  2317 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thpdf.cxx.o
  2261 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thexpmap.cxx.o

**** Files that took longest to codegen (compiler backend):
  3265 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/utest.dir/utest-main.cxx.o
  1410 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thpdf.cxx.o
  1214 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thepsparse.cxx.o
  1090 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thsymbolset.cxx.o
   991 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thexpmap.cxx.o
   892 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thproj.cxx.o
   852 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thtexfonts.cxx.o
   808 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thsvg.cxx.o
   634 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thdb2d.cxx.o
   592 ms: /home/afforix/build/therion/Clang-Debug/CMakeFiles/therion-common.dir/thexpmodel.cxx.o

**** Templates that took longest to instantiate:
  2668 ms: fmt::vsprintf<fmt::basic_string_view<char>, char> (12 times, avg 222 ms)
  2626 ms: fmt::detail::vprintf<char, fmt::basic_printf_context<fmt::appender, ... (12 times, avg 218 ms)
  1434 ms: std::basic_regex<char>::_M_compile (4 times, avg 358 ms)
  1380 ms: std::__detail::_Compiler<std::regex_traits<char>>::_Compiler (4 times, avg 345 ms)
  1189 ms: std::__detail::_Compiler<std::regex_traits<char>>::_M_disjunction (4 times, avg 297 ms)
  1181 ms: std::__detail::_Compiler<std::regex_traits<char>>::_M_alternative (4 times, avg 295 ms)
  1162 ms: std::__detail::_Compiler<std::regex_traits<char>>::_M_term (4 times, avg 290 ms)
  1076 ms: std::basic_regex<char>::basic_regex (3 times, avg 358 ms)
   996 ms: std::__detail::_Compiler<std::regex_traits<char>>::_M_atom (4 times, avg 249 ms)
   891 ms: fmt::detail::vformat_to<char> (3 times, avg 297 ms)
   615 ms: std::unordered_map<int, int> (62 times, avg 9 ms)
   535 ms: fmt::detail::write<char, fmt::appender, float, 0> (18 times, avg 29 ms)
   490 ms: std::_Hashtable<int, std::pair<const int, int>, std::allocator<std::... (62 times, avg 7 ms)
   456 ms: fmt::detail::vformat_to(buffer<char> &, basic_string_view<char>, bas... (3 times, avg 152 ms)
   452 ms: std::_Rb_tree<lxTriGeomPoint, std::pair<const lxTriGeomPoint, unsign... (67 times, avg 6 ms)
   443 ms: std::_Rb_tree<lxTriGeomPoint, std::pair<const lxTriGeomPoint, unsign... (67 times, avg 6 ms)
   425 ms: std::unique_ptr<char[]> (41 times, avg 10 ms)
   412 ms: std::unique_ptr<thinput::ifile> (41 times, avg 10 ms)
   409 ms: fmt::detail::printf_arg_formatter<fmt::appender, char>::operator()<i... (12 times, avg 34 ms)
   385 ms: fmt::detail::printf_arg_formatter<fmt::appender, char>::operator()<f... (12 times, avg 32 ms)
   369 ms: fmt::format<char *&> (40 times, avg 9 ms)
   366 ms: std::_Rb_tree<unsigned long, std::pair<const unsigned long, thattr_a... (53 times, avg 6 ms)
   360 ms: __gnu_cxx::__to_xstring<std::basic_string<wchar_t>, wchar_t> (114 times, avg 3 ms)
   359 ms: std::basic_regex<char>::basic_regex<std::char_traits<char>, std::all... (1 times, avg 359 ms)
   358 ms: std::_Rb_tree<unsigned long, std::pair<const unsigned long, thattr_a... (53 times, avg 6 ms)
   352 ms: std::__uniq_ptr_data<char, std::default_delete<char[]>, true, true> (41 times, avg 8 ms)
   352 ms: std::__uniq_ptr_data<thinput::ifile, std::default_delete<thinput::if... (41 times, avg 8 ms)
   348 ms: std::__uniq_ptr_impl<char, std::default_delete<char[]>> (41 times, avg 8 ms)
   348 ms: std::basic_string<char16_t>::basic_string (114 times, avg 3 ms)
   348 ms: std::__uniq_ptr_impl<thinput::ifile, std::default_delete<thinput::if... (41 times, avg 8 ms)

**** Template sets that took longest to instantiate:
  5652 ms: std::list<$> (2215 times, avg 2 ms)
  4431 ms: std::map<$> (1279 times, avg 3 ms)
  4042 ms: std::_List_base<$> (2215 times, avg 1 ms)
  2865 ms: fmt::sprintf<$> (22 times, avg 130 ms)
  2725 ms: std::_Rb_tree<$> (1591 times, avg 1 ms)
  2668 ms: fmt::vsprintf<$> (12 times, avg 222 ms)
  2626 ms: fmt::detail::vprintf<$> (12 times, avg 218 ms)
  2322 ms: std::unique_ptr<$> (223 times, avg 10 ms)
  2075 ms: std::__and_<$> (2194 times, avg 0 ms)
  1959 ms: std::__uniq_ptr_data<$> (223 times, avg 8 ms)
  1938 ms: std::__uniq_ptr_impl<$> (223 times, avg 8 ms)
  1788 ms: std::vector<$> (1042 times, avg 1 ms)
  1674 ms: std::allocator<$> (2478 times, avg 0 ms)
  1529 ms: fmt::detail::write<$> (202 times, avg 7 ms)
  1453 ms: std::unordered_map<$> (155 times, avg 9 ms)
  1440 ms: std::_Rb_tree<$>::~_Rb_tree (248 times, avg 5 ms)
  1434 ms: std::basic_regex<$>::_M_compile (4 times, avg 358 ms)
  1415 ms: std::_Rb_tree<$>::_M_erase (251 times, avg 5 ms)
  1380 ms: std::__detail::_Compiler<$>::_Compiler (4 times, avg 345 ms)
  1336 ms: fmt::format<$> (172 times, avg 7 ms)
  1320 ms: std::_Hashtable<$> (217 times, avg 6 ms)
  1205 ms: std::pair<$> (596 times, avg 2 ms)
  1193 ms: std::basic_string<$> (456 times, avg 2 ms)
  1189 ms: std::__detail::_Compiler<$>::_M_disjunction (4 times, avg 297 ms)
  1181 ms: std::__detail::_Compiler<$>::_M_alternative (4 times, avg 295 ms)
  1162 ms: std::__detail::_Compiler<$>::_M_term (4 times, avg 290 ms)
  1133 ms: fmt::make_format_args<$> (207 times, avg 5 ms)
  1102 ms: ththrow<$> (400 times, avg 2 ms)
  1076 ms: std::basic_regex<$>::basic_regex (3 times, avg 358 ms)
  1059 ms: vtkAOSDataArrayTemplate<$> (91 times, avg 11 ms)

**** Functions that took longest to compile:
   338 ms: thsymbolset::export_pdf(thlayout*, _IO_FILE*, unsigned int&) (/home/afforix/Dropbox/Devel/C++/therion/thsymbolset.cxx)
    87 ms: lxFrame::lxFrame(lxApp*, wxString const&, wxPoint const&, wxSize con... (/home/afforix/Dropbox/Devel/C++/therion/loch/lxGUI.cxx)
    87 ms: build_pages() (/home/afforix/Dropbox/Devel/C++/therion/thpdf.cxx)
    63 ms: print_grid_pdf(std::basic_ofstream<char, std::char_traits<char> >&, ... (/home/afforix/Dropbox/Devel/C++/therion/thpdf.cxx)
    59 ms: thexpmap::export_pdf(thdb2dxm*, thdb2dprj*) (/home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx)
    57 ms: lxLRUD::Calculate() (/home/afforix/Dropbox/Devel/C++/therion/loch/lxLRUD.cxx)
    53 ms: distill_eps(std::__cxx11::basic_string<char, std::char_traits<char>,... (/home/afforix/Dropbox/Devel/C++/therion/thconvert.cxx)
    51 ms: lxModelSetupDlg::lxModelSetupDlg(wxWindow*) (/home/afforix/Dropbox/Devel/C++/therion/loch/lxSScene.cxx)
    51 ms: lxViewpointSetupDlg::lxViewpointSetupDlg(wxWindow*) (/home/afforix/Dropbox/Devel/C++/therion/loch/lxSView.cxx)
    48 ms: print_map(int, std::basic_ofstream<char, std::char_traits<char> >&, ... (/home/afforix/Dropbox/Devel/C++/therion/thpdf.cxx)
    46 ms: thsvg(char const*, int, legenddata const&) (/home/afforix/Dropbox/Devel/C++/therion/thsvg.cxx)
    44 ms: thgraphics2pdf() (/home/afforix/Dropbox/Devel/C++/therion/thepsparse.cxx)
    40 ms: __cxx_global_var_init.1 (/home/afforix/Dropbox/Devel/C++/therion/loch/lxSView.cxx)
    39 ms: Catch::makeCommandLineParser(Catch::ConfigData&) (/home/afforix/Dropbox/Devel/C++/therion/utest-main.cxx)
    37 ms: thexpmap::export_mp(thexpmapmpxs*, thscrap*, unsigned int&, bool) (/home/afforix/Dropbox/Devel/C++/therion/thexpmap.cxx)
    36 ms: thwarplin::morph(thsketch*, double) (/home/afforix/Dropbox/Devel/C++/therion/thwarp.cxx)
    36 ms: parse_eps(std::__cxx11::basic_string<char, std::char_traits<char>, s... (/home/afforix/Dropbox/Devel/C++/therion/thepsparse.cxx)
    36 ms: thdb1d::scan_data() (/home/afforix/Dropbox/Devel/C++/therion/thdb1d.cxx)
    35 ms: convert_scraps() (/home/afforix/Dropbox/Devel/C++/therion/thconvert.cxx)
    33 ms: print_navigator(std::basic_ofstream<char, std::char_traits<char> >&,... (/home/afforix/Dropbox/Devel/C++/therion/thpdf.cxx)
    28 ms: utf2tex(std::__cxx11::basic_string<char, std::char_traits<char>, std... (/home/afforix/Dropbox/Devel/C++/therion/thtexfonts.cxx)
    28 ms: __cxx_global_var_init.4 (/home/afforix/Dropbox/Devel/C++/therion/loch/lxSScene.cxx)
    26 ms: thpoint::export_mp(thexpmapmpxs*) (/home/afforix/Dropbox/Devel/C++/therion/thpoint.cxx)
    26 ms: lxData::Rebuild() (/home/afforix/Dropbox/Devel/C++/therion/loch/lxData.cxx)
    25 ms: lxRenderDataConfig::lxRenderDataConfig(wxWindow*, lxRenderData*, lxG... (/home/afforix/Dropbox/Devel/C++/therion/loch/lxRender.cxx)
    24 ms: lxOptionsDlg::lxOptionsDlg(wxWindow*) (/home/afforix/Dropbox/Devel/C++/therion/loch/lxOptDlg.cxx)
    23 ms: compose_page(std::_List_iterator<sheetrecord>, std::basic_ofstream<c... (/home/afforix/Dropbox/Devel/C++/therion/thpdf.cxx)
    22 ms: thexpdb::export_sql_file(thdatabase*) (/home/afforix/Dropbox/Devel/C++/therion/thexpdb.cxx)
    22 ms: thexpmodel::export_lox_file(thdatabase*) (/home/afforix/Dropbox/Devel/C++/therion/thexpmodel.cxx)
    21 ms: __cxx_global_var_init.4 (/home/afforix/Dropbox/Devel/C++/therion/loch/lxGUI.cxx)

**** Function sets that took longest to compile / optimize:
   158 ms: fmt::v9::appender fmt::v9::detail::write_int_noinline<$>(fmt::v9::ap... (45 times, avg 3 ms)
   127 ms: void fmt::v9::detail::convert_arg<$>(fmt::v9::basic_format_arg<$>&, ... (72 times, avg 1 ms)
   124 ms: void fmt::v9::detail::vprintf<$>(fmt::v9::detail::buffer<$>&, fmt::v... (12 times, avg 10 ms)
    93 ms: fmt::v9::detail::format_dragon(fmt::v9::detail::basic_fp<$>, unsigne... (15 times, avg 6 ms)
    72 ms: void std::_Rb_tree<$>::_M_construct_node<$>(std::_Rb_tree_node<$>*, ... (63 times, avg 1 ms)
    68 ms: std::_Rb_tree_iterator<$> std::_Rb_tree<$>::_M_emplace_hint_unique<$... (63 times, avg 1 ms)
    64 ms: std::vector<$>::vector(std::vector<$> const&) (61 times, avg 1 ms)
    63 ms: print_grid_pdf(std::basic_ofstream<$>&, double, double, double, doub... (1 times, avg 63 ms)
    53 ms: distill_eps(std::__cxx11::basic_string<$>, std::__cxx11::basic_strin... (1 times, avg 53 ms)
    51 ms: fmt::v9::appender fmt::v9::detail::write_padded<$>(fmt::v9::appender... (60 times, avg 0 ms)
    50 ms: fmt::v9::appender fmt::v9::detail::write<$>(fmt::v9::appender, long ... (15 times, avg 3 ms)
    50 ms: std::_Rb_tree<$>::_M_insert_node(std::_Rb_tree_node_base*, std::_Rb_... (74 times, avg 0 ms)
    49 ms: fmt::v9::appender fmt::v9::detail::write_padded<$>(fmt::v9::appender... (60 times, avg 0 ms)
    48 ms: fmt::v9::appender fmt::v9::detail::write_padded<$>(fmt::v9::appender... (60 times, avg 0 ms)
    48 ms: print_map(int, std::basic_ofstream<$>&, std::_List_iterator<$>) (1 times, avg 48 ms)
    46 ms: fmt::v9::appender fmt::v9::detail::do_write_float<$>(fmt::v9::append... (15 times, avg 3 ms)
    42 ms: fmt::v9::appender fmt::v9::detail::write<$>(fmt::v9::appender, float... (15 times, avg 2 ms)
    41 ms: fmt::v9::appender fmt::v9::detail::write_codepoint<$>(fmt::v9::appen... (51 times, avg 0 ms)
    41 ms: fmt::v9::format_arg_store<$> fmt::v9::make_format_args<$>(char*&) (42 times, avg 0 ms)
    41 ms: int fmt::v9::detail::format_float<$>(double, int, fmt::v9::detail::f... (15 times, avg 2 ms)
    40 ms: fmt::v9::appender fmt::v9::detail::format_uint<$>(fmt::v9::appender,... (45 times, avg 0 ms)
    39 ms: fmt::v9::detail::counting_iterator fmt::v9::detail::write_codepoint<... (51 times, avg 0 ms)
    38 ms: fmt::v9::appender fmt::v9::detail::write<$>(fmt::v9::appender, doubl... (15 times, avg 2 ms)
    36 ms: parse_eps(std::__cxx11::basic_string<$>, std::__cxx11::basic_string<... (1 times, avg 36 ms)
    36 ms: std::vector<$>::~vector() (65 times, avg 0 ms)
    35 ms: std::__cxx11::_List_base<$>::_M_clear() (64 times, avg 0 ms)
    35 ms: std::vector<$>::_M_check_len(unsigned long, char const*) const (63 times, avg 0 ms)
    34 ms: char* fmt::v9::detail::format_uint<$>(char*, unsigned __int128, int,... (45 times, avg 0 ms)
    34 ms: void std::__cxx11::basic_string<$>::_M_construct<$>(char const*, cha... (34 times, avg 1 ms)
    34 ms: int fmt::v9::detail::parse_header<$>(char const*&, char const*, fmt:... (12 times, avg 2 ms)

**** Expensive headers:
11613 ms: /home/afforix/Dropbox/Devel/C++/therion/thdatabase.h (included 50 times, avg 232 ms), included via:
  thdatabase.cxx.o  (699 ms)
  thlibrarydata.cxx  (673 ms)
  thperson.cxx.o  (649 ms)
  thpic.cxx.o  (461 ms)
  thdb2dji.cxx.o  (443 ms)
  thobjectname.cxx.o  (436 ms)
  ...

9985 ms: /home/afforix/Dropbox/Devel/C++/therion/thparse.h (included 82 times, avg 121 ms), included via:
  thdatastation.cxx.o thdatastation.h thdataobject.h  (245 ms)
  thsurvey.cxx.o thsurvey.h thdataobject.h  (237 ms)
  thdb2dprj.cxx.o thdb2dprj.h  (236 ms)
  thdataobject.cxx.o thdataobject.h  (231 ms)
  thlang.cxx.o thlang.h  (226 ms)
  thexpsys.cxx.o thexpsys.h thexport.h  (225 ms)
  ...

9100 ms: /home/afforix/Dropbox/Devel/C++/therion/thexception.h (included 59 times, avg 154 ms), included via:
  thexpmap.cxx.o  (417 ms)
  thexpuni.cxx.o  (411 ms)
  thexptable.cxx.o  (409 ms)
  thselector.cxx.o  (405 ms)
  thexpshp.cxx.o  (394 ms)
  thexpdb.cxx.o  (353 ms)
  ...

8890 ms: /home/afforix/Dropbox/Devel/C++/therion/thdataobject.h (included 55 times, avg 161 ms), included via:
  thdatastation.cxx.o thdatastation.h  (383 ms)
  thsurvey.cxx.o thsurvey.h  (364 ms)
  thdataobject.cxx.o  (362 ms)
  thscrap.cxx.o thscrap.h  (353 ms)
  th2ddataobject.cxx.o th2ddataobject.h  (344 ms)
  thlayout.cxx.o thlayout.h  (331 ms)
  ...

8705 ms: /home/afforix/Dropbox/Devel/C++/therion/thexport.h (included 39 times, avg 223 ms), included via:
  thexpsys.cxx.o thexpsys.h  (479 ms)
  thexptable.cxx.o thexptable.h  (471 ms)
  thexpshp.cxx.o thexpmap.h  (469 ms)
  thexporter.cxx.o thexporter.h  (467 ms)
  thexpdb.cxx.o thexpdb.h  (456 ms)
  thexpuni.cxx.o thexpmap.h  (453 ms)
  ...

8239 ms: /home/afforix/Dropbox/Devel/C++/therion/thdb1d.h (included 50 times, avg 164 ms), included via:
  thscraplp.cxx.o thscraplp.h  (454 ms)
  thdb1d.cxx.o  (447 ms)
  thdatabase.cxx.o thdatabase.h  (333 ms)
  thperson.cxx.o thdatabase.h  (285 ms)
  thlibrarydata.cxx thdatabase.h  (278 ms)
  thwarp.cxx.o  (270 ms)
  ...

7686 ms: /home/afforix/Dropbox/Devel/C++/therion/thconfig.h (included 31 times, avg 247 ms), included via:
  thcmdline.cxx.o  (656 ms)
  thconfig.cxx.o  (654 ms)
  therion-main.cxx.o  (647 ms)
  therion.cxx.o  (470 ms)
  thlookup.cxx.o  (292 ms)
  thmapstat.cxx.o  (290 ms)
  ...

6804 ms: /usr/include/c++/13.1.1/bits/basic_string.h (included 114 times, avg 59 ms), included via:
  thsurface.h thdataobject.h thparse.h string  (94 ms)
  thwarpp.h thwarp.h thpic.h string  (72 ms)
  thpic.h string  (70 ms)
  thlang.h thparse.h string  (69 ms)
  thinit.h string  (68 ms)
  thexception.h stdexcept string  (68 ms)
  ...

6114 ms: /home/afforix/Dropbox/Devel/C++/therion/thlayoutclr.h (included 63 times, avg 97 ms), included via:
  thsymbolset.cxx.o thsymbolset.h  (306 ms)
  thlayoutclr.cxx.o  (301 ms)
  thlayoutln.cxx.o thlayoutln.h  (212 ms)
  thselector.cxx.o thselector.h  (203 ms)
  thexporter.cxx.o thexporter.h thexport.h thlayout.h thdataobject.h  (127 ms)
  thexpuni.cxx.o thexpmap.h thexport.h thlayout.h thdataobject.h  (125 ms)
  ...

5963 ms: /home/afforix/Dropbox/Devel/C++/therion/thinput.h (included 41 times, avg 145 ms), included via:
  thdatareader.cxx.o thdatareader.h  (397 ms)
  thinput.cxx.o  (395 ms)
  thcmdline.cxx.o thconfig.h  (308 ms)
  thconfig.cxx.o thconfig.h  (297 ms)
  therion-main.cxx.o thconfig.h  (294 ms)
  thtmpdir.cxx.o thinit.h  (210 ms)
  ...

  done in 0.0s.
```