### PR TITLE
Do not use C-casts to construct std::string

### DIFF
--- a/thconvert.cxx
+++ b/thconvert.cxx
@@ -48,7 +48,7 @@
 
 // extern list<scraprecord> SCRAPLIST;
 
-#define IOerr(F) ((std::string)"Can't open file "+F+"!\n").c_str()
+#define IOerr(F) fmt::format("Can't open file {}!\n", (F)).c_str()
 
 std::map<std::string,std::string> ALL_FONTS, ALL_PATTERNS;
 typedef std::set<unsigned char> FONTCHARS;

--- a/thepsparse.cxx
+++ b/thepsparse.cxx
@@ -50,7 +50,7 @@
 #include "therion.h"
 #include "thdouble.h"
 
-#define IOerr(F) ((std::string)"Can't open file "+F+"!\n").c_str()
+#define IOerr(F) fmt::format("Can't open file {}!\n", (F)).c_str()
 
 extern std::map<std::string,std::string> ALL_FONTS, ALL_PATTERNS;
 typedef std::set<unsigned char> FONTCHARS;

--- a/thpdf.cxx
+++ b/thpdf.cxx
@@ -55,7 +55,7 @@
 #include "thchenc.h"
 #include "thbuffer.h"
 
-#define IOerr(F) ((std::string)"Can't open file "+F+"!\n").c_str()
+#define IOerr(F) fmt::format("Can't open file {}!\n", (F)).c_str()
 
 
 
