### PR TITLE
Coverity fixes

### DIFF
--- a/loch/lxOGLFT.cxx
+++ b/loch/lxOGLFT.cxx
@@ -1567,7 +1567,7 @@ namespace OGLFT {
       rotation_offset.x /= 1024;
       rotation_offset.y /= 1024;
 
-      error = FT_Glyph_Transform( glyph, &rotation_matrix, &rotation_offset );
+      FT_Glyph_Transform( glyph, &rotation_matrix, &rotation_offset );
     }
 
     error = FT_Glyph_To_Bitmap( &glyph, FT_RENDER_MODE_MONO, 0, 1 );
@@ -1674,7 +1674,7 @@ namespace OGLFT {
       rotation_offset.x /= 1024;
       rotation_offset.y /= 1024;
 
-      error = FT_Glyph_Transform( glyph, &rotation_matrix, &rotation_offset );
+      FT_Glyph_Transform( glyph, &rotation_matrix, &rotation_offset );
     }
 
     error = FT_Glyph_To_Bitmap( &glyph, FT_RENDER_MODE_NORMAL, 0, 1 );
@@ -1814,7 +1814,7 @@ namespace OGLFT {
       rotation_offset.x /= 1024;
       rotation_offset.y /= 1024;
 
-      error = FT_Glyph_Transform( glyph, &rotation_matrix, &rotation_offset );
+      FT_Glyph_Transform( glyph, &rotation_matrix, &rotation_offset );
     }
 
     error = FT_Glyph_To_Bitmap( &glyph, FT_RENDER_MODE_NORMAL, 0, 1 );

--- a/thattr.cxx
+++ b/thattr.cxx
@@ -523,7 +523,6 @@ void thattr::export_txt(const char * fname, int /*encoding*/) // TODO unused par
   FILE * f;
   unsigned i;
   thattr_attr * ca;
-  thattr_field * cf;
   thattr_obj_list::iterator oi;
   thattr_id2attr_map::iterator ai;
   thattr_field_list::iterator fli;
@@ -540,7 +539,6 @@ void thattr::export_txt(const char * fname, int /*encoding*/) // TODO unused par
   // Create fields.
   bool hasone = false;
   for(fli = this->m_field_list.begin(); fli != this->m_field_list.end(); ++fli) {
-    cf = &(*fli);
     fprintf(f,"%s%s",hasone ? "\t" : "",fli->m_name.c_str());
     hasone = true;
   }
@@ -551,8 +549,7 @@ void thattr::export_txt(const char * fname, int /*encoding*/) // TODO unused par
   for(oi = this->m_obj_list.begin(); oi != this->m_obj_list.end(); ++oi) {
     hasone = false;    
     for(fli = this->m_field_list.begin(); fli != this->m_field_list.end(); ++fli) {
-      cf = &(*fli);
-      ai = oi->m_attributes.find(cf->m_id);
+      ai = oi->m_attributes.find(fli->m_id);
       if (ai == oi->m_attributes.end()) {
         value = "";
       } else {

--- a/thconvert.cxx
+++ b/thconvert.cxx
@@ -95,10 +95,8 @@ std::string process_pdf_string(std::string s, std::string font) {
   unsigned char c;
   char *err;
   unsigned j;
-  std::map<std::string,FONTCHARS>::iterator I; 
 
-  I = USED_CHARS.find(font);
-  if (I == USED_CHARS.end()) std::cerr << "This can't happen!";
+  auto& I = USED_CHARS.at(font); // must be there
   s = s.substr(1,s.length()-3);  // delete surrounding parentheses and final space
   for (unsigned i=0; i<s.size(); i++) {
     c = s[i];
@@ -128,8 +126,8 @@ std::string process_pdf_string(std::string s, std::string font) {
   t = "";
   for (unsigned i=0; i<r.size(); i++) {
     c = r[i];
-    if (((*I).second).find(c) == ((*I).second).end()) {
-      ((*I).second).insert(c);
+    if (I.find(c) == I.end()) {
+      I.insert(c);
     }
     t += fmt::format("{:02x}",c);
   }

--- a/thconvert.cxx
+++ b/thconvert.cxx
@@ -126,9 +126,7 @@ std::string process_pdf_string(std::string s, std::string font) {
   t = "";
   for (unsigned i=0; i<r.size(); i++) {
     c = r[i];
-    if (I.find(c) == I.end()) {
-      I.insert(c);
-    }
+    I.insert(c);
     t += fmt::format("{:02x}",c);
   }
   return "<" + t + ">";

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -283,7 +283,7 @@ void thdb1d::scan_data()
                     else
                   	  gradient_sd = lei->gradient_sd;
                     if (abs(lei->backgradient - lei->gradient) > (3.0 * gradient_sd))
-                    	thwarning(("%s [%d] -- forwards and backwards gradient readings do not match", lei->srcf.name, lei->srcf.line));
+                    	thwarning(("%s [%lu] -- forwards and backwards gradient readings do not match", lei->srcf.name, lei->srcf.line));
                     lei->gradient += lei->backgradient;
                     lei->gradient = lei->gradient / 2.0;
                   }

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -420,13 +420,13 @@ char * thinput::read_line()
           
         case TT_ENCODING:
           if (this->tmpmb.get_size() != 1)
-            therror(("%s [%d] -- encoding name expected -- %s", \
+            therror(("%s [%lu] -- encoding name expected -- %s", \
               this->get_cif_name(), this->get_cif_line_number(), \
               this->valuebf.get_buffer()));
           this->last_ptr->encoding = \
             thmatch_token(*(this->tmpmb.get_buffer()), thtt_encoding);
           if (this->last_ptr->encoding == TT_UNKNOWN_ENCODING) {
-            therror(("%s [%d] -- unknown encoding -- %s", \
+            therror(("%s [%lu] -- unknown encoding -- %s", \
               this->get_cif_name(), this->get_cif_line_number(), \
               this->valuebf.get_buffer()));
             this->last_ptr->encoding = TT_UTF_8;


### PR DESCRIPTION
Fixed warnings reported by Coverity:

* unused values in `loch/lxOGLFT.cxx` and `thattr.cxx`
* invalid iterator in `thconvert.cxx`
* printf argument type in `thdb1d.cxx` and `thinput.cxx`