### PR TITLE
Fix xtherion line artifact

### DIFF
--- a/xtherion/me_cmds2.tcl
+++ b/xtherion/me_cmds2.tcl
@@ -3156,7 +3156,7 @@ proc xth_me_cmds_set_colors {} {
 	  }   
 	}
 	$xth(me,can) itemconfigure lnpt$id -outline $col -fill $col -state normal
-	$xth(me,can) itemconfigure lnln$id -fill $col -state normal
+	$xth(me,can) itemconfigure lnln$id -fill $col
 	if {$xth(me,hinactives) && ($col == $dcol)} {
 	  $xth(me,can) itemconfigure ln$id -state hidden  
 	}


### PR DESCRIPTION
Fixes a regression from v5.3.14 where xtherion displays a line fragment at position `[(0, 0), (10, 10)]` for every line.

Line was previously changed here: https://github.com/therion/therion/compare/v5.3.13...v5.3.14#diff-83001d07ad7e0f90bbec2bab18115c6c336170ebb8ac189a0669e777a9bc5353L3111

![clipboard](https://github.com/therion/therion/assets/1239490/b6e3a5af-7731-4f23-be6d-a47180589887)