### PR TITLE
New area symbol underwater ceiling

### DIFF
--- a/mpost/thArea.mp
+++ b/mpost/thArea.mp
@@ -29,9 +29,13 @@ if unknown a_water_UIS: else: endinput fi;
 % patterns
 
 beginpattern(pattern_water_UIS);
-    draw origin--10up withpen pensquare scaled (0.02u);
-    patternxstep(.18u);
-    patterntransform(identity rotated 45);
+	dim := 0.16u;
+	z1 = origin;
+	z2 = dim*up + 3dim*right;
+	z3 = 8dim*right;
+	draw z1{right}..z2..{right}z3 withcolor black withpen PenA scaled (0.018u);
+	patternbbox(0.1dim * down, 8dim * right + 1.1dim*up);
+	patterntransform(identity rotated -45);
 endpattern;
 
 beginpattern(pattern_sump_UIS);

--- a/mpost/thTrans.mp
+++ b/mpost/thTrans.mp
@@ -199,6 +199,7 @@ let a_pillarwithcurtains = a_pillarwithcurtains_SBE;
 let a_stalactite = a_stalactite_SBE;
 let a_stalactitestalagmite = a_stalactitestalagmite_SBE;
 let a_stalagmite = a_stalagmite_SBE;
+let a_underwaterceiling = a_underwaterceiling_SBE;
 
 let s_northarrow = s_northarrow_SKBB;
 let s_scalebar = s_scalebar_SKBB;

--- a/mpost/uSBE.mp
+++ b/mpost/uSBE.mp
@@ -1308,13 +1308,9 @@ def a_stalagmite_SBE(expr P) =
 enddef;
 
 beginpattern(pattern_underwaterceiling_SBE);
-	dim := 0.16u;
-	z1 = origin;
-	z2 = dim*up + 3dim*right;
-	z3 = 8dim*right;
-	draw z1{right}..z2..{right}z3 withcolor black withpen PenA scaled (0.018u);
-	patternbbox(0.1dim * down, 8dim * right + 1.1dim*up);
-	patterntransform(identity rotated -45);
+    draw origin--10up withpen pensquare scaled (0.02u);
+    patternxstep(.18u);
+    patterntransform(identity rotated 45);
 endpattern;
 
 def a_underwaterceiling_SBE (expr Path) =

--- a/mpost/uSBE.mp
+++ b/mpost/uSBE.mp
@@ -1306,3 +1306,19 @@ def a_stalagmite_SBE(expr P) =
 	pickup PenA;
 	thfill P withcolor (1, 0.6, 0);
 enddef;
+
+beginpattern(pattern_underwaterceiling_SBE);
+	dim := 0.16u;
+	z1 = origin;
+	z2 = dim*up + 3dim*right;
+	z3 = 8dim*right;
+	draw z1{right}..z2..{right}z3 withcolor black withpen PenA scaled (0.018u);
+	patternbbox(0.1dim * down, 8dim * right + 1.1dim*up);
+	patterntransform(identity rotated -45);
+endpattern;
+
+def a_underwaterceiling_SBE (expr Path) =
+	T:=identity;
+	thclean Path;
+	thfill Path withpattern pattern_underwaterceiling_SBE;
+enddef;

--- a/tharea.cxx
+++ b/tharea.cxx
@@ -211,6 +211,7 @@ bool tharea::export_mp(class thexpmapmpxs * out)
     tharea_type_export_mp(TT_AREA_TYPE_STALACTITE, SYMA_STALACTITE)
     tharea_type_export_mp(TT_AREA_TYPE_STALACTITESTALAGMITE, SYMA_STALACTITESTALAGMITE)
     tharea_type_export_mp(TT_AREA_TYPE_STALAGMITE, SYMA_STALAGMITE)
+    tharea_type_export_mp(TT_AREA_TYPE_UNDERWATERCEILING, SYMA_UNDERWATERCEILING)
   }
   omacroid = macroid;
   if (this->context >= 0)

