### PR TITLE
Improve documentation of valid team roles

### DIFF
--- a/thbook/ch02.tex
+++ b/thbook/ch02.tex
@@ -401,9 +401,24 @@ the command may be used anywhere.
   * |team <person> [<roles>]| = a survey team member. The first argument
     is his/her name, the others describe the roles of the person in
     the team (optional---currently not used). The following role keywords are
-    supported: station, [back]length, [back]tape, [back]compass, [back]bearing, [back]clino,
-    [back]gradient, counter, depth, station, position, notes, pictures, pics,
-    instruments (insts), assistant (dog).
+    supported:
+    [back]tape ([back]length),
+    [back]compass ([back]bearing),
+    [back]clino ([back]gradient),
+    counter (count),
+    depth,
+    station,
+    position,
+    notes (notebook),
+    pictures (pics),
+    instruments (insts),
+    assistant (dog),
+    altitude (dz),
+    dimensions,
+    left,
+    right,
+    up (ceiling),
+    down (floor).
   * |explo-team <person>| = a discovery team member.
   * |instrument <quantity list> <description>| = description
     of the instrument that was used to survey the given quantities (same


### PR DESCRIPTION
Full list found by reading the source code.  I've verified all the roles now listed are actually accepted by therion.

Changes:

Consistently list aliases in parentheses so it's clear to the reader which roles are actually distinct.

Add missing aliases: `count` for `counter`, `notebook` for `notes`

Add previously undocumented roles: `dimensions`, `left`, `right`, `up (ceiling)`, `down (floor)`

Removed duplicate entry for `station`.

Format .tex source with one role per line for easier comparison with the list in the source code.