### PR TITLE
New setting to disable "normalized" xtherion geometry

### DIFF
--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -43,6 +43,7 @@ set xth(gui,help) ".xth_help"
 set xth(gui,message) ".xthmsg"
 #set xth(gui,minsize) {480 300}
 set xth(gui,minsize) {720 576}
+set xth(gui,init_app_normalized) 1
 set xth(gui,balloons) 0
 set xth(gui,toolbar) 1
 set xth(te,template) {}

--- a/xtherion/init.tcl
+++ b/xtherion/init.tcl
@@ -81,8 +81,10 @@ toplevel $xth(gui,main)
 wm withdraw $xth(gui,main)
 wm protocol $xth(gui,main) WM_DELETE_WINDOW "xth_exit"
 wm title $xth(gui,main) $xth(prj,name)
-wm geometry $xth(gui,main) [format "%dx%d+0+0" [lindex $xth(gui,minsize) 0] \
-  [lindex $xth(gui,minsize) 1]]
+if {$xth(gui,init_app_normalized)} {
+  wm geometry $xth(gui,main) [format "%dx%d+0+0" [lindex $xth(gui,minsize) 0] \
+    [lindex $xth(gui,minsize) 1]]
+}
 wm minsize $xth(gui,main) [lindex $xth(gui,minsize) 0] \
   [lindex $xth(gui,minsize) 1]
 update idletasks

--- a/xtherion/main.tcl
+++ b/xtherion/main.tcl
@@ -33,7 +33,9 @@ set xth(encoding_system) [encoding system]
 xth_about_hide
 
 wm deiconify $xth(gui,main)
-xth_app_normalize
+if {$xth(gui,init_app_normalized)} {
+  xth_app_normalize
+}
 
 foreach xapp $xth(app,list) {
   catch {

--- a/xtherion/xtherion.ini
+++ b/xtherion/xtherion.ini
@@ -28,6 +28,9 @@
 ## Enable/disable balloon hints
 # set xth(gui,balloons) 0
 
+## Normalize main window at startup
+# set xth(gui,init_app_normalized) 1
+
 ## Enable/disable auto save at startup
 # set xth(gui,auto_save) 0
 


### PR DESCRIPTION
`xtherion` always starts with "normalized" window geometry. On Linux (KDE) with dual-monitor setup, "normalized" spans both screens which is not very useful and quite annoying.

This patch adds a new setting `$xth(gui,init_app_normalized)` which allows disabling any geometry adjustment when `xtherion` starts.