--- a/tharea.h
+++ b/tharea.h
@@ -80,6 +80,7 @@ enum {
   TT_AREA_TYPE_STALACTITE,
   TT_AREA_TYPE_STALACTITESTALAGMITE,
   TT_AREA_TYPE_STALAGMITE,
+  TT_AREA_TYPE_UNDERWATERCEILING,
 };
 
 
@@ -107,6 +108,7 @@ static const thstok thtt_area_types[] = {
   {"stalagmite", TT_AREA_TYPE_STALAGMITE},
   {"sump", TT_AREA_TYPE_SUMP},
   {"u",TT_AREA_TYPE_U},
+  {"underwater-ceiling", TT_AREA_TYPE_UNDERWATERCEILING},
   {"water", TT_AREA_TYPE_WATER},
   {NULL, TT_AREA_TYPE_UNKNOWN},
 };

--- a/thbook/ch02.tex
+++ b/thbook/ch02.tex
@@ -1218,7 +1218,8 @@ by each separate line.
     |pillars-with-curtains|,
     |stalactite|,
     |stalactite-stalagmite|,
-    |stalagmite|.
+    |stalagmite|,
+    |underwater-ceiling|.
 \endarguments
 
 \comopt

--- a/thlang/texts.txt
+++ b/thlang/texts.txt
@@ -2067,6 +2067,9 @@ sl: stalagmit
 sq: stalagmit
 zh_CN: 石笋
 
+therion: area underwater-ceiling
+pt: área submersa
+
 therion: area blocks
 bg: блокаж
 ca: blocs
@@ -3341,7 +3344,6 @@ rs: veštački zid
 ru: каменная кладка
 sl: zidarstvo
 
-
 therion: point minus
 de: Minus
 en: minus
@@ -3899,8 +3901,8 @@ fr: Profondeur
 it: Profondità
 pt: Profundidade
 rs: Dubina
-sl: Globina
 ru: Шкала глубин
+sl: Globina
 
 therion: title color-legend-map
 bg: Карти
@@ -3931,8 +3933,8 @@ fr: Scraps
 it: Scrap
 pt: Croquis
 rs: Delovi nacrta
-sl: Izrez
 ru: Скрапы
+sl: Izrez
 
 therion: title color-legend-survey
 ca: Topos
@@ -3943,8 +3945,8 @@ fr: Relevés
 it: Rilievi
 pt: Topos
 rs: Topografska merenja
-sl: Meritve
 ru: Съёмки
+sl: Meritve
 
 therion: title color-legend-explodate
 ca: Data d'exploració
@@ -3955,8 +3957,8 @@ fr: Date d'exploration
 it: Date di esplorazione
 pt: Data da exploração
 rs: Datum istraživanja
-sl: Datum raziskovanja
 ru: Дата первопрохождения
+sl: Datum raziskovanja
 
 therion: title color-legend-topodate
 ca: Data de topografia
@@ -3967,8 +3969,8 @@ fr: Date de relevé
 it: Date di rilievo
 pt: Data da topo
 rs: Datum merenja
-sl: Datum merjenja
 ru: Дата топосъёмки
+sl: Datum merjenja
 
 therion: title color-legend-default
 ca: Llegenda de colors
@@ -3981,8 +3983,8 @@ fr: Légende colorée
 it: Legenda dei colori
 pt: Cores
 rs: Tumač boja
-sl: Legenda barv
 ru: Цветовая шкала
+sl: Legenda barv
 
 therion: units ft
 bg: футове
@@ -4012,7 +4014,7 @@ de: Gesamtlänge
 el: Μήκος
 en: Length
 es: Desarrollo
-fr: Longueur 
+fr: Longueur
 it: Sviluppo
 mi: Roa a ana
 pl: długość
@@ -4052,7 +4054,7 @@ de: Niveaudifferenz
 el: Βάθος
 en: Depth
 es: Desnivel
-fr: Dénivellation 
+fr: Dénivellation
 it: Profondità
 mi: Hōhonu a ana, Rētōtanga
 pl: przewyższenie
@@ -4072,7 +4074,7 @@ de: Entdeckung
 el: Εξερευνητές
 en: Explored by
 es: Exploración
