### PR TITLE
xtherion: Remove check for Img package

### DIFF
--- a/xtherion/init.tcl
+++ b/xtherion/init.tcl
@@ -27,18 +27,10 @@
 
 package require BWidget
 
-if {[catch {set imgver [package require Img]}]} {
-  set xth(gui,imgfiletypes) {
-	   { {Pictures} {.gif .pnm .ppm .xvi .GIF .PNM .PPM .XVI} }
-	   { {PocketTopo therion export} {.txt .TXT} }
-	   { {All Files}               * }
-	 } 
-} else {
-  set xth(gui,imgfiletypes) {
-	   { {Pictures} {.png .jpeg .jpg .gif .pnm .ppm .xvi .PNG .JPEG .JPG .GIF .PNM .PPM .XVI} }
-	   { {PocketTopo therion export} {.txt .TXT} }
-	   { {All Files}                                               * }
-	 } 
+set xth(gui,imgfiletypes) {
+  { {Pictures} {.png .jpeg .jpg .gif .pnm .ppm .xvi .PNG .JPEG .JPG .GIF .PNM .PPM .XVI} }
+  { {PocketTopo Therion Export} {.txt .TXT} }
+  { {All Files} * }
 }
 
 # read xtherion.ini file from THERION directory


### PR DESCRIPTION
This commit removes a check for the Img package, which determined the
image file types that would be recognised by XTherion.  This check
appears to be redundant because if the user enables "all file types"
they can select a PNG, furthermore XTherion is able to work with PNGs
despite the Img package not being present.

Closes: #479