### PR TITLE
Removed include thpdfdata.h from thlayoutclr.h

### DIFF
--- a/thlayoutclr.cxx
+++ b/thlayoutclr.cxx
@@ -28,6 +28,7 @@
 #include "thlayoutclr.h"
 #include "thdatabase.h"
 #include "thexception.h"
+#include "thepsparse.h"
 #include <cmath>
 #include <fmt/printf.h>
 

--- a/thlayoutclr.h
+++ b/thlayoutclr.h
@@ -30,8 +30,8 @@
 #define thlayoutclr_h
 
 #include "thstok.h"
-#include "thpdfdata.h"
 #include <stdio.h>
+#include <string>
 
 enum {
   TT_LAYOUTCLRMODEL_UNKNOWN = 0,
@@ -64,7 +64,7 @@ struct thlayout_color {
   thlayout_color(double c, double m, double y, double k) : R(0.0), G(0.0), B(0.0), A(1.0), C(c), M(m), Y(y), K(k), W(1-k), defined(0), model(TT_LAYOUTCLRMODEL_CMYK) {}
   void copy_color(const thlayout_color& src);
   bool is_defined();
-  void set_color(int output_model, color & clr);
+  void set_color(int output_model, struct color & clr);
   void print_to_file(int output_model, FILE * f);
   std::string print_to_str(int output_model);
   void encode_to_str(int output_model, std::string & str);  

--- a/thsymbolset.h
+++ b/thsymbolset.h
@@ -32,6 +32,8 @@
 #include "thsymbolsetlist.h"
 #include "thlayoutclr.h"
 #include <stdio.h>
+#include <vector>
+#include <map>
 
 
 struct thsymbolset_usym {


### PR DESCRIPTION
Quick fix to remove unused include `thpdfdata.h` from `thlayoutclr.h`, it was using only transitively included declarations. 

`thlayoutclr.h` was reported to be unreasonably slow to compile, after this change I have a more accurate data to work with.