-fr: Explorateurs 
+fr: Explorateurs
 it: Esplorazione
 mi: Kaipokai whenua
 pl: odkryli
@@ -4092,7 +4094,7 @@ de: Entdeckung
 el: Εξερευνητής
 en: Explored by
 es: Exploración
-fr: Explorateur 
+fr: Explorateur
 it: Esplorazione
 mi: Kaipokai whenua
 pl: odkrył
@@ -4112,7 +4114,7 @@ de: Vermessung
 el: Χαρτογραφήθηκε από τους
 en: Surveyed by
 es: Topografiado por
-fr: Topographes 
+fr: Topographes
 it: Topografia
 mi: Kairūri
 pl: pomierzyli
@@ -4132,7 +4134,7 @@ de: Vermessung
 el: Χαρτογραφήθηκε από τον
 en: Surveyed by
 es: Topografiado por
-fr: Topographe 
+fr: Topographe
 it: Topografia
 mi: Kairūri
 pl: mierzył
@@ -4152,7 +4154,7 @@ de: Zeichnung
 el: Σκαρίφημα
 en: Drawn by
 es: Dibujado por
-fr: Dessinateurs 
+fr: Dessinateurs
 it: Cartografia
 mi: Kaituhi
 pl: rysowali
@@ -4172,7 +4174,7 @@ de: Zeichnung
 el: Σκαρίφημα
 en: Drawn by
 es: Dibujado por
-fr: Dessinateur 
+fr: Dessinateur
 it: Cartografia
 mi: Kaituhi
 pl: rysował
@@ -4243,3 +4245,4 @@ sk: [Povrchová mapa]
 sl: Slika površja
 sq: harta e siperfaqes
 zh_CN: 外观图
+

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -260,6 +260,7 @@ int thsymbolset_get_id(const char * symclass, const char * symbol)
         c2(TT_AREA_TYPE_STALACTITESTALAGMITE, SYMA_STALACTITESTALAGMITE);
         c2(TT_AREA_TYPE_STALAGMITE, SYMA_STALAGMITE);
         c2(TT_AREA_TYPE_U, SYMA_U);
+        c2(TT_AREA_TYPE_UNDERWATERCEILING, SYMA_UNDERWATERCEILING);
       }
       break;
     case TT_SYMBOL_LINE:
@@ -1382,6 +1383,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
   legend_area(SYMA_STALACTITE,thT("area stalactite",layout->lang));
   legend_area(SYMA_STALACTITESTALAGMITE,thT("area stalactite-stalagmite",layout->lang));
   legend_area(SYMA_STALAGMITE,thT("area stalagmite",layout->lang));
+  legend_area(SYMA_UNDERWATERCEILING,thT("area underwater-ceiling",layout->lang));
   legend_nocliparea(SYMA_BLOCKS,thT("area blocks",layout->lang));
   legend_nocliparea(SYMA_BEDROCK,thT("area bedrock",layout->lang));
 

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -744,6 +744,7 @@ int thsymbolset_get_group(int group_id, int cid) {
     group(4,SYMA_SUMP)
     group(5,SYMP_SPRING)
     group(6,SYMP_SINK)
+    group(7,SYMA_UNDERWATERCEILING)
     egroup
 
     bgroup(SYMX_EQUIPMENT)

--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -354,6 +354,7 @@ set xth(me,themes) {
     {area water}
     {area sump}
     {area bedrock}
+    {area underwater-ceiling}
   {theme passage-fills}
     {point blocks}
     {point archeo-material}


### PR DESCRIPTION
Implements a "underwater-ceiling" new area symbol to represent the diveable parts of the cave.

There are 2 commits:

1. the first actually implements the new symbol. I hope there won't be a problem to accept it.
2. the second inverts the patterns used to draw the water and underwater-ceiling areas as, when used together, they make much more sense inverted. I also believe the underwater-ceiling is, generally, a better symbol for water but that's just a matter of personal opinion, I am sure.

Please feel free to accept the first commit and not the second if you believe this would be better. Maybe you don't want to mess with such a traditional symbol as water but it would be great if you accept both of them.