### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ jobs:
           - { os: ubuntu-22.04, toolchain: clang-sanitizers.cmake, args: ""                                                }
           - { os: ubuntu-22.04, toolchain: gcc.cmake,              args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug" }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           sudo apt -qq update
@@ -35,7 +35,7 @@ jobs:
       - name: Run samples
         if: matrix.toolchain == 'clang-sanitizers.cmake'
         run: cmake --build build -t samples-verify-crc
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: matrix.toolchain == 'clang-sanitizers.cmake' && always()
         with:
           name: samples-${{ matrix.os }}-${{ matrix.toolchain }}
@@ -49,13 +49,13 @@ jobs:
       matrix:
         os: [macos-12, macos-13, macos-14]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete -print
           brew unlink python && brew link --overwrite python
           brew update  # try to comment out in case of package problems
-          brew install wxwidgets vtk proj xquartz ninja basictex fmt pkgconfig catch2
+          brew install wxwidgets vtk proj xquartz ninja basictex fmt catch2
       - name: Configure CMake
         run: |
           mkdir build && cd build && cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/sanitizers.cmake -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DOPENGL_gl_LIBRARY:FILEPATH=/opt/X11/lib/libGL.dylib -DOPENGL_glu_LIBRARY:FILEPATH=/opt/X11/lib/libGLU.dylib -DBUILD_THBOOK=OFF ..
@@ -68,7 +68,7 @@ jobs:
           sudo tlmgr install collection-langcyrillic
           sudo tlmgr install collection-langczechslovak
           cmake --build build -t samples-build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: samples-${{ matrix.os }}
@@ -90,7 +90,7 @@ jobs:
       THDIR: d:/a/therion
       PROJ_LIB: d:/a/therion/proj-lib
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.config.msystem }}
@@ -105,7 +105,7 @@ jobs:
           wget -qO - https://github.com/therion/therion-batteries/archive/master.tar.gz | tar -xzf - && mv therion-batteries-master ../therion-batteries
           mkdir -p ../proj-lib && cp -r ../therion-batteries/_proj/{proj-$(awk -F "=" '/version/{print $2}' build/innosetup.ini),proj-datumgrid}/. ../proj-lib
           cmake --build build -t samples-build -- -j 4
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: samples-windows-${{ matrix.config.msystem }}
@@ -120,7 +120,7 @@ jobs:
   #         - { os: ubuntu-20.04, osname: focal, pkg: i686,   cmd: i686,   wine-pkg: wine32, wine: wine }
   #         - { os: ubuntu-20.04, osname: focal, pkg: x86-64, cmd: x86_64, wine-pkg: wine64, wine: wine64-stable }
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - name: install dependencies
   #       run: |
   #         sudo dpkg --add-architecture i386

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -7,14 +7,14 @@ jobs:
     - name: Enable parallel compilation
       run:  echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Dependencies
       run: |
         sudo apt -qq update
         sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build gettext libfmt-dev catch2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -10,7 +10,7 @@ jobs:
   #     THDIR: /home/runner/work/therion
   #     PROJ_LIB: /home/runner/work/therion/proj-lib
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #       with:
   #         fetch-depth: 0
   #     - name: install dependencies
@@ -52,7 +52,7 @@ jobs:
   #         cd ../therion.bin
   #         mv therion-setup.exe therion-setup-$THID.exe
   #         mv thbook/thbook.pdf thbook-$THID.pdf
-  #     - uses: 'actions/upload-artifact@v3'
+  #     - uses: 'actions/upload-artifact@v4'
   #       with:
   #         name: therion-setup-mxe-${{ steps.build.outputs.THID_out }}
   #         path: |
@@ -81,7 +81,7 @@ jobs:
           install: make git python mingw-w64-${{ matrix.config.arch }}-freetype mingw-w64-${{ matrix.config.arch }}-cmake mingw-w64-${{ matrix.config.arch }}-proj mingw-w64-${{ matrix.config.arch }}-shapelib mingw-w64-${{ matrix.config.arch }}-vtk mingw-w64-${{ matrix.config.arch }}-wxWidgets3.2 mingw-w64-${{ matrix.config.arch }}-gcc mingw-w64-${{ matrix.config.arch }}-make mingw-w64-${{ matrix.config.arch }}-bwidget mingw-w64-${{ matrix.config.arch }}-fmt mingw-w64-${{ matrix.config.arch }}-catch
       - name: prevent git EOL conversion
         run: git config --global core.autocrlf input
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: build and create the installation package
@@ -107,7 +107,7 @@ jobs:
           cd ../therion.bin
           mv therion-setup.exe therion-setup-$THID.exe
           mv thbook/thbook.pdf thbook-$THID.pdf
-      - uses: 'actions/upload-artifact@v3'
+      - uses: 'actions/upload-artifact@v4'
         with:
           name: therion-setup-msys2-${{ steps.build.outputs.THID_out }}
           path: |

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -4,7 +4,7 @@ jobs:
   ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           sudo apt -qq update
@@ -21,13 +21,13 @@ jobs:
   mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: |
           # brew update  # commented out because of conflicting python versions
           brew tap homebrew/core
           rm /usr/local/bin/2to3
-          brew install wxwidgets vtk proj fmt pkgconfig
+          brew install wxwidgets vtk proj fmt
       - name: compile therion
         run: |
           make config-macosx
@@ -38,7 +38,7 @@ jobs:
   # mxe-i686:
   #   runs-on: ubuntu-20.04
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - name: install dependencies
   #       run: |
   #         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
@@ -56,7 +56,7 @@ jobs:
   # mxe-x86_64:
   #   runs-on: ubuntu-20.04
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - name: install dependencies
   #       run: |
   #         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
@@ -82,7 +82,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}


### PR DESCRIPTION
Fixed following warnings on GitHub Actions:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

```
CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
```

```
Warning: pkg-config 0.29.2_3 is already installed and up-to-date.
```