### PR TITLE
Fix throw outside of catch

### DIFF
--- a/thwarppt.cxx
+++ b/thwarppt.cxx
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "thexception.h"
 #include "thwarppt.h"
 
 #ifndef M_PI
@@ -106,7 +107,7 @@ therion::warp::plaquette_algo::insert_line(
     if ( mPairs[i]->m_name == from ) { p1 = mPairs[i]; if (p2) break; }
     if ( mPairs[i]->m_name == to   ) { p2 = mPairs[i]; if (p1) break; }
   }
-  if ( p1 == NULL || p2 == NULL ) throw;
+  if ( p1 == NULL || p2 == NULL ) ththrow("plaquette algorithm error");
   mLines.push_back( new therion::warp::line( t, p1, p2 ) );
 }
 


### PR DESCRIPTION
There is a `throw;` command outside of a `catch` block. Calling `throw;` without an active exception terminates the program, so I have changed it to `ththrow`. This issue was reported by `Cppcheck` and `SonarCloud`.