### PR TITLE
Added macOS 15 CI job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies


### PR DESCRIPTION
macOS 15 (Sequoia) is now available as a public beta in GitHub Actions