### PR TITLE
xtherion: Allow space in filename (version 2)

### DIFF
--- a/xtherion/cp_procs.tcl
+++ b/xtherion/cp_procs.tcl
@@ -431,7 +431,7 @@ proc xth_cp_compile {} {
   $xth(ctrl,cp,stp).gores configure -text [mc "RUNNING"] -fg black -bg yellow
   update idletasks
   catch {
-    set thid [open "|$xth(gui,compcmd) -x $xth(cp,opts) $xth(cp,fname)" r]
+    set thid [open "|$xth(gui,compcmd) -x $xth(cp,opts) \"$xth(cp,fname)\"" r]
     if $xth(gui,compshow) {
       while {![eof $thid]} {
 	$xth(cp,log).txt insert end [read $thid 8]

--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -290,15 +290,6 @@ case $tcl_platform(platform) {
     set xth(gui,cursor) arrow
     set xth(app,sencoding) [encoding system]
     set xth(gui,bindinsdel) 0
-    if {[catch {
-      set fid [open "|cmd.exe /c" r]
-      read $fid;
-      close $fid
-    }]} {
-      set xth(gui,compcmd) "command.com /c $xth(gui,compcmd)"
-    } else {
-      set xth(gui,compcmd) "cmd.exe /c $xth(gui,compcmd)"
-    }
   }
   macintosh {
     set xth(kb_meta) Meta


### PR DESCRIPTION
Replacement for https://github.com/therion/therion/pull/590 which didn't work on Windows.

Tested on:
- Arch Linux
- Windows Server 2025
- Windows 10 Home 64bit

For testing: https://thomas-holder.de/tmp/xtherion.tcl