### PR TITLE
CI: ubuntu-latest -> ubuntu-22.04

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,7 +2,7 @@ name: CodeQL
 on: [push, pull_request]
 jobs:
   CodeQL:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Enable parallel compilation
       run:  echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,7 +2,7 @@ name: CodeQL
 on: [push, pull_request]
 jobs:
   CodeQL:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Enable parallel compilation
       run:  echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
@@ -11,7 +11,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt -qq update
-        sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.0-gtk3-dev libvtk7-dev survex imagemagick ghostscript ninja-build gettext libfmt-dev catch2
+        sudo apt install -y texlive-binaries texlive-metapost libproj-dev libshp-dev libwxgtk3.2-dev libvtk9-dev survex imagemagick ghostscript ninja-build gettext libfmt-dev catch2
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
     - name: Autobuild

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -2,7 +2,7 @@ name: make
 on: [push, pull_request]
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies


### PR DESCRIPTION
Simple fix for `CodeQL` and `make` workflows: Keep using `ubuntu-22.04`.

Previously, these jobs used `ubuntu-latest`, which is now `ubuntu-24.04`.
See https://github.com/actions/runner-images/issues/10636