### PR TITLE
Remove macOS 12 from CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-13, macos-14]
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies


### PR DESCRIPTION
macOS 12 is no longer supported by Homebrew