@@ -996,7 +996,7 @@ void print_map(int layer, std::ofstream& PAGEDEF,
       if (used_scraps.count(K->name) > 0) {
         for (std::list<surfpictrecord>::iterator I_sk = K->SKETCHLIST.begin();
                                             I_sk != K->SKETCHLIST.end(); I_sk++) {
-          PAGEDEF << "\\pdfximage{" << (std::string) I_sk->filename << "}%" << std::endl;
+          PAGEDEF << "\\pdfximage{" << I_sk->filename << "}%" << std::endl;
           PAGEDEF << "\\bitmap{" <<
               fmt::format("{}",thdouble(I_sk->xx,prec_matrix)) << "}{" << fmt::format("{}",thdouble(I_sk->yx,prec_matrix)) << "}{" <<
               fmt::format("{}",thdouble(I_sk->xy,prec_matrix)) << "}{" << fmt::format("{}",thdouble(I_sk->yy,prec_matrix)) << "}{" <<
@@ -1480,7 +1480,7 @@ R"(\pdfcompresslevel=9%
   int i = 1;
   for (std::list<surfpictrecord>::iterator I = SURFPICTLIST.begin();
                                       I != SURFPICTLIST.end(); I++) {
-    PAGEDEF << "\\pdfximage{" << (std::string) I->filename << "}%" << std::endl;
+    PAGEDEF << "\\pdfximage{" << I->filename << "}%" << std::endl;
     PAGEDEF << "\\newcount\\" << tex_BMPname(u2str(i)) << "\\" <<
                tex_BMPname(u2str(i)) << "=\\pdflastximage%" << std::endl;
     i++;

--- a/thproj.cxx
+++ b/thproj.cxx
@@ -358,8 +358,7 @@ proj_cache cache;
           for (int j = 0; j < proj_coordoperation_get_grid_used_count(PJ_DEFAULT_CTX, P_tmp); j++) {
             proj_coordoperation_get_grid_used(PJ_DEFAULT_CTX, P_tmp, j,
                 &short_name, nullptr, nullptr, &url, nullptr, nullptr, nullptr);
-            std::string s_tmp = (std::string) "missing PROJ transformation grid '" + short_name + "'; you can download it from " +
-                          url + " and install it to a location where PROJ finds it";
+            std::string s_tmp = fmt::format("missing PROJ transformation grid '{}'; you can download it from {} and install it to a location where PROJ finds it", short_name, url);
             switch (thcs_cfg.proj_auto_grid) {
               case GRID_WARN:
                 thwarning((s_tmp.c_str()));
@@ -451,7 +450,7 @@ proj_cache cache;
 // set CA bundle path; supported since proj 7.2.0
 #ifdef THWIN32
 #if PROJ_VER >= 8
-    std::string ca_path = (std::string) thcfg.install_path.get_buffer() + "\\lib\\cacert.pem";
+    std::string ca_path = fmt::format("{}\\lib\\cacert.pem", thcfg.install_path.get_buffer());
     proj_context_set_ca_bundle_path(PJ_DEFAULT_CTX, ca_path.c_str());
 #endif
 #endif
@@ -575,10 +574,9 @@ void thcs_log_transf_used() {
 std::string thcs_get_label([[maybe_unused]] std::string s) {
 #if PROJ_VER >= 6
     PJ* P;
-    std::string res;
     th_init_proj(P, sanitize_crs(s));
     PJ_PROJ_INFO pinfo = proj_pj_info(P);
-    res = (std::string) pinfo.description;
+    const std::string res(pinfo.description);
     proj_destroy(P);
     return res;
 #else

--- a/thsvg.cxx
+++ b/thsvg.cxx
@@ -128,7 +128,7 @@ void base64_encode(const char * fname, std::ofstream & fout) {
   unsigned char out_buffer[4];
 
   std::ifstream fin(fname, std::ios::binary);
-  if (!fin) therror((((std::string)"Can't read file "+fname+"!\n").c_str()));
+  if (!fin) therror((fmt::format("Can't read file {}!\n", fname).c_str()));
 
   do {
       for (int i = 0; i < 3; i++) in_buffer[i] = '\x0';

--- a/thtexfonts.cxx
+++ b/thtexfonts.cxx
@@ -380,19 +380,19 @@ std::string utf2tex(std::string str, bool remove_kerning) {
   std::string::const_iterator it = str.cbegin(), end = str.cend();
   for (std::smatch match; std::regex_search(it, end, match, reg_fontsize); it = match[0].second) {
     if (match.str(1) == "xs")
-      out += (std::string) match.prefix() + "\x1B\xE" + (char) 101;
+      out += match.prefix().str() + "\x1B\xE" + (char) 101;
     else if (match.str(1) == "s")
-      out += (std::string) match.prefix() + "\x1B\xE" + (char) 102;
+      out += match.prefix().str() + "\x1B\xE" + (char) 102;
     else if (match.str(1) == "m")
-      out += (std::string) match.prefix() + "\x1B\xE" + (char) 103;
+      out += match.prefix().str() + "\x1B\xE" + (char) 103;
     else if (match.str(1) == "l")
-      out += (std::string) match.prefix() + "\x1B\xE" + (char) 104;
+      out += match.prefix().str() + "\x1B\xE" + (char) 104;
     else if (match.str(1) == "xl")
-      out += (std::string) match.prefix() + "\x1B\xE" + (char) 105;
+      out += match.prefix().str() + "\x1B\xE" + (char) 105;
     else if (match.str(3) == "%")  // font size in percents; 10 % increments to fit the values into <1,100> range
-      out += (std::string) match.prefix() + "\x1B\xE" + (char) (std::max((int) std::round(std::stod(match.str(2)) / 10), 1));
+      out += match.prefix().str() + "\x1B\xE" + (char) (std::max((int) std::round(std::stod(match.str(2)) / 10), 1));
     else if (match.str(1) == match.str(2))   // font size in points; limited to <1,127>
-      out += (std::string) match.prefix() + "\x1B\xD" + (char) (std::min(std::max(std::stoi(match.str(2)),1),127));
+      out += match.prefix().str() + "\x1B\xD" + (char) (std::min(std::max(std::stoi(match.str(2)),1),127));
     else therror(("invalid font size specification"));
   }
   out.append(it, end);


### PR DESCRIPTION
C-casts should not be used to construct `std::string`, there are cleaner ways, for example constructors, explicit conversions or `fmt::format()`.