### PR TITLE
Initialize member variables

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,24 @@
 ---
-Checks: '-*,modernize-use-override,clang-analyzer-cplusplus*,clang-analyzer-unix*,misc-definitions-in-headers,bugprone*,-bugprone-easily-swappable-parameters,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-suspicious-enum-usage,-bugprone-integer-division,-bugprone-implicit-widening-of-multiplication-result,-bugprone-incorrect-roundings,-bugprone-suspicious-include,-bugprone-unhandled-self-assignment,-bugprone-branch-clone,-bugprone-assignment-in-if-condition,performance-for-range-copy,cppcoreguidelines-no-malloc'
+Checks: '-*,
+        modernize-use-override,
+        clang-analyzer-cplusplus*,
+        clang-analyzer-unix*,
+        misc-definitions-in-headers,
+        bugprone*,
+          -bugprone-easily-swappable-parameters,
+          -bugprone-macro-parentheses,
+          -bugprone-narrowing-conversions,
+          -bugprone-suspicious-enum-usage,
+          -bugprone-integer-division,
+          -bugprone-implicit-widening-of-multiplication-result,
+          -bugprone-incorrect-roundings,
+          -bugprone-suspicious-include,
+          -bugprone-unhandled-self-assignment,
+          -bugprone-branch-clone,
+          -bugprone-assignment-in-if-condition,
+        performance-for-range-copy,
+        cppcoreguidelines-no-malloc,
+        cppcoreguidelines-pro-type-member-init'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/loch/lxData.cxx
+++ b/loch/lxData.cxx
@@ -244,8 +244,8 @@ void lxDataTexture::CreateTexImages(int sizeS, int sizeO)
 
 
 struct lxDataRebuildStationStruct {
-  lxFileStation * m_pst;
-  size_t m_pos;
+  lxFileStation * m_pst = {};
+  size_t m_pos = {};
 };
 
 

--- a/loch/lxData.h
+++ b/loch/lxData.h
@@ -54,13 +54,13 @@
 
 struct lxDataSurvey {
 
-  size_t m_id, m_parent, m_level;
+  size_t m_id = {}, m_parent = {}, m_level = {};
 
-  const char * m_name, * m_title;
+  const char * m_name = {}, * m_title = {};
 
   std::string m_full_name;
   
-  bool m_selected;
+  bool m_selected = {};
 
 };
 
