### PR TITLE
Support Catch2 version 3

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,10 +52,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: install dependencies
         run: |
-          # brew update  # try to comment out in case of package problems
+          brew update  # try to comment out in case of package problems
           brew tap homebrew/core
           rm /usr/local/bin/2to3
-          rm /usr/local/bin/2to3-3.12
           brew install wxwidgets vtk proj xquartz ninja basictex fmt pkgconfig catch2
       - name: Configure CMake
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: install dependencies
         run: |
-          brew update  # try to comment out in case of package problems
+          # brew update  # try to comment out in case of package problems
           brew tap homebrew/core
           rm /usr/local/bin/2to3
           brew install wxwidgets vtk proj xquartz ninja basictex fmt pkgconfig catch2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-20.04, toolchain: gcc.cmake,              args: ""                                                }
+          - { os: ubuntu-20.04, toolchain: gcc.cmake,              args: "-DUSE_BUNDLED_CATCH2=ON"                         }
           - { os: ubuntu-22.04, toolchain: clang-sanitizers.cmake, args: ""                                                }
           - { os: ubuntu-22.04, toolchain: gcc.cmake,              args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug" }
     steps:
@@ -15,6 +15,9 @@ jobs:
         run: |
           sudo apt -qq update
           sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build clang-tidy gettext libfmt-dev
+      - name: install Catch2
+        if: matrix.os == 'ubuntu-22.04'
+        run: sudo apt install -y catch2
       - name: install additional texlive languages
         if: matrix.toolchain == 'clang-sanitizers.cmake'
         run:  sudo apt install -y texlive-lang-czechslovak texlive-lang-cyrillic
@@ -52,7 +55,8 @@ jobs:
           # brew update  # try to comment out in case of package problems
           brew tap homebrew/core
           rm /usr/local/bin/2to3
-          brew install wxwidgets vtk proj xquartz ninja basictex fmt pkgconfig
+          rm /usr/local/bin/2to3-3.12
+          brew install wxwidgets vtk proj xquartz ninja basictex fmt pkgconfig catch2
       - name: Configure CMake
         run: |
           mkdir build && cd build && cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/sanitizers.cmake -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DOPENGL_gl_LIBRARY:FILEPATH=/opt/X11/lib/libGL.dylib -DOPENGL_glu_LIBRARY:FILEPATH=/opt/X11/lib/libGLU.dylib -DBUILD_THBOOK=OFF ..

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt -qq update
-        sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build gettext libfmt-dev
+        sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build gettext libfmt-dev catch2
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
     - name: Autobuild

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if (BUILD_THERION)
         COMPONENT th-runtime)
 
     # unit tests
-    add_executable(utest utest-proj.cxx utest-icase.cxx utest-thdouble.cxx utest-main.cxx)
+    add_executable(utest utest-proj.cxx utest-icase.cxx utest-thdouble.cxx)
     target_link_libraries(utest PUBLIC therion-common catch2-interface)
     enable_testing()
     if (NOT WIN32)

--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -4,13 +4,21 @@
 # * ON - use Catch2 header from extern subdirectory
 # * OFF - use Catch2 installed in the system
 #
-option(USE_BUNDLED_CATCH2 "Use bundled version of Catch2." ON)
+option(USE_BUNDLED_CATCH2 "Use bundled version of Catch2." OFF)
 
 add_library(catch2-interface INTERFACE)
 
 if (USE_BUNDLED_CATCH2)
     target_include_directories(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/extern)
-else()
-    find_package(Catch2 REQUIRED)
+    target_sources(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/utest-main.cxx)
+    return()
+endif()
+
+find_package(Catch2 REQUIRED)
+if (Catch2_VERSION_MAJOR LESS 3)
     target_link_libraries(catch2-interface INTERFACE Catch2::Catch2)
+    target_sources(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/utest-main.cxx)
+else()
+    target_link_libraries(catch2-interface INTERFACE Catch2::Catch2WithMain)
+    target_compile_definitions(catch2-interface INTERFACE CATCH2_V3)
 endif()

--- a/thbook/ch06.tex
+++ b/thbook/ch06.tex
@@ -73,11 +73,12 @@ For Windows consider using MinGW and MSYS2 (\www{https://www.msys2.org/}).
 It's a distribution of GNU utilities with GNU make and GCC.
 (BTW, why not to use precompiled Windows version?)
 
-Installing dependencies to compile Therion on Ubuntu 20.04 or 22.04:
+Installing dependencies to compile Therion on Ubuntu 22.04:
 
 {\rightskip 0pt plus 3cm
   |sudo apt install|
   |bwidget|
+  |catch2|
   |cmake|
   |gcc|
   |ghostscript|
@@ -103,6 +104,7 @@ Installing dependencies in Fedora 37:
   |sudo dnf install|
   |brotli-devel|
   |bwidget|
+  |catch2-devel|
   |cmake|
   |fmt-devel|
   |g++|
@@ -146,7 +148,7 @@ Here is a selection of parameters which can be used with cmake:
   |-G Ninja| to use {\it Ninja} build system instead of make,
   or |-G "MSYS Makefiles"| to build using {\it make} under MSYS2
 * {\catcode`\=12|-DUSE_BUNDLED_SHAPELIB=OFF|} = use the system Shapelib library
-* {\catcode`\=12|-DUSE_BUNDLED_CATCH2=OFF|} = use the system Catch2 library
+* {\catcode`\=12|-DUSE_BUNDLED_CATCH2=ON|} = use the bundled version of Catch2 library
 * {\catcode`\=12|-DECM_ENABLE_SANITIZERS=<option>|} = use runtime sanitizers, relevant options:
 
   |address| -- detects invalid memory accesses, use-after-free, double free, memory leaks, useful for debugging

--- a/utest-icase.cxx
+++ b/utest-icase.cxx
@@ -1,4 +1,9 @@
+#ifdef CATCH2_V3
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+#else
 #include <catch2/catch.hpp>
+#endif
 #include "loch/icase.h"
 #include "thparse.h"
 #include "thcsdata.h"

--- a/utest-proj.cxx
+++ b/utest-proj.cxx
@@ -1,4 +1,8 @@
+#ifdef CATCH2_V3
+#include <catch2/catch_test_macros.hpp>
+#else
 #include <catch2/catch.hpp>
+#endif
 #include <cmath>
 
 #include "thproj.h"
@@ -8,7 +12,6 @@
 #ifndef M_PI
 #define M_PI       3.14159265358979323846
 #endif
-
 
 // tests for coordinate systems transformations using Proj library
 

--- a/utest-thdouble.cxx
+++ b/utest-thdouble.cxx
@@ -1,6 +1,10 @@
 #include "thdouble.h"
 
+#ifdef CATCH2_V3
+#include <catch2/catch_test_macros.hpp>
+#else
 #include <catch2/catch.hpp>
+#endif
 
 TEST_CASE("thdouble")
 {


### PR DESCRIPTION
Add support for Catch2 version 3, version 2 support is preserved. New default for CMake builds is to use installed version.