### PR TITLE
Fedora 40 fixes

### DIFF
--- a/extern/quickhull/Structs/Mesh.hpp
+++ b/extern/quickhull/Structs/Mesh.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include "VertexDataSource.hpp"
 #include <unordered_map>
+#include <cstdint>
 
 namespace quickhull {
 

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -442,7 +442,7 @@ void thimport::import_file_img()
   img* pimg = img_open(this->fname);
   if (pimg == NULL) {	
     imgerr = img_error();
-    ththrow("unable to open file {}, error code: {}", this->fname, imgerr);
+    ththrow("unable to open file {}, error code: {}", this->fname, +imgerr);
   }
   do {
     result = img_read_item(pimg, &imgpt);


### PR DESCRIPTION
A couple of small fixes so Therion builds on Fedora 40. Likely needed for all gcc-14 builds.