### PR TITLE
Fixed missing breaks

### DIFF
--- a/loch/lxR2D.cxx
+++ b/loch/lxR2D.cxx
@@ -548,6 +548,7 @@ case WM_SIZE:
 		resize();
 		return 0;
 	}
+	break;
 case WM_PALETTECHANGED:
 	/*
 	** Update palette mapping if this *is not* the active window.
@@ -597,6 +598,7 @@ case VK_SPACE:
 	} else {
 		idleFunc = doRedraw;
 	}
+	break;
 default:
 	break;
 	}


### PR DESCRIPTION
SonarQube Cloud reports missing `break`s in `switch` statements, one of them is trivial, one can be a potential bug. Please check it and if the behaviour was intended then it should be annotated with `[[fallthrough]]` instead.