### PR TITLE
Length can also be equal to depth change (verticals)

### DIFF
--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -219,7 +219,7 @@ void thdb1d::scan_data()
               else
                 dcc = lei->todepth - lei->fromdepth;
               lei->depthchange = dcc;  
-              if (fabs(dcc) > lei->length)
+              if (fabs(dcc) >= lei->length)
                 ththrow("length reading is less than change in depth");
             }
             


### PR DESCRIPTION
Small fix but allows vertical sections where length is actually equal to change of depth. 

Has nothing to do with excel calculations, rounding errors or truncation of decimals (!?) 