### PR TITLE
Revert removal of xtherion cmd wrapping on Windows

### DIFF
--- a/xtherion/global.tcl
+++ b/xtherion/global.tcl
@@ -291,6 +291,15 @@ switch -- $tcl_platform(platform) {
     set xth(gui,cursor) arrow
     set xth(app,sencoding) [encoding system]
     set xth(gui,bindinsdel) 0
+    if {[catch {
+      set fid [open "|cmd.exe /c" r]
+      read $fid;
+      close $fid
+    }]} {
+      set xth(gui,compcmd) "command.com /c $xth(gui,compcmd)"
+    } else {
+      set xth(gui,compcmd) "cmd.exe /c $xth(gui,compcmd)"
+    }
   }
   macintosh {
     set xth(kb_meta) Meta


### PR DESCRIPTION
Improves user experience because all output goes to a single cmd window. With the cmd wrapping removed, MetaPost and TeX processes would open separate cmd windows, which can be irritating.

- Path to `thconfig` file may contain spaces (primary goal of #603)
- Path to `therion.exe` must not contain spaces

This reverts part of commit 2e7c2a96ed4b40f9e964e169064ebf72770bb772

Closes https://github.com/therion/therion/issues/629