### PR TITLE
Use our main witn Catch2v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if (BUILD_THERION)
         COMPONENT th-runtime)
 
     # unit tests
-    add_executable(utest utest-proj.cxx utest-icase.cxx utest-thdouble.cxx)
+    add_executable(utest utest-main.cxx utest-proj.cxx utest-icase.cxx utest-thdouble.cxx)
     target_link_libraries(utest PUBLIC therion-common catch2-interface)
     enable_testing()
     if (NOT WIN32)

--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -10,15 +10,12 @@ add_library(catch2-interface INTERFACE)
 
 if (USE_BUNDLED_CATCH2)
     target_include_directories(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/extern)
-    target_sources(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/utest-main.cxx)
     return()
 endif()
 
 find_package(Catch2 REQUIRED)
-if (Catch2_VERSION_MAJOR LESS 3)
-    target_link_libraries(catch2-interface INTERFACE Catch2::Catch2)
-    target_sources(catch2-interface INTERFACE ${CMAKE_SOURCE_DIR}/utest-main.cxx)
-else()
-    target_link_libraries(catch2-interface INTERFACE Catch2::Catch2WithMain)
+
+target_link_libraries(catch2-interface INTERFACE Catch2::Catch2)
+if (Catch2_VERSION_MAJOR GREATER_EQUAL 3)
     target_compile_definitions(catch2-interface INTERFACE CATCH2_V3)
 endif()

--- a/utest-main.cxx
+++ b/utest-main.cxx
@@ -1,5 +1,9 @@
+#ifdef CATCH2_V3
+#include <catch2/catch_session.hpp>
+#else
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+#endif
 #include "thinit.h"
 #include "thproj.h"
 


### PR DESCRIPTION
Always use `utest-main.cxx` no matter which version of Catch2 is used.