### PR TITLE
Tcl: Replace obsolete "case" with "switch".

### DIFF
--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -246,7 +246,7 @@ set xth(gui,bindinsdel) 1
 set xth(gui,me,pointsizectrl) 0
 
 # platform dependent settings
-case $tcl_platform(platform) {
+switch -- $tcl_platform(platform) {
   unix {
     set xth(gui,sbwidth) 9
     set xth(gui,sbwidthb) 1
@@ -303,7 +303,7 @@ case $tcl_platform(platform) {
 }
 
 
-case $tcl_platform(os) {
+switch -- $tcl_platform(os) {
   Darwin {
     set xth(gui,rmb) 2
   }

--- a/xtherion/mkall.tcl
+++ b/xtherion/mkall.tcl
@@ -35,7 +35,7 @@ switch $what {
 ##}
   }
   default {
-    case $what {
+    switch $what {
       WIN32 {
         set oid [open "xtherion.tcl" w]
       }
@@ -93,7 +93,7 @@ while {![eof $fid]} {
 close $fid
 close $oid
 
-case $tcl_platform(platform) {
+switch -- $tcl_platform(platform) {
   unix {
     catch {exec chmod 775 xtherion}
     catch {exec chmod 775 svxedit}

--- a/xtherion/svx_global.tcl
+++ b/xtherion/svx_global.tcl
@@ -48,7 +48,7 @@ set xth(prj,title) "survex source editor"
 set xth(about,info) "svxedit v1.0 beta\n \u00A9 2002 Stacho Mudrak"
 
 # fonts :-)
-case $tcl_platform(platform) {
+switch -- $tcl_platform(platform) {
   unix {
     set xth(gui,lfont) "Helvetica 10"
     set xth(gui,efont) {fixed 10 roman}


### PR DESCRIPTION
The **case** command was removed in Tcl 9.0.

https://www.tcl.tk/software/tcltk/9.0.html

> Removed pre-Tcl 8 legacies: case, puts and read variant syntaxes

https://wiki.tcl-lang.org/page/case

> command is obsolete [...] You should use the [switch](https://wiki.tcl-lang.org/page/switch) command instead.