### PR TITLE
Removed redundant include

### DIFF
--- a/thdata.cxx
+++ b/thdata.cxx
@@ -34,6 +34,7 @@
 #include "thcsdata.h"
 #include "thdatareader.h"
 #include "thdatabase.h"
+#include "therion.h"
 #include "loch/icase.h"
 
 thdata::thdata()

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -51,6 +51,7 @@
 #include "thendscrap.h"
 #include "thconfig.h"
 #include "thproj.h"
+#include "therion.h"
 
 
 const char * thlibrarydata_init_text =

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -49,6 +49,7 @@
 #include "loch/lxMath.h"
 #include "thcsdata.h"
 #include "thgeomagdata.h"
+#include "therion.h"
 #include "QuickHull.hpp"
 
 //#define THUSESVX

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -45,6 +45,7 @@
 #include "thtmpdir.h"
 #include "thinit.h"
 #include "thfilehandle.h"
+#include "therion.h"
 #include <list>
 #include <set>
 #include <iterator>

--- a/thdb2d00.cxx
+++ b/thdb2d00.cxx
@@ -35,6 +35,7 @@
 #include "thconfig.h"
 #include <list>
 #include <algorithm>
+#include <cstring>
 #include "thmapstat.h"
 
 void thdb2d::insert_basic_maps(thdb2dxm * fmap, thmap * map, int mode, int level, thdb2dmi_shift shift) {

--- a/thexpdb.cxx
+++ b/thexpdb.cxx
@@ -38,6 +38,7 @@
 #include "thchenc.h"
 #include <map>
 #include "thinfnan.h"
+#include "therion.h"
 
 thexpdb::thexpdb() {
   this->format = TT_EXPDB_FMT_UNKNOWN;

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -63,6 +63,7 @@
 #include "thcsdata.h"
 #include "thproj.h"
 #include "thsurface.h"
+#include "therion.h"
 #include <stdlib.h>
 #include "loch/lxMath.h"
 #include "thsvg.h"

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -44,6 +44,7 @@
 #include "thtexfonts.h"
 #include "thlang.h"
 #include "thfilehandle.h"
+#include "therion.h"
 #include <filesystem>
 
 #include <fmt/printf.h>

--- a/thexporter.cxx
+++ b/thexporter.cxx
@@ -34,6 +34,7 @@
 #include "thexpdb.h"
 #include "thexpsys.h"
 #include "thexptable.h"
+#include "therion.h"
 #include <stdio.h>
 
 

--- a/thexpshp.cxx
+++ b/thexpshp.cxx
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "thcs.h"
+#include "therion.h"
 #include <filesystem>
 
 #include "thexpshp.h"

--- a/thexptable.cxx
+++ b/thexptable.cxx
@@ -40,6 +40,7 @@
 #include "thproj.h"
 #include "thconfig.h"
 #include "thcs.h"
+#include "therion.h"
 #include <filesystem>
 
 

--- a/thexpuni.cxx
+++ b/thexpuni.cxx
@@ -46,6 +46,7 @@
 #include "thproj.h"
 #include "thtexfonts.h"
 #include "thlang.h"
+#include "therion.h"
 
 
 static const char * DXFpre = 

--- a/thgrade.cxx
+++ b/thgrade.cxx
@@ -29,6 +29,7 @@
 #include "thdata.h"
 #include "thparse.h"
 #include "thdatabase.h"
+#include "therion.h"
 
 thgrade::thgrade()
 {

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -31,6 +31,7 @@
 #include "thdata.h"
 #include "thsurvey.h"
 #include "thdatabase.h"
+#include "therion.h"
 #include "img.h"
 #include <string.h>
 #include <string>

--- a/thlayout.cxx
+++ b/thlayout.cxx
@@ -40,6 +40,7 @@
 #include "thconfig.h"
 #include "th2ddataobject.h"
 #include "thdatabase.h"
+#include "therion.h"
 #include <string.h>
 #include <filesystem>
 #include <algorithm>

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -37,6 +37,7 @@
 #include "thlayout.h"
 #include "thtexfonts.h"
 #include "thdatabase.h"
+#include "therion.h"
 #include <string.h>
 
 

--- a/thobjectname.h
+++ b/thobjectname.h
@@ -30,7 +30,6 @@
 #define thobjectname_h
 
 #include "thmbuffer.h"
-#include "therion.h"
 
 #include <string>
 

--- a/thpic.cxx
+++ b/thpic.cxx
@@ -33,6 +33,7 @@
 #include "thtmpdir.h"
 #include "thexception.h"
 #include "thconfig.h"
+#include "therion.h"
 #include <filesystem>
 
 #include <fmt/printf.h>

--- a/thpoint.cxx
+++ b/thpoint.cxx
@@ -36,6 +36,7 @@
 #include "thdate.h"
 #include "thscrap.h"
 #include "thobjectname.h"
+#include "therion.h"
 #include <string>
 #include <cstdio>
 

--- a/thscrap.cxx
+++ b/thscrap.cxx
@@ -40,6 +40,7 @@
 #include "thsketch.h"
 #include "thcsdata.h"
 #include "thdatabase.h"
+#include "therion.h"
 
 #define EXPORT3D_INVISIBLE true
 

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -38,6 +38,7 @@
 #include <vector>
 #include "thchenc.h"
 #include "thmap.h"
+#include "therion.h"
 
 #include <fmt/printf.h>
 

--- a/thsurface.cxx
+++ b/thsurface.cxx
@@ -36,6 +36,7 @@
 #include "thparse.h"
 #include "thdb1d.h"
 #include "thinfnan.h"
+#include "therion.h"
 #include <algorithm>
 #include <filesystem>
 

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -38,6 +38,7 @@
 #include "thsurvey.h"
 #include "thcsdata.h"
 #include "thlogfile.h"
+#include "therion.h"
 #include "img.h"
 #include <math.h>
 #include <string>

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -44,6 +44,7 @@
 #include "thlogfile.h"
 #include "thepsparse.h"
 #include "thdatabase.h"
+#include "therion.h"
 #include <fmt/printf.h>
 
 thsymbolset::thsymbolset()

--- a/thwarp.cxx
+++ b/thwarp.cxx
@@ -34,6 +34,7 @@
 #include "thpoint.h"
 #include "thconfig.h"
 #include "thdatabase.h"
+#include "therion.h"
 #include <cstring>
 
 thwarp::~thwarp() {}


### PR DESCRIPTION
I have removed `therion.h` from `thobjectname.h`, because it was not used there. This is a small but important optimization to further improve compilation times.