@@ -99,11 +99,11 @@ struct lxDataTexture {
 
 struct lxDataShot {
 
-  unsigned long from, to;
+  unsigned long from = {}, to = {};
 
-  size_t m_survey_idx;
+  size_t m_survey_idx = {};
   
-  bool surface, invisible, splay, duplicate, m_selected;
+  bool surface = {}, invisible = {}, splay = {}, duplicate = {}, m_selected = {};
   
 };
 

--- a/loch/lxFile.cxx
+++ b/loch/lxFile.cxx
@@ -1000,8 +1000,8 @@ void lxFile::Import3D(const char * fn)
 
 
 struct missingShot {
-  lxFileSizeT f, t;
-  double length;
+  lxFileSizeT f = {}, t = {};
+  double length = {};
 };
 
 

--- a/loch/lxFile.h
+++ b/loch/lxFile.h
@@ -200,11 +200,11 @@ struct lxFile {
 
   lxFileSurvey_list m_surveys;
   lxFileData m_surveysData;
-  lxFileSizeT m_nSurveys;
+  lxFileSizeT m_nSurveys = {};
 
   lxFileStation_list m_stations;
   lxFileData m_stationsData;
-  lxFileSizeT m_nStations;
+  lxFileSizeT m_nStations = {};
 
   lxFileShot_list m_shots;
   lxFileData m_shotsData;

--- a/loch/lxGLC.h
+++ b/loch/lxGLC.h
@@ -88,15 +88,15 @@ class lxGLCanvas: public wxGLCanvas {
     bool m_sMoveSingle = false, m_isO;
 
     // fonty
-    FT_Face m_ftFace1, m_ftFace2, m_ftFace3;
+    FT_Face m_ftFace1 = {}, m_ftFace2 = {}, m_ftFace3 = {};
     OGLFT::Monochrome * m_fntNumericS,
       * m_fntTitleS;
     OGLFT::Filled * m_fntNumericO,
       * m_fntTitleO;
 
-    GLdouble m_camera_modelview[16];
-    GLdouble m_camera_projection[16];
-    GLint m_camera_viewport[4];
+    GLdouble m_camera_modelview[16] = {};
+    GLdouble m_camera_projection[16] = {};
+    GLint m_camera_viewport[4] = {};
 
 		bool m_sCameraAutoRotate, m_sCameraLockRotation;
     wxStopWatch m_sCameraAutoRotateSWatch;

--- a/loch/lxGUI.h
+++ b/loch/lxGUI.h
@@ -152,7 +152,7 @@ class lxFrame: public wxFrame
 
     lxGLCanvas * canvas;
     wxString m_fileDir, m_fileToOpen, m_fileName;
-    int m_fileType;
+    int m_fileType = {};
     
     struct lxData * data;
     struct lxSetup * setup;
@@ -181,10 +181,10 @@ class lxFrame: public wxFrame
     wxFileHistory * m_fileHistory;
     wxString m_iniDirectory;
 
-    long m_iniUnits;
-    int m_iniStereoGlasses;
-    int m_iniStereoGlassesLast;
-    long m_iniWallsInterpolate;
+    long m_iniUnits = {};
+    int m_iniStereoGlasses = {};
+    int m_iniStereoGlassesLast = {};
+    long m_iniWallsInterpolate = {};
 
     class lxApp * m_app;
 
@@ -266,7 +266,7 @@ class lxApp: public wxGLApp
 
   public:
   
-    class lxFrame * frame;
+    class lxFrame * frame = {};
 
     wxLocale m_locale;
     wxFileName m_path;

--- a/loch/lxImgIO.cxx
+++ b/loch/lxImgIO.cxx
@@ -68,7 +68,7 @@ lxWrite_JPEG_file (const char * filename, int quality, lxImageRGB img) {
    * compression/decompression processes, in existence at once.  We refer
    * to any one struct (and its associated working data) as a "JPEG object".
    */
-  struct jpeg_compress_struct cinfo;
+  struct jpeg_compress_struct cinfo = {};
   /* This struct represents a JPEG error handler.  It is declared separately
    * because applications often want to supply a specialized error handler
    * (see the second half of this file for an example).  But here we just
@@ -77,7 +77,7 @@ lxWrite_JPEG_file (const char * filename, int quality, lxImageRGB img) {
    * Note that this struct must live as long as the main JPEG parameter
    * struct, to avoid dangling-pointer problems.
    */
-  struct jpeg_error_mgr jerr;
+  struct jpeg_error_mgr jerr = {};
   /* More stuff */
   FILE * outfile;               /* target file */
   JSAMPROW row_pointer[1];      /* pointer to JSAMPLE row[s] */
@@ -279,12 +279,12 @@ lxRead_JPEG_file (const char * filename, FILE * infile)
   /* This struct contains the JPEG decompression parameters and pointers to
    * working space (which is allocated as needed by the JPEG library).
    */
-  struct jpeg_decompress_struct cinfo;
+  struct jpeg_decompress_struct cinfo = {};
   /* We use our private extension JPEG error handler.
    * Note that this struct must live as long as the main JPEG parameter
    * struct, to avoid dangling-pointer problems.
    */
-  struct my_error_mgr jerr;
+  struct my_error_mgr jerr = {};
   /* More stuff */
   //FILE * infile;                /* source file */
   JSAMPARRAY buffer;            /* Output row buffer */

--- a/loch/lxLRUD.cxx
+++ b/loch/lxLRUD.cxx
@@ -126,13 +126,13 @@ xcNAGet(FR,fr,tl)
 
 
 struct xcNode {
-  size_t id;
+  size_t id = {};
   lxVec p;
   std::list<xcNodeArrow> arrows;
 };
 
 struct xcSeriesStart {
-  double prob;
+  double prob = {};
   xcNodeArrow arrow;
 };
 

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -335,10 +335,10 @@ namespace OGLFT {
     //! display lists. Anyway, you'll be able to get even more fancy
     //! by passing in a function to map the color with, so why balk at
     //! this?)
-    GLfloat foreground_color_[4];
+    GLfloat foreground_color_[4] = {};
 
     //! Background color (what modes would use this?)
-    GLfloat background_color_[4];
+    GLfloat background_color_[4] = {};
 
     //! PHIGS-like horizontal positioning of text.
     enum HorizontalJustification horizontal_justification_ = {};
@@ -1034,7 +1034,7 @@ namespace OGLFT {
      * implement the ColorTess and TextureTess interfaces.
      */
     struct VertexInfo {
-      double v_[3]; //!< Why is this double precision? Because the second
+      double v_[3] = {}; //!< Why is this double precision? Because the second
 		    //!< argument to the routine gluTessVertex is a pointer
 		    //!< to an array of doubles. Otherwise, we could use
 		    //!< single precision everywhere.
@@ -1816,16 +1816,16 @@ namespace OGLFT {
      * texture objects than we have to, so they are always cached.
      */
     struct TextureInfo {
-      GLuint texture_name_;  //!< A bound texture name is an integer in OpenGL.
-      FT_Int left_bearing_,  //!< The left bearing of the transformed glyph.
-	bottom_bearing_;     //!< The bottom bearing of the transformed glyph.
-      int width_,	     //!< The 2**l width of the texture.
-	height_;	     //!< The 2**m height of the texture.
-      GLfloat texture_s_,    //!< The fraction of the texture width occupied
+      GLuint texture_name_ = {};  //!< A bound texture name is an integer in OpenGL.
+      FT_Int left_bearing_ = {},  //!< The left bearing of the transformed glyph.
+	bottom_bearing_ = {};     //!< The bottom bearing of the transformed glyph.
+      int width_ = {},	     //!< The 2**l width of the texture.
+	height_ = {};	     //!< The 2**m height of the texture.
+      GLfloat texture_s_ = {},    //!< The fraction of the texture width occupied
 			     //!< by the glyph.
-	texture_t_;	     //!< The fraction of the texture height occupied
+	texture_t_ = {};	     //!< The fraction of the texture height occupied
                              //!< by the glyph.
-      FT_Vector advance_;    //!< The advance vector of the transformed glyph.
+      FT_Vector advance_ = {};    //!< The advance vector of the transformed glyph.
     };
 
     //! Type of the cache of defined glyph to texture objects mapping.

--- a/loch/lxPres.h
+++ b/loch/lxPres.h
@@ -34,7 +34,7 @@ public:
 
   lxTBoxPos m_toolBoxPosition;
   wxString m_fileName, m_fileDir;
-  bool m_changed;
+  bool m_changed = {};
   class lxFrame * m_mainFrame;
   class wxListBox * m_posLBox;
 

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -720,7 +720,7 @@ void lxRenderFile::RenderBMPHeader() {
     wxUint32  h_res, v_res;   // image resolution in dpi
     wxUint32  num_clrs;       // number of colors used
     wxUint32  num_signif_clrs;// number of significant colors
-  } hdr;
+  } hdr = {};
 
 
   double imgRes;

--- a/loch/lxSetup.h
+++ b/loch/lxSetup.h
@@ -41,8 +41,8 @@ struct lxSetup {
     cam_orig_center, cam_orig_pos;
   int cam_anaglyph_glasses, m_colormd;
   double cam_dist = 0.0, cam_dir, cam_tilt, cam_width = 0.0,
-    cam_orig_dist = 0.0, cam_orig_dir = 0.0, cam_orig_tilt = 0.0, cam_lens, cam_lens_vfov, cam_lens_vfovr, cam_anaglyph_eyesep,
-    data_limits_diam;
+    cam_orig_dist = 0.0, cam_orig_dir = 0.0, cam_orig_tilt = 0.0, cam_lens = 0.0, cam_lens_vfov = 0.0, cam_lens_vfovr = 0.0, cam_anaglyph_eyesep,
+    data_limits_diam = 0.0;
   bool cam_persp, cam_anaglyph, cam_anaglyph_bw, cam_anaglyph_left;
 
   bool m_vis_centerline = false, m_vis_walls, m_vis_surface, 

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -66,8 +66,8 @@ extern wxPoint lxPoint;
 
 class lxTBoxPos {
 
-  int m_xOffset, m_yOffset, m_corner;
-  wxWindow * m_winTool, * m_winFrame;
+  int m_xOffset = {}, m_yOffset = {}, m_corner = {};
+  wxWindow * m_winTool = {}, * m_winFrame = {};
 
 public:
 

--- a/thbezier.cxx
+++ b/thbezier.cxx
@@ -120,7 +120,7 @@
 class NR_Point {
 
 private:
-    double _pt[2];
+    double _pt[2] = {};
 
 public:
 

--- a/thconfig.h
+++ b/thconfig.h
@@ -110,7 +110,7 @@ class thconfig {
   thexporter exporter;  ///< Data exporter.
   thselector selector;  ///< Database selector.
 
-  double ibbx[4]; ///< Input bounding box.
+  double ibbx[4] = {}; ///< Input bounding box.
   bool ibbx_def; ///< Input bounding box defined.
 
   bool m_decl_out_of_geomag_range; ///< Whether declination out of geomag model range.

--- a/thdata.h
+++ b/thdata.h
@@ -142,9 +142,9 @@ class thdata : public thdataobject {
     dlc_up, dlc_down, dlc_left, dlc_right;
     
   // dls - data standard deviation and declination
-  double dls_length, dls_gradient, dls_bearing, dls_counter, dls_depth,
-    dls_dx, dls_dy, dls_dz, dls_x, dls_y, dls_z, dl_declination,
-    dl_survey_declination;
+  double dls_length = {}, dls_gradient = {}, dls_bearing = {}, dls_counter = {}, dls_depth = {},
+    dls_dx = {}, dls_dy = {}, dls_dz = {}, dls_x = {}, dls_y = {}, dls_z = {}, dl_declination = {},
+    dl_survey_declination = {};
     
   // statistics  
   double stat_length, stat_dlength, stat_splaylength, stat_slength, stat_alength;
@@ -155,16 +155,16 @@ class thdata : public thdataobject {
   bool dli_plumbs, dli_equates, dl_direction;
   
   // what is inserted
-  bool di_station, di_from, di_to, di_length, di_bearing, di_gradient,
-    di_backlength, di_backbearing, di_backgradient,
-    di_depth, di_fromdepth, di_todepth, di_depthchange, di_count, di_fromcount,
-    di_tocount, di_dx, di_dy, di_dz, di_direction, di_newline, di_interleaved,
-    di_up, di_down, di_left, di_right;
+  bool di_station = {}, di_from = {}, di_to = {}, di_length = {}, di_bearing = {}, di_gradient = {},
+    di_backlength = {}, di_backbearing = {}, di_backgradient = {},
+    di_depth = {}, di_fromdepth = {}, di_todepth = {}, di_depthchange = {}, di_count = {}, di_fromcount = {},
+    di_tocount = {}, di_dx = {}, di_dy = {}, di_dz = {}, di_direction = {}, di_newline = {}, di_interleaved = {},
+    di_up = {}, di_down = {}, di_left = {}, di_right = {};
   
   bool dl_survey_declination_on, dl_declination_north_grid;
   
   int d_type, ///< Type of data.
-    d_order[THDATA_MAX_ITEMS],  ///< Data order.
+    d_order[THDATA_MAX_ITEMS] = {},  ///< Data order.
     d_nitems,  ///< Number of items.
     d_current,  ///< Currently inserted item.
     d_mark,  ///< Station mark type.
@@ -182,7 +182,7 @@ class thdata : public thdataobject {
   void reset_data();  ///< Reset data type and order.
   
   thdataleg_list::iterator cd_leg, pd_leg;  // Current data leg.
-  bool cd_leg_def, pd_leg_def;  // Whether these legs are defined.
+  bool cd_leg_def = {}, pd_leg_def = {};  // Whether these legs are defined.
   
   void set_data_calibration(int nargs, char ** args);  ///< Data calibration.
   

--- a/thdatabase.h
+++ b/thdatabase.h
@@ -162,18 +162,18 @@ class thdatabase {
   thmbuffer buff_strings;   ///< String storage buffer.
   
   
-  int ccontext;  ///< Current context.
-  class thsurvey * csurveyptr,  ///< Pointer to the current survey.
-    * fsurveyptr;  ///< Pointer to the first survey.
-  unsigned csurveylevel; ///< Current survey level.
-  class thscrap * cscrapptr; ///< Current scrap.
-  class th2ddataobject * lcscrapoptr; ///< Last object in given current scrap.
-  class thdataobject * lcsobjectptr;  ///< Last object in given current survey.
+  int ccontext = {};  ///< Current context.
+  class thsurvey * csurveyptr = {},  ///< Pointer to the current survey.
+    * fsurveyptr = {};  ///< Pointer to the first survey.
+  unsigned csurveylevel = {}; ///< Current survey level.
+  class thscrap * cscrapptr = {}; ///< Current scrap.
+  class th2ddataobject * lcscrapoptr = {}; ///< Last object in given current scrap.
+  class thdataobject * lcsobjectptr = {};  ///< Last object in given current survey.
 
   thdb_dictionary_type dictionary;  ///< Database dictionary.
   
-  unsigned long objid,  ///< Object identifier
-    nscraps;  ///< Total number of scraps.
+  unsigned long objid = {},  ///< Object identifier
+    nscraps = {};  ///< Total number of scraps.
   
   void reset_context();  ///< Reset database context.
 

--- a/thdataleg.h
+++ b/thdataleg.h
@@ -401,38 +401,38 @@ class thdataleg {
 
   public:
   
-  bool is_valid;  ///< whether leg is valid.
+  bool is_valid = {};  ///< whether leg is valid.
   
   thobjectsrc srcf;  ///< Source file.
   
-  int data_type,  ///< leg data type
-      flags;  ///< Leg flags.
+  int data_type = {},  ///< leg data type
+      flags = {};  ///< Leg flags.
       
-  unsigned int s_mark,  ///< Type of the station mark
-    extend;  ///< Extend flags: normal, reverse, left, right, break
+  unsigned int s_mark = {},  ///< Type of the station mark
+    extend = {};  ///< Extend flags: normal, reverse, left, right, break
 
-  int walls, shape, gridcs;
+  int walls = {}, shape = {}, gridcs = {};
   
-  bool splay_walls;
+  bool splay_walls = {};
 
-  struct thdb1d_loop * loop; ///< Worst loop leg is a part of.
-  struct thdb1d_traverse * traverse; ///< Centreline traverse, leg is a part of.
+  struct thdb1d_loop * loop = {}; ///< Worst loop leg is a part of.
+  struct thdb1d_traverse * traverse = {}; ///< Centreline traverse, leg is a part of.
 
   thobjectname station, from, to;
-  class thsurvey * psurvey;  ///< parent survey
+  class thsurvey * psurvey = {};  ///< parent survey
   
-  double length, counter, fromcounter, tocounter, depth, fromdepth,
-    todepth, depthchange, bearing, gradient, dx, dy, dz,
-    backbearing, backgradient, backlength, total_length, total_bearing, total_gradient,
-    total_dx, total_dy, total_dz, adj_dx, adj_dy, adj_dz,
-    from_up, from_down, from_left, from_right,
-    to_up, to_down, to_left, to_right, vtresh, extend_ratio;
+  double length = {}, counter = {}, fromcounter = {}, tocounter = {}, depth = {}, fromdepth = {},
+    todepth = {}, depthchange = {}, bearing = {}, gradient = {}, dx = {}, dy = {}, dz = {},
+    backbearing = {}, backgradient = {}, backlength = {}, total_length = {}, total_bearing = {}, total_gradient = {},
+    total_dx = {}, total_dy = {}, total_dz = {}, adj_dx = {}, adj_dy = {}, adj_dz = {},
+    from_up = {}, from_down = {}, from_left = {}, from_right = {},
+    to_up = {}, to_down = {}, to_left = {}, to_right = {}, vtresh = {}, extend_ratio = {};
     
-  double length_sd, counter_sd, depth_sd, bearing_sd, gradient_sd,
-    dx_sd, dy_sd, dz_sd, x_sd, y_sd, z_sd, declination, implicit_declination, 
-    total_sdx, total_sdy, total_sdz, fxx, txx;
+  double length_sd = {}, counter_sd = {}, depth_sd = {}, bearing_sd = {}, gradient_sd = {},
+    dx_sd = {}, dy_sd = {}, dz_sd = {}, x_sd = {}, y_sd = {}, z_sd = {}, declination = {}, implicit_declination = {}, 
+    total_sdx = {}, total_sdy = {}, total_sdz = {}, fxx = {}, txx = {};
     
-  bool infer_plumbs, infer_equates, direction, adjusted, to_be_adjusted, topofil, plumbed;
+  bool infer_plumbs = {}, infer_equates = {}, direction = {}, adjusted = {}, to_be_adjusted = {}, topofil = {}, plumbed = {};
   
  
   /**

--- a/thdate.cxx
+++ b/thdate.cxx
@@ -64,12 +64,6 @@ void thdate::reset_current()
 }
 
 
-thdate::thdate()
-{
-  this->reset();
-}
-
-
 thdate::~thdate()
 {
 }

--- a/thdate.h
+++ b/thdate.h
@@ -70,19 +70,19 @@ class thdate {
 
   public:
 
-  int syear,  ///< Start date year
-    smonth,  ///< Start date month
-    sday,  ///< Start date day
-    shour,  ///< Star date hour
-    smin,  ///< Star date minute
-    eyear,  ///< End date year
-    emonth,  ///< End date month
-    eday,  ///< End date month
-    ehour,  ///< End date hour
-    emin;  ///< End date minute
+  int syear = -1,  ///< Start date year
+    smonth = -1,  ///< Start date month
+    sday = -1,  ///< Start date day
+    shour = -1,  ///< Star date hour
+    smin = -1,  ///< Star date minute
+    eyear = -1,  ///< End date year
+    emonth = -1,  ///< End date month
+    eday = -1,  ///< End date month
+    ehour = -1,  ///< End date hour
+    emin = -1;  ///< End date minute
 
-  double ssec, ///< Start date seconds
-    esec;  ///< End date seconds
+  double ssec = -1.0, ///< Start date seconds
+    esec = -1.0;  ///< End date seconds
     
   std::array<char, thdate_bufflen> dstr = {}; ///< String for given date.
 
@@ -128,7 +128,7 @@ class thdate {
    * Standard constructor.
    */
   
-  thdate();
+  thdate() = default;
   
   
   /**

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -1373,21 +1373,21 @@ struct thlc_series
 
 struct thlc_cross_arrow
 {
-  thlc_cross * target;
-  thlc_cross_arrow * prev_arrow, * next_arrow;
-  thlc_series * series;
-  bool reverse;
+  thlc_cross * target = {};
+  thlc_cross_arrow * prev_arrow = {}, * next_arrow = {};
+  thlc_series * series = {};
+  bool reverse = {};
 };
 
 
 struct thlc_loop
 {
-  thlc_cross * from_cross, * to_cross;
-  thlc_cross_arrow * first_arrow, * last_arrow;
-  unsigned long minid, size, id;
+  thlc_cross * from_cross = {}, * to_cross = {};
+  thlc_cross_arrow * first_arrow = {}, * last_arrow = {};
+  unsigned long minid = {}, size = {}, id = {};
 #ifdef THDEBUG
-  bool is_new;
-  long old_id;
+  bool is_new = {};
+  long old_id = {};
 #endif  
 };
 
@@ -3559,7 +3559,7 @@ thdb3ddata * thdb1ds::get_3d_outline() {
   thdb1d_tree_arrow * a;
   thdb1ds * tt;
   n = &(thdb.db1d.tree_nodes[this->uid - 1]);
-  Vector3<double> fv(this->x, this->y, this->z), tv, txv;
+  Vector3<double> fv(this->x, this->y, this->z), tv = {}, txv = {};
 
   // TODO: Add points to point cloud
 	// traverse all splay shots from given station, calculate normalized position and add

--- a/thdb1d.h
+++ b/thdb1d.h
@@ -46,18 +46,18 @@ enum {
 };
 
 struct thdb1d_loop_leg {
-  thdb1d_loop_leg * next_leg, * prev_leg;
-  thdataleg * leg;
-  bool reverse;
+  thdb1d_loop_leg * next_leg = {}, * prev_leg = {};
+  thdataleg * leg = {};
+  bool reverse = {};
 };
 
 struct thdb1d_loop {
-  thdb1d_loop_leg * first_leg, * last_leg;
-  class thdb1ds * from, * to;
-  unsigned long nlegs;
-  unsigned long id;
-  bool open;
-  double err_dx, err_dy, err_dz, err_length, src_length, err;
+  thdb1d_loop_leg * first_leg = {}, * last_leg = {};
+  class thdb1ds * from = {}, * to = {};
+  unsigned long nlegs = {};
+  unsigned long id = {};
+  bool open = {};
+  double err_dx = {}, err_dy = {}, err_dz = {}, err_length = {}, src_length = {}, err = {};
 };
 
 struct thdb1d_traverse {

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -2378,10 +2378,10 @@ void thdb2d::pp_morph_points(thdb2dprj * prj)
 
 
 struct joincand {
-	th2ddataobject * obj;
-	thdb2dlp * lp;
-	thdb2dpt * pt;
-	long fileid;
+	th2ddataobject * obj = {};
+	thdb2dlp * lp = {};
+	thdb2dpt * pt = {};
+	long fileid = {};
 };
 
 
@@ -3421,8 +3421,8 @@ thdb2dprj * thdb2d::get_projection(int id) {
 
 
 struct area_proc {
-  tharea * area;
-  double x, y, a, s;
+  tharea * area = {};
+  double x = {}, y = {}, a = {}, s = {};
 };
 
 void thdb2d::process_areas_in_projection(thdb2dprj * prj)

--- a/thepsparse.h
+++ b/thepsparse.h
@@ -68,8 +68,8 @@ struct CGS {  // current graphics state
 };
 
 struct MP_transform {
-  int command;
-  double transf[6];
+  int command = {};
+  double transf[6] = {};
   
   MP_transform();
   void clear();
@@ -78,15 +78,15 @@ struct MP_transform {
 };
 
 struct MP_path_segment {
-  int command;
-  double coord[6];
+  int command = {};
+  double coord[6] = {};
 };
 
 struct MP_path {
   std::vector<MP_path_segment> segments;
-  bool closed;
+  bool closed = {};
 //  bool clip;  mp nevie orezat aj vykreslit
-  int fillstroke;
+  int fillstroke = {};
   MP_transform transformation;
 //  bool transform;
   
@@ -100,14 +100,14 @@ struct MP_path {
 };
 
 struct MP_index {
-  int vector, idx;
+  int vector = {}, idx = {};
 };
 
 struct MP_text {
   std::string text, font;
-  double size, x, y, xx, xy, yx, yy;
+  double size = {}, x = {}, y = {}, xx = {}, xy = {}, yx = {}, yy = {};
   color col;    // color of the associated scrap
-  bool transformed;
+  bool transformed = {};
   
   MP_text();
   void clear();
@@ -195,18 +195,18 @@ struct converted_data {
 
 struct pattern {
   converted_data data;
-  float llx, lly, urx, ury, xstep, ystep;
-  double llx1,lly1,urx1,ury1;
-  double xx, xy, yx, yy, x, y;
+  float llx = {}, lly = {}, urx = {}, ury = {}, xstep = {}, ystep = {};
+  double llx1 = {},lly1 = {},urx1 = {},ury1 = {};
+  double xx = {}, xy = {}, yx = {}, yy = {}, x = {}, y = {};
   std::string name;
-  bool used;
+  bool used = {};
 };
 
 struct gradient {
-  int type;
-  double x0, y0, r0, x1, y1, r1;
+  int type = {};
+  double x0 = {}, y0 = {}, r0 = {}, x1 = {}, y1 = {}, r1 = {};
   color c0, c1;
-  bool used_in_map;
+  bool used_in_map = {};
 };
 
 int thconvert_eps();

--- a/thexpshp.h
+++ b/thexpshp.h
@@ -44,7 +44,7 @@ struct thexpshpf_data {
 };
 
 struct thexpshpf_part {
-  int m_type, m_start;
+  int m_type = {}, m_start = {};
 };
 
 

--- a/thexpuni.h
+++ b/thexpuni.h
@@ -61,7 +61,7 @@ struct thexpuni {
   thexpuni();
   void clear();
 
-  thexpuni_part * m_cpart;
+  thexpuni_part * m_cpart = {};
   std::list<thexpuni_data> m_ring_list;
   void polygon_start_ring(bool outer);
   void polygon_insert_line(thline * ln, bool reverse);

--- a/thgrade.h
+++ b/thgrade.h
@@ -68,8 +68,8 @@ class thgrade : public thdataobject {
   
   public:
 
-  double dls_length, dls_gradient, dls_bearing, dls_counter, dls_depth,
-    dls_dx, dls_dy, dls_dz, dls_x, dls_y, dls_z;
+  double dls_length = {}, dls_gradient = {}, dls_bearing = {}, dls_counter = {}, dls_depth = {},
+    dls_dx = {}, dls_dy = {}, dls_dz = {}, dls_x = {}, dls_y = {}, dls_z = {};
   
   /**
    * Standard constructor.

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -42,7 +42,7 @@
 
 struct thsst {
   std::string name, fullname;
-  thsurvey * survey;  
+  thsurvey * survey = {};  
 };
 
 
@@ -365,12 +365,12 @@ const char * thimport::station_name(const char * sn, const char separator, struc
 }
 
 struct thimg_shot {
-  double fx, fy, fz, tx, ty, tz;
-  long flags;
+  double fx = {}, fy = {}, fz = {}, tx = {}, ty = {}, tz = {};
+  long flags = {};
 };
 
 struct thimg_stpos {
-  double x, y, z;
+  double x = {}, y = {}, z = {};
 };
 
 bool operator < (const thimg_stpos & p1, 

--- a/thlayout.h
+++ b/thlayout.h
@@ -600,7 +600,7 @@ class thlayout : public thdataobject {
   int color_crit; // none, altitude, ...
   const char * color_crit_fname;
 
-  double min_symbol_scale, font_setup[5];
+  double min_symbol_scale, font_setup[5] = {};
 
   
   thlayoutln * first_line, * last_line;

--- a/thmapstat.cxx
+++ b/thmapstat.cxx
@@ -245,7 +245,7 @@ void thmapstat::scanmap(class thmap * map) {
 
 struct thmapstat_person_data {
   thperson person;
-  double crit;
+  double crit = {};
   bool operator < (const thmapstat_person_data& x) const
   {
 	  if (crit > x.crit)
@@ -262,7 +262,7 @@ struct thmapstat_person_data {
 struct thmapstat_copyright_data {
   thmapstat_copyright copy;
   thmapstat_data data;
-  double crit;
+  double crit = {};
   bool operator < (const thmapstat_copyright_data& x) const
   {
 	  if (crit > x.crit)

--- a/thmapstat.h
+++ b/thmapstat.h
@@ -60,7 +60,7 @@ class thmapstat_copyright {
   friend bool operator < (const thmapstat_copyright & c1, 
       const thmapstat_copyright & c2);
   
-  const char * str;  
+  const char * str = {};  
   
 };
 

--- a/thobjectname.h
+++ b/thobjectname.h
@@ -42,12 +42,12 @@ class thobjectname {
 
   public:
   
-  const char * name,  ///< Object name.
-      * survey;  ///< Survey name.
+  const char * name = {},  ///< Object name.
+      * survey = {};  ///< Survey name.
        
   class thsurvey * psurvey = nullptr; ///< Parent survey.
        
-  unsigned long id;  ///< Object identifier.
+  unsigned long id = {};  ///< Object identifier.
 
   /**
    * Standard constructor.

--- a/thpdfdata.h
+++ b/thpdfdata.h
@@ -34,8 +34,8 @@
 enum class shading_mode {off, quick};  // add precise
 
 struct surfpictrecord {
-  const char * filename, * type;
-  double dx, dy, xx, xy, yx, yy, width, height;
+  const char * filename = {}, * type = {};
+  double dx = {}, dy = {}, xx = {}, xy = {}, yx = {}, yy = {}, width = {}, height = {};
 };
 
 struct scraprecord {
@@ -85,7 +85,7 @@ struct layerrecord {
 struct legendrecord {
   std::string name, fname, descr;
   converted_data ldata;
-  unsigned idsym, idfig, idnum;
+  unsigned idsym = {}, idfig = {}, idnum = {};
 };
 
 struct colorlegendrecord {

--- a/thperson.h
+++ b/thperson.h
@@ -35,9 +35,9 @@
  
 class thperson {
 
-  const char * n1,  ///< First name.
-    * n2,  ///< Second name.
-    * nn;  ///< Identification string.
+  const char * n1 = {},  ///< First name.
+    * n2 = {},  ///< Second name.
+    * nn = {};  ///< Identification string.
     
   void reset();  ///< Reset person names.
   

--- a/thscrap.h
+++ b/thscrap.h
@@ -97,7 +97,7 @@ class thscrap : public thdataobject {
   class th2ddataobject * fs2doptr,  ///< First scrap 2D object.
     * ls2doptr;  ///< Last scrap 2D object.
     
-  double lxmin, lxmax, lymin, lymax; ///< Coordinate limits.
+  double lxmin = {}, lxmax = {}, lymin = {}, lymax = {}; ///< Coordinate limits.
 
   unsigned long RGBsrc;
 
@@ -120,7 +120,7 @@ class thscrap : public thdataobject {
   int scale_cs;
   bool scale_p9; ///< 9 parameters scaling
   
-  double mx, my, mxx, mxy, myx, myy, mr, ms;  ///< Calibration coefficients.
+  double mx = {}, my = {}, mxx = {}, mxy = {}, myx = {}, myy = {}, mr = {}, ms = {};  ///< Calibration coefficients.
   
   double maxdist, avdist;
   thdb2dpt * maxdistp1, * maxdistp2;

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -154,8 +154,8 @@ class thselector_select_item {
   
   public:
 
-  thdataobject * objp;
-  const char * n1, * n2, * n3;
+  thdataobject * objp = {};
+  const char * n1 = {}, * n2 = {}, * n3 = {};
   
   void clear();
   

--- a/thsymbolset.h
+++ b/thsymbolset.h
@@ -47,8 +47,8 @@ struct thsymbolset_usym {
  
 struct thsymbolset {
   
-  bool assigned[thsymbolset_size],        ///< definovane symboly
-    used[thsymbolset_size];               ///< pouzite symboly
+  bool assigned[thsymbolset_size] = {},        ///< definovane symboly
+    used[thsymbolset_size] = {};               ///< pouzite symboly
   thlayout_color color[thsymbolset_size];    ///< Symbol colors.
   int color_model; ///< Output color model.
   

--- a/thtexfonts.h
+++ b/thtexfonts.h
@@ -34,9 +34,9 @@
 std::string select_lang(std::string s, std::string lang);
 
 struct fontrecord {
-  int id;
+  int id = {};
   std::string rm,it,bf,ss,si;
-  bool opt;
+  bool opt = {};
 };
 
 extern std::list <fontrecord> FONTS;

--- a/thtrans.cxx
+++ b/thtrans.cxx
@@ -493,8 +493,8 @@ typedef std::list<thm2t_zoom_point> thm2t_zoom_point_list;
 
 
 struct thm2t_feature {
-  bool m_single;
-  thm2t_point_ptr m_fp, m_tp;
+  bool m_single = {};
+  thm2t_point_ptr m_fp = {}, m_tp = {};
   thline2 m_ln, m_lnf, m_lnt;
   thlintrans m_lintrans;
   thlinzoomtrans m_zoomtrans;

--- a/thtrans.h
+++ b/thtrans.h
@@ -201,7 +201,7 @@ struct thlintrans {
   thmat2 m_fmat;           //!< forward matrix
   thmat2 m_bmat;           //!< backward matrix
   thvec2 m_shift;
-  double m_rot, m_scale;
+  double m_rot = {}, m_scale = {};
 
   thlintrans_pt_list m_initpts;
 
@@ -267,7 +267,7 @@ struct thmorphtrans {
 struct thmorph2trans {
   
   struct thmorph2trans_members * m;
-  double m_eps;
+  double m_eps = {};
 
   thmorph2trans();
   ~thmorph2trans();

--- a/thwarpp.h
+++ b/thwarpp.h
@@ -43,8 +43,8 @@ class thscrap;
  */
 
 struct thsketchst {
-  thmorph_type code;     //!< station code
-  double x, y;           //!< station image coords
+  thmorph_type code = {};     //!< station code
+  double x = {}, y = {};           //!< station image coords
   thobjectname station;  //!< station survey name
   thobjectsrc source;
 };
@@ -54,7 +54,7 @@ struct thsketchst {
  */
 
 struct thsketchlg {
-  thmorph_type code;    //!< leg code
+  thmorph_type code = {};    //!< leg code
   thobjectname from;    //!< station survey name
   thobjectname to;      //!< station survey name
   thobjectsrc source;

--- a/thwarppme.h
+++ b/thwarppme.h
@@ -312,8 +312,8 @@ namespace therion
     struct item 
     {
       protected:
-        double m_theta_l;  //!< left angle
-	double m_theta_r;  //!< right angle
+        double m_theta_l = {};  //!< left angle
+	double m_theta_r = {};  //!< right angle
 
       public:
         /** default cstr is fine */
@@ -435,9 +435,9 @@ namespace therion
         double m_bound;             //!< this basic_pair bound
     
       public:
-        basic_pair * m_ngbh[THWARP_NGBH_DIM];     //!< this basic_pair neighbors
-        point_pair * m_pair[THWARP_PAIR_DIM];  //!< pointer to the point_pairs
-        double m_ndist[THWARP_NGBH_DIM];       //!< neighbors distances
+        basic_pair * m_ngbh[THWARP_NGBH_DIM] = {};     //!< this basic_pair neighbors
+        point_pair * m_pair[THWARP_PAIR_DIM] = {};  //!< pointer to the point_pairs
+        double m_ndist[THWARP_NGBH_DIM] = {};       //!< neighbors distances
         double m_kl;                     //!< left angle differences (from - to)
         double m_kr;                     //!< right angle differences (from - to)
 	double m_dl;                     //!< left end-size ratio (from/to)
@@ -1101,25 +1101,25 @@ namespace therion
 	thvec2 m_bcn;               //!< unit vector BC
 	thvec2 m_abn;               //!< unit vector from A to B
         thvec2 m_abh;               //!< unit orthogonal vector
-        double m_AB_len;            //!< length of AB
+        double m_AB_len = {};            //!< length of AB
 
-        double m_a, m_b, m_c, m_d, m_e, m_f, m_g, m_h; 
-        double m_A0, m_B0, m_C0;
-        double m_D0, m_E0, m_F0;
+        double m_a = {}, m_b = {}, m_c = {}, m_d = {}, m_e = {}, m_f = {}, m_g = {}, m_h = {}; 
+        double m_A0 = {}, m_B0 = {}, m_C0 = {};
+        double m_D0 = {}, m_E0 = {}, m_F0 = {};
 
-        double m_adab;   //!< ad ^ ab
-        double m_bcab;   //!< bc ^ ab
-        double m_adA;    //!< ad ^ A
-        double m_bcB;    //!< bc ^ B
+        double m_adab = {};   //!< ad ^ ab
+        double m_bcab = {};   //!< bc ^ ab
+        double m_adA = {};    //!< ad ^ A
+        double m_bcB = {};    //!< bc ^ B
         thvec2 m_AB;     //!< vector AB = B - A
 	thvec2 m_BA;     //!< vector BA (= -m_AB)
         thvec2 m_C1;
         thvec2 m_C1C;
 
-        double m_AD_len;  //!< length of AD
-        double m_BC_len;  //!< length of BC
+        double m_AD_len = {};  //!< length of AD
+        double m_BC_len = {};  //!< length of BC
 
-        double m_tan, m_ctg, m_cos, m_sin; // coeff for the "normal" direction
+        double m_tan = {}, m_ctg = {}, m_cos = {}, m_sin = {}; // coeff for the "normal" direction
 
 	double (plaquette::* s_map_impl)( const thvec2 & p ) const;
         void (plaquette::* bn_map_impl)( const thvec2 & p, thvec2 & ret ) const;


### PR DESCRIPTION
Fix warnings reported by `clang-tidy`'s check `cppcoreguidelines-pro-type-member-init`.