### PR TITLE
Remove macOS 11 CI job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
     steps:
       - uses: actions/checkout@v3
       - name: install dependencies


### PR DESCRIPTION
Homebrew no longer provide binary packages of some libraries, resulting in hours long builds from source. We need to remove macOS 11 from our CI.