### PR TITLE
Move thstok into its own header

### DIFF
--- a/tharea.h
+++ b/tharea.h
@@ -32,6 +32,7 @@
 
 #include "th2ddataobject.h"
 #include "thdb2dab.h"
+#include "thstok.h"
 
 #include <memory>
 

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -28,7 +28,6 @@
 
 #include "thconfig.h"
 #include "therion.h"
-#include "thparse.h"
 #include "thlang.h"
 #include <stdlib.h>
 #include <stdio.h>

--- a/thcs.cxx
+++ b/thcs.cxx
@@ -26,7 +26,6 @@
  */
 
 #include "thcs.h"
-#include "thparse.h"
 #include "thcsdata.h"
 #include "thexception.h"
 #include "thproj.h"

--- a/thcs.h
+++ b/thcs.h
@@ -27,6 +27,7 @@
 
 #include "thcsdata.h"
 #include <map>
+#include <string>
 
 const int TTCS_EPSG = 1000000;
 const int TTCS_ESRI = 2000000;

--- a/thcsdata.tcl
+++ b/thcsdata.tcl
@@ -323,7 +323,7 @@ puts $fid {/**
 #ifndef thcsdata_h
 #define thcsdata_h
  
-#include "thparse.h"
+#include "thstok.h"
  
 #include <map>
 

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -32,7 +32,6 @@
 #include "thobjectid.h"
 #include "thexception.h"
 #include "thdata.h"
-#include "thparse.h"
 #include "thdatastation.h"
 #include "thlookup.h"
 #include "thgrade.h"

--- a/thdataleg.cxx
+++ b/thdataleg.cxx
@@ -27,6 +27,7 @@
  
 #include "thdataleg.h"
 #include "thcsdata.h"
+#include "thparse.h"
 
 thdataleg::thdataleg()
 {

--- a/thdataleg.h
+++ b/thdataleg.h
@@ -29,7 +29,7 @@
 #ifndef thdataleg_h
 #define thdataleg_h
 
-#include "thparse.h"
+#include "thstok.h"
 #include "thobjectname.h"
 #include "thobjectsrc.h"
 #include "thinfnan.h"

--- a/thdataobject.cxx
+++ b/thdataobject.cxx
@@ -30,7 +30,6 @@
 #include "thchenc.h"
 #include "thsurvey.h"
 #include "thconfig.h"
-#include "thparse.h"
 #include "thcsdata.h"
 #include "thdata.h"
 #include "thproj.h"

--- a/thdataobject.h
+++ b/thdataobject.h
@@ -31,7 +31,6 @@
 
 
 #include "thperson.h"
-#include "thparse.h"
 #include "thdate.h"
 #include "thlayoutclr.h"
 #include "thobjectsrc.h"

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -28,7 +28,6 @@
 #include "thdb2d.h"
 #include "thexception.h"
 #include "thdatabase.h"
-#include "thparse.h"
 #include "thtfangle.h"
 #include "tharea.h"
 #include "thmap.h"

--- a/thdb2d00.cxx
+++ b/thdb2d00.cxx
@@ -27,7 +27,6 @@
  
 #include "thdb2d.h"
 #include "thdatabase.h"
-#include "thparse.h"
 #include "thmap.h"
 #include "thscrap.h"
 #include "thsurvey.h"

--- a/thdb2dmi.h
+++ b/thdb2dmi.h
@@ -32,7 +32,7 @@
 #include <list>
 #include "thobjectname.h"
 #include "thobjectsrc.h"
-#include "thparse.h"
+#include "thstok.h"
 
 
 /**

--- a/thdb2dprj.h
+++ b/thdb2dprj.h
@@ -30,7 +30,7 @@
 #define thdb2dprj_h
 
 
-#include "thparse.h"
+#include "thstok.h"
 #include "thmapstat.h"
 #include <map>
 #include <list>

--- a/therion.cxx
+++ b/therion.cxx
@@ -33,6 +33,7 @@
 #include "thline.h"
 #include "tharea.h"
 #include "thlang.h"
+#include "thparse.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/thexport.h
+++ b/thexport.h
@@ -30,7 +30,7 @@
 #define thexport_h
 
 #include <stdio.h>
-#include "thparse.h"
+#include "thbuffer.h"
 #include "thobjectsrc.h"
 #include "thlayout.h"
 #include "loch/icase.h"

--- a/thexporter.h
+++ b/thexporter.h
@@ -31,7 +31,7 @@
 
 
 #include "thexport.h"
-#include "thparse.h"
+#include "thstok.h"
 #include <stdio.h>
 #include <list>
 

--- a/thgrade.cxx
+++ b/thgrade.cxx
@@ -27,7 +27,6 @@
  
 #include "thgrade.h"
 #include "thdata.h"
-#include "thparse.h"
 #include "thdatabase.h"
 #include "therion.h"
 

--- a/thinit.cxx
+++ b/thinit.cxx
@@ -26,7 +26,6 @@
  */
  
 #include "thinit.h"
-#include "thparse.h"
 #include "thchenc.h"
 #include "therion.h"
 #include "thconfig.h"

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -26,7 +26,6 @@
  */
  
 #include "thinput.h"
-#include "thparse.h"
 #include "thchencdata.h"
 #include "therion.h"
 #include "thexception.h"

--- a/thinput.h
+++ b/thinput.h
@@ -31,7 +31,6 @@
 
 #include "thbuffer.h"
 #include "thmbuffer.h"
-#include "thparse.h"
 #include <fstream>
 #include <memory>
 

--- a/thjoin.cxx
+++ b/thjoin.cxx
@@ -27,7 +27,6 @@
  
 #include "thjoin.h"
 #include "thexception.h"
-#include "thparse.h"
 #include "thdatabase.h"
 
 thjoin::thjoin()

--- a/thlang.cxx
+++ b/thlang.cxx
@@ -26,7 +26,6 @@
  */
  
 #include "thlang.h"
-#include "thparse.h"
 #include "thlangdatafields.h"
 #include "thinit.h"
 #include "thconfig.h"

--- a/thlang.h
+++ b/thlang.h
@@ -30,7 +30,7 @@
 #define thlang_h
 
 #include "thlangdata.h"
-#include "thparse.h"
+#include "thstok.h"
 
 const char * thT(const char * txt, int lng = THLANG_UNKNOWN);
 

--- a/thlang/process.pl
+++ b/thlang/process.pl
@@ -218,7 +218,7 @@ ENDOUT
  */
 
 #include "thlangdata.h"
-#include "thparse.h"
+#include "thstok.h"
 #include <cstddef>
 
 typedef const char * thlang_pchar;

--- a/thlayout.cxx
+++ b/thlayout.cxx
@@ -30,7 +30,6 @@
 #include "thexception.h"
 #include "thchenc.h"
 #include "thtfangle.h"
-#include "thparse.h"
 #include "thinfnan.h"
 #include "thpdfdata.h"
 #include "thsymbolset.h"

--- a/thlayoutclr.cxx
+++ b/thlayoutclr.cxx
@@ -26,7 +26,6 @@
  */
  
 #include "thlayoutclr.h"
-#include "thparse.h"
 #include "thdatabase.h"
 #include "thexception.h"
 #include <cmath>

--- a/thlayoutclr.h
+++ b/thlayoutclr.h
@@ -29,7 +29,7 @@
 #ifndef thlayoutclr_h
 #define thlayoutclr_h
 
-#include "thparse.h"
+#include "thstok.h"
 #include "thpdfdata.h"
 #include <stdio.h>
 

--- a/thline.cxx
+++ b/thline.cxx
@@ -27,7 +27,6 @@
 
 #include "thline.h"
 #include "thexception.h"
-#include "thparse.h"
 #include "thchenc.h"
 #include "thdb2dlp.h"
 #include "thexpmap.h"

--- a/thlookup.cxx
+++ b/thlookup.cxx
@@ -28,7 +28,6 @@
 #include "thlookup.h"
 #include "thexception.h"
 #include "thchenc.h"
-#include "thparse.h"
 #include "thinfnan.h"
 #include "thpdfdata.h"
 #include "thlang.h"

--- a/thobjectname.cxx
+++ b/thobjectname.cxx
@@ -27,7 +27,6 @@
  
 #include "thobjectname.h"
 #include "thexception.h"
-#include "thparse.h"
 #include "thdatabase.h"
 #include "thdataobject.h"
 #include "thsurvey.h"

--- a/thparse.cxx
+++ b/thparse.cxx
@@ -26,7 +26,6 @@
  * --------------------------------------------------------------------
  */
 
-#include "thparse.h"
 #include "therion.h"
 #include "thlang.h"
 #include "thtexfonts.h"

--- a/thparse.h
+++ b/thparse.h
@@ -33,6 +33,7 @@
 #include <string>
 #include "thbuffer.h"
 #include "thmbuffer.h"
+#include "thstok.h"
 
 
 enum {
@@ -40,15 +41,6 @@ enum {
   TT_IMG_TYPE_JPEG,
   TT_IMG_TYPE_PNG,
 };
-
-/**
- * Token definition structure.
- */
-
-typedef struct {
-  const char * s;  ///< String.
-  int tok;  ///< Token.
-} thstok;
 
 
 /**

--- a/thperson.cxx
+++ b/thperson.cxx
@@ -27,7 +27,6 @@
  
 #include "thperson.h"
 #include "thdatabase.h"
-#include "thparse.h"
 #include "thexception.h"
 #include <string.h>
 

--- a/thpoint.h
+++ b/thpoint.h
@@ -31,7 +31,7 @@
 
 
 #include "th2ddataobject.h"
-#include "thparse.h"
+#include "thstok.h"
 #include "thdb2dpt.h"
 #include "thobjectname.h"
 

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -30,7 +30,6 @@
 #include "thconfig.h"
 #include <stdio.h>
 #include <string.h>
-#include "thparse.h"
 #include "thdatabase.h"
 #include "thdataobject.h"
 #include "thsurvey.h"

--- a/thstok.h
+++ b/thstok.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/**
+ * Token definition structure.
+ */
+struct thstok {
+  const char * s = {};  ///< String.
+  int tok = {};  ///< Token.
+};

--- a/thsurface.cxx
+++ b/thsurface.cxx
@@ -33,7 +33,6 @@
 #include "thcsdata.h"
 #include <cmath>
 #include "thdatareader.h"
-#include "thparse.h"
 #include "thdb1d.h"
 #include "thinfnan.h"
 #include "therion.h"

--- a/thsurvey.h
+++ b/thsurvey.h
@@ -33,6 +33,7 @@
 #include "thtfpwf.h"
 #include "thperson.h"
 #include "thdata.h"
+#include "thbuffer.h"
 #include <map>
 #include <memory>
 

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -26,7 +26,6 @@
  */
 
 #include "thsymbolset.h"
-#include "thparse.h"
 #include "thpoint.h"
 #include "thline.h"
 #include "tharea.h"

--- a/thtfangle.h
+++ b/thtfangle.h
@@ -30,7 +30,7 @@
 #define thtfangle_h
 
 #include "thtf.h"
-#include "thparse.h"
+#include "thstok.h"
 
 
 enum {TT_TFU_DEG, TT_TFU_DMS, TT_TFU_GRAD, TT_TFU_MIN, TT_TFU_PERC, TT_TFU_UNKNOWN_ANGLE, TT_TFU_MILS};

--- a/thtflength.cxx
+++ b/thtflength.cxx
@@ -28,6 +28,7 @@
 
 #include "thtflength.h"
 #include "thexception.h"
+#include "thparse.h"
 
 thtflength::thtflength() : thtf(TT_TFU_M) {}
 

--- a/thtflength.h
+++ b/thtflength.h
@@ -30,7 +30,7 @@
 #define thtflength_h
 
 #include "thtf.h"
-#include "thparse.h"
+#include "thstok.h"
 
 
 enum {TT_TFU_YD, TT_TFU_FT, TT_TFU_IN, TT_TFU_M, TT_TFU_CM, TT_TFU_MM, TT_TFU_UNKNOWN_LENGTH};
@@ -61,7 +61,7 @@ static const thstok thtt_tfunits_length[] = {
   {"yard", TT_TFU_YD},
   {"yards", TT_TFU_YD},
   {"yd", TT_TFU_YD},
-	{NULL, TT_TFU_UNKNOWN_LENGTH},
+	{nullptr, TT_TFU_UNKNOWN_LENGTH},
 };
 
 


### PR DESCRIPTION
Some files include `thparse.h` only to get a definition of `thstok`. After this change `thparse.h` is included only in 9 `.cxx` files.