### PR TITLE
Issue 570

### DIFF
--- a/mpost/thLine.mp
+++ b/mpost/thLine.mp
@@ -261,8 +261,19 @@ enddef;
 
 def l_chimney_UIS (expr P) =
   T:=identity;
+  cas := 0;
+  dlzka := arclength P;
+  mojkrok:=adjust_step(dlzka, 0.8u);
   pickup PenC;
-  thdraw P dashed evenly scaled optical_zoom;
+  forever:
+    t1 := arctime (cas + mojkrok*1/5) of P;
+    t  := arctime (cas + mojkrok/2) of P;
+    t2 := arctime (cas + mojkrok*4/5) of P;
+    thdraw (subpath (t1,t2) of P);
+    mark_ (P,t,-0.2u);
+    cas := cas + mojkrok;
+    exitif cas > dlzka - (2*mojkrok/3); % for rounding errors
+  endfor;
 enddef;
 
 def l_ceilingstep_SKBB (expr P) =

--- a/mpost/thPoint.mp
+++ b/mpost/thPoint.mp
@@ -197,7 +197,7 @@ def p_rimstonedam_ASF (expr pos,theta,sc,al)=
     thdraw (-.4u,.2u){dir -70}..{dir 70}(.4u,.2u);
 enddef;
 
-def p_anastomosis_UIS (expr pos,theta,sc,al)=
+def p_karren_UIS (expr pos,theta,sc,al)=
     U:=(.5u,.4u);
     T:=identity aligned al rotated theta scaled sc shifted pos;
     pickup PenC;
@@ -207,7 +207,7 @@ def p_anastomosis_UIS (expr pos,theta,sc,al)=
         {dir 85}(.5u,-.3u);
 enddef;
 
-def p_karren_UIS (expr pos,theta,sc,al)=
+def p_anastomosis_UIS (expr pos,theta,sc,al)=
     U:=(.4u,.3u);
     T:=identity aligned al rotated theta scaled sc shifted pos;
     pickup PenC;


### PR DESCRIPTION
- Swap UIS Karren/Anastomosis point symbol
- Add ticks to UIS chimney line Symbol

![grafik](https://github.com/user-attachments/assets/bce0eaa3-d354-4c79-acd3-174e0ec01eed)
(colouring by me, original symbol is black, but supports `symbol-color`)

Fix #570