### PR TITLE
CI: Fix Windows installer version in forks

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -84,6 +84,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fetch tags (relevant for forks)
+        run: git fetch https://github.com/therion/therion tag 'v*'
       - name: build and create the installation package
         id: build
         run: |


### PR DESCRIPTION
When running Github actions in a fork, git tags from upstream are not automatically fetched, which leads to wrong Therion version number in the Windows installer.

Fixed by explicitly fetching tags.