### PR TITLE
Code coverage for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ if (ENABLE_CCACHE)
     endif()
 endif()
 
+option(ENABLE_CODE_COVERAGE "Enable code coverage." OFF)
+include(CodeCoverage)
+
 # determine platform
 if(UNIX AND NOT APPLE)
     set(THPLATFORM LINUX)
@@ -187,6 +190,9 @@ if (BUILD_THERION)
     target_link_libraries(utest PUBLIC therion-common catch2-interface)
     enable_testing()
     add_test(NAME utest COMMAND $<TARGET_FILE:utest> WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    if (ENABLE_CODE_COVERAGE)
+        set_property(TEST utest PROPERTY ENVIRONMENT LLVM_PROFILE_FILE=${COVERAGE_FOLDER}/utest.profraw)
+    endif()
 
     # updates thlibrarydata.cxx
     add_custom_target(library 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,48 @@
+#
+# Generate code coverage report for unit tests.
+#
+# How to use:
+#   1. Use Clang compiler.
+#   2. Set already configured build folder as a working directory.
+#   3. Enable code coverage: cmake -DENABLE_CODE_COVERAGE=ON .
+#   4. Build the project:    cmake --build .
+#   5. Run unit tests:       cmake --build . --target test
+#   6. Generate report:      cmake --build . --target ccov-report
+#   7. View HTML report at ./coverage/html/index.html.
+#
+
+# interface library for setting compiler and linker flags
+add_library(code-coverage INTERFACE)
+
+if (ENABLE_CODE_COVERAGE)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR "Code coverage requires Clang compiler.")
+    endif()
+
+    set(COVERAGE_FLAGS -fprofile-instr-generate -fcoverage-mapping)
+    target_compile_options(code-coverage INTERFACE ${COVERAGE_FLAGS})
+    target_link_options(code-coverage INTERFACE ${COVERAGE_FLAGS})
+endif()
+
+set(COVERAGE_FOLDER ${CMAKE_BINARY_DIR}/coverage)
+
+add_custom_target(ccov-report
+    # process raw coverage profile
+    COMMAND llvm-profdata merge -sparse ${COVERAGE_FOLDER}/utest.profraw -o ${COVERAGE_FOLDER}/utest.profdata
+    # generate HTML report
+    COMMAND llvm-cov show 
+        $<TARGET_FILE:utest>
+        -instr-profile=${COVERAGE_FOLDER}/utest.profdata
+        -output-dir=${COVERAGE_FOLDER}/html
+        -format=html
+        -show-line-counts-or-regions
+        -show-expansions
+        -Xdemangler=c++filt
+    # Generate console summary
+    COMMAND llvm-cov report 
+        $<TARGET_FILE:utest> 
+        -instr-profile=${COVERAGE_FOLDER}/utest.profdata
+        -show-region-summary=false
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Generating coverage report for utest"
+)

--- a/loch/CMakeLists.txt
+++ b/loch/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LOCH_DEFINITIONS _GNU_SOURCE LOCH "LX${THPLATFORM}" GL_SILENCE_DEPRECATION T
 # library common with therion
 add_library(common-utils STATIC icase.h icase.cxx lxFile.h lxFile.cxx lxMath.h lxMath.cxx)
 target_compile_definitions(common-utils PUBLIC $<$<BOOL:${WIN32}>:WIN32_LEAN_AND_MEAN> PRIVATE ${LOCH_DEFINITIONS})
-target_link_libraries(common-utils PUBLIC img enable-warnings fmt::fmt)
+target_link_libraries(common-utils PUBLIC img enable-warnings code-coverage fmt::fmt)
 
 if (NOT BUILD_LOCH)
     return()


### PR DESCRIPTION
Initial implementation of code coverage, using Clang’s source-based code coverage feature: https://clang.llvm.org/docs/SourceBasedCodeCoverage.html.