### PR TITLE
Use dynamic_cast in loch

### DIFF
--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -462,7 +462,7 @@ bool lxGLCanvas::CameraAutoRotate() {
     if (elapsed < 10) wxMilliSleep(10 - elapsed);
     this->m_sCameraAutoRotateCounter++;
     if (this->m_sCameraAutoRotateSWatch.Time() > 1000) {  
-      ((wxStaticText *)(this->frame->m_viewpointSetupDlg->FindWindow(LXVSTP_RENSPEED)))->SetLabel(
+      dynamic_cast<wxStaticText*>(this->frame->m_viewpointSetupDlg->FindWindow(LXVSTP_RENSPEED))->SetLabel(
         wxString::Format(_("Rendering at %.1f fps."), 1000.0 * double(this->m_sCameraAutoRotateCounter) / double(this->m_sCameraAutoRotateSWatch.Time())));
       this->m_sCameraAutoRotateCounter = 0;
       this->m_sCameraAutoRotateSWatch.Start();

--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -1002,7 +1002,7 @@ void lxFrame::ToggleRotation() {
     this->canvas->m_sCameraAutoRotateSWatch.Start();
     this->setup->StartCameraMovement();
   } else {
-    ((wxStaticText *)(this->m_viewpointSetupDlg->FindWindow(LXVSTP_RENSPEED)))->SetLabel(_T(""));
+    dynamic_cast<wxStaticText*>(this->m_viewpointSetupDlg->FindWindow(LXVSTP_RENSPEED))->SetLabel(_T(""));
   }
 	this->UpdateM2TB();
 }

--- a/loch/lxOptDlg.cxx
+++ b/loch/lxOptDlg.cxx
@@ -48,7 +48,7 @@ lxOptionsDlg::lxOptionsDlg(wxWindow * parent)
 : wxDialog(parent, wxID_ANY, wxString(_("Options")))
 {
 
-  this->m_lxframe = (lxFrame *) parent;
+  this->m_lxframe = dynamic_cast<lxFrame*>(parent);
 
   wxBoxSizer * sizerAll = new wxBoxSizer(wxVERTICAL);
   lxStaticBoxSizer = new wxStaticBoxSizer(

--- a/loch/lxPres.cxx
+++ b/loch/lxPres.cxx
@@ -306,7 +306,7 @@ lxPresentDlg::lxPresentDlg(wxWindow *parent)
 		this->SetIcon(wxIcon(loch_xpm));
 #endif
 
-  this->m_mainFrame = (lxFrame *) parent;
+  this->m_mainFrame = dynamic_cast<lxFrame*>(parent);
   this->m_fileName = wxEmptyString;
 
    

--- a/loch/lxSScene.cxx
+++ b/loch/lxSScene.cxx
@@ -268,7 +268,7 @@ lxModelSetupDlg::lxModelSetupDlg(wxWindow *parent)
 		this->SetIcon(wxIcon(loch_xpm));
 #endif
 
-  this->m_mainFrame = (lxFrame *) parent;
+  this->m_mainFrame = dynamic_cast<lxFrame*>(parent);
    
   wxBoxSizer * sizerTop = new wxBoxSizer(wxHORIZONTAL),
 		* sizerFrame = new wxBoxSizer(wxVERTICAL);

--- a/loch/lxSStats.cxx
+++ b/loch/lxSStats.cxx
@@ -62,7 +62,7 @@ lxSurveyStatsDlg::lxSurveyStatsDlg(wxWindow *parent)
 		this->SetIcon(wxIcon(loch_xpm));
 #endif
 
-  this->m_mainFrame = (lxFrame *) parent;
+  this->m_mainFrame = dynamic_cast<lxFrame*>(parent);
    
   wxBoxSizer * sizerFrame = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer * sizerTop = new wxBoxSizer(wxVERTICAL);

--- a/loch/lxSTree.cxx
+++ b/loch/lxSTree.cxx
@@ -58,7 +58,7 @@ void lxModelTreeDlg::OnCommand(wxCommandEvent& event)
 		size_t selcnt = this->m_treeControl->GetSelections(csel);
     	if (selcnt > 0) {
     		for(size_t i = 0; i < selcnt; i++) {
-    			SurveyTreeData * data = (SurveyTreeData *) this->m_treeControl->GetItemData(csel.Item(i));
+    			SurveyTreeData * data = dynamic_cast<SurveyTreeData*>(this->m_treeControl->GetItemData(csel.Item(i)));
         		if (data != NULL) {
         			this->m_mainFrame->data->AddSelectedSurvey(data->m_id);
         		}
@@ -99,7 +99,7 @@ lxModelTreeDlg::lxModelTreeDlg(wxWindow *parent)
 		this->SetIcon(wxIcon(loch_xpm));
 #endif
 
-  this->m_mainFrame = (lxFrame *) parent;
+  this->m_mainFrame = dynamic_cast<lxFrame*>(parent);
    
   wxBoxSizer * sizerFrame = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer * sizerTop = new wxBoxSizer(wxVERTICAL);

--- a/loch/lxSView.cxx
+++ b/loch/lxSView.cxx
@@ -247,7 +247,7 @@ lxViewpointSetupDlg::lxViewpointSetupDlg(wxWindow *parent)
 		this->SetIcon(wxIcon(loch_xpm));
 #endif
 
-  this->m_mainFrame = (lxFrame *) parent;
+  this->m_mainFrame = dynamic_cast<lxFrame*>(parent);
 
   this->m_uicFacing = false;
   this->m_uicTilt = false;

--- a/loch/lxWX.cxx
+++ b/loch/lxWX.cxx
@@ -38,15 +38,15 @@ bool lxDoubleValidator::Validate(wxWindow * WXUNUSED(parent))
 	if( !CheckValidator() )
     return FALSE;
 
-	if (!((wxTextCtrl *)m_validatorWindow)->GetValue().ToDouble(&tmp)) {
+	if (!dynamic_cast<wxTextCtrl*>(m_validatorWindow)->GetValue().ToDouble(&tmp)) {
 		// TODO: MSGBox saying something about the range
-		((wxTextCtrl *)this->m_validatorWindow)->SetSelection(-1, -1);
+		dynamic_cast<wxTextCtrl*>(this->m_validatorWindow)->SetSelection(-1, -1);
 		this->m_validatorWindow->SetFocus();
 		return FALSE;
 	}
 
 	if ((tmp < this->m_vMin) || (tmp > this->m_vMax)) {
-		((wxTextCtrl *)this->m_validatorWindow)->SetSelection(-1, -1);
+		dynamic_cast<wxTextCtrl*>(this->m_validatorWindow)->SetSelection(-1, -1);
 		this->m_validatorWindow->SetFocus();
 		return FALSE;
 	}
@@ -59,14 +59,14 @@ bool lxDoubleValidator::TransferToWindow()
 {
   if (!CheckValidator())
     return FALSE;
-	((wxTextCtrl *) m_validatorWindow)->SetValue(wxString::Format(this->m_fmt, *this->m_variable));
+	dynamic_cast<wxTextCtrl*>(m_validatorWindow)->SetValue(wxString::Format(this->m_fmt, *this->m_variable));
 	return TRUE;
 }
 
 
 bool lxDoubleValidator::TransferFromWindow()
 {
-  if (((wxTextCtrl *)m_validatorWindow)->GetValue().ToDouble(this->m_variable)) {
+  if (dynamic_cast<wxTextCtrl*>(m_validatorWindow)->GetValue().ToDouble(this->m_variable)) {
 		if (*this->m_variable < this->m_vMin)
 			*this->m_variable = this->m_vMin;
 		if (*this->m_variable > this->m_vMax)
@@ -99,14 +99,14 @@ bool lxRadioBtnValidator::TransferToWindow()
 {
   if (!CheckValidator())
     return FALSE;
-	((wxRadioButton *) m_validatorWindow)->SetValue((*this->m_variable) == this->m_variableValue);
+	dynamic_cast<wxRadioButton*>(m_validatorWindow)->SetValue((*this->m_variable) == this->m_variableValue);
 	return TRUE;
 }
 
 
 bool lxRadioBtnValidator::TransferFromWindow()
 {
-	if (((wxRadioButton *) m_validatorWindow)->GetValue())
+	if (dynamic_cast<wxRadioButton*>(m_validatorWindow)->GetValue())
 		*this->m_variable = this->m_variableValue;
 	return TRUE;
 }
@@ -289,7 +289,7 @@ void lxTBoxPos::Save()
 
   this->m_corner = nc;
 
-  if (((wxFrame*)this->m_winFrame)->IsFullScreen() && ((nc == 1) || (nc == 4))) {
+  if (dynamic_cast<wxFrame*>(this->m_winFrame)->IsFullScreen() && ((nc == 1) || (nc == 4))) {
     ty += this->m_fsOffset;
   }
 
@@ -326,7 +326,7 @@ void lxTBoxPos::Restore()
   this->m_winTool->GetSize(& tw, & th);
   this->m_winTool->GetPosition(& tx, & ty);
 
-  if (((wxFrame*)this->m_winFrame)->IsFullScreen() && ((this->m_corner == 1) || (this->m_corner == 4))) {
+  if (dynamic_cast<wxFrame*>(this->m_winFrame)->IsFullScreen() && ((this->m_corner == 1) || (this->m_corner == 4))) {
     fy -= this->m_fsOffset;
   }
   switch (this->m_corner) {

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -20,14 +20,14 @@
 #define lxBORDER 5
 #endif
 
-#define lxFStaticText(ID) ((wxStaticText *)FindWindow(ID))
-#define lxFRadioBtn(ID) ((wxRadioButton *)FindWindow(ID))
-#define lxFCheckBox(ID) ((wxCheckBox *)FindWindow(ID))
-#define lxFButton(ID) ((wxButton *)FindWindow(ID))
-#define lxFTextCtrl(ID) ((wxTextCtrl*)FindWindow(ID))
-#define lxFSpinCtrl(ID) ((wxSpinCtrl*)FindWindow(ID))
-#define lxFSlider(ID) ((wxSlider*)FindWindow(ID))
-#define lxFChoice(ID) ((wxChoice*)FindWindow(ID))
+#define lxFStaticText(ID) (dynamic_cast<wxStaticText*>(FindWindow(ID)))
+#define lxFRadioBtn(ID) (dynamic_cast<wxRadioButton*>(FindWindow(ID)))
+#define lxFCheckBox(ID) (dynamic_cast<wxCheckBox*>(FindWindow(ID)))
+#define lxFButton(ID) (dynamic_cast<wxButton*>(FindWindow(ID)))
+#define lxFTextCtrl(ID) (dynamic_cast<wxTextCtrl*>(FindWindow(ID)))
+#define lxFSpinCtrl(ID) (dynamic_cast<wxSpinCtrl*>(FindWindow(ID)))
+#define lxFSlider(ID) (dynamic_cast<wxSlider*>(FindWindow(ID)))
+#define lxFChoice(ID) (dynamic_cast<wxChoice*>(FindWindow(ID)))
 
 #define lxNOTTOP wxBOTTOM | wxLEFT | wxRIGHT
 #define lxNOTLEFT wxBOTTOM | wxTOP | wxRIGHT
@@ -128,7 +128,7 @@ protected:
 			_T("No	window associated	with validator") );
 		wxCHECK_MSG( m_validatorWindow->IsKindOf(CLASSINFO(wxTextCtrl)), FALSE,
 			_T("wxNumberValidator is	only for wxTextCtrl's")	);
-		wxCHECK_MSG( ((wxTextCtrl	*)m_validatorWindow)->IsSingleLine(),	FALSE,
+		wxCHECK_MSG( dynamic_cast<wxTextCtrl*>(m_validatorWindow)->IsSingleLine(),	FALSE,
 			_T("Multiline wxTextCtrl	not	allowed	yet")	);
 
 		return TRUE;


### PR DESCRIPTION
This pull request is a first step to remove unsafe C-casts. C-casts ignore type safety and just perform first successful cast from the following list:

1. const_cast
2. static_cast
3. static_cast + const_cast
4. reinterpret_cast
5. reinterpret_cast + const_cast

After we fix all the issues we can forbid unsafe casts by enabling `clang-tidy` check `cppcoreguidelines-pro-type-cstyle-cast` on GitHub Actions.