### PR TITLE
thlogfile::print()

### DIFF
--- a/thlogfile.cxx
+++ b/thlogfile.cxx
@@ -81,7 +81,20 @@ void thlogfile::close_file()
   }
 }
   
-void thlogfile::set_file_name(char *fname)
+void thlogfile::print(std::string_view msg)
+{
+  if (this->is_logging) {
+    if (!this->is_open)
+      this->open_file();
+    if (this->is_open) {
+      fmt::print(this->fileh, "{}", msg);
+      if (std::fflush(this->fileh) != 0)
+        this->log_error();
+    }
+  }
+}
+
+void thlogfile::set_file_name(const char *fname)
 {
   size_t fnl = strlen(fname);
   if ((!this->is_open) && (fnl > 0))

--- a/thlogfile.h
+++ b/thlogfile.h
@@ -83,20 +83,18 @@ class thlogfile {
   thlogfile& operator=(thlogfile&&) = delete;
 
   /**
+   * Print string into log file.
+   * @param msg Message.
+   */
+  void print(std::string_view msg);
+
+  /**
    * Print formatted into log file.
    */
   template <typename FormatStr, typename... Args>
   void printf(const FormatStr& format, const Args&... args)
   {
-    if (this->is_logging) {
-      if (!this->is_open)
-        this->open_file();
-      if (this->is_open) {
-        fmt::fprintf(this->fileh, format, args...);
-        if (std::fflush(this->fileh) != 0)
-          this->log_error();
-      }
-    }
+    this->print(fmt::sprintf(format, args...));
   }
   
   /**
@@ -112,7 +110,7 @@ class thlogfile {
    * @param fname File name.
    */
    
-  void set_file_name(char *fname);
+  void set_file_name(const char *fname);
   
   
   /**

--- a/utest-thlogfile.cxx
+++ b/utest-thlogfile.cxx
@@ -6,9 +6,38 @@
 #include <catch2/catch.hpp>
 #endif
 
+#include <fstream>
+#include <filesystem>
+
 TEST_CASE("thlog()")
 {
     // tests (with the help of code coverage) that the thlogfile instance
     // is created and correctly destroyed at the end of the program
     [[maybe_unused]] auto& log = thlog();
+}
+
+TEST_CASE("thlogfile")
+{
+    std::filesystem::remove("test.log");
+
+    thlogfile log;
+    log.set_file_name("test.log");
+    REQUIRE(strcmp(log.get_file_name(), "test.log") == 0);
+    log.set_logging(true);
+    REQUIRE(log.get_logging());
+    log.print("test\n");
+    log.printf("hello, %s\n", "world");
+    log.printf("test2\n");
+
+    std::vector<std::string> lines;
+    std::ifstream test_file("test.log");
+    std::string line;
+    while (std::getline(test_file, line))
+    {
+        lines.push_back(line);
+    }
+    REQUIRE(lines.size() == 3);
+    REQUIRE(lines[0] == "test");
+    REQUIRE(lines[1] == "hello, world");
+    REQUIRE(lines[2] == "test2");
 }

--- a/utest-thlogfile.cxx
+++ b/utest-thlogfile.cxx
@@ -18,19 +18,22 @@ TEST_CASE("thlog()")
 
 TEST_CASE("thlogfile")
 {
-    std::filesystem::remove("test.log");
+    static const std::string file_name = "test.log";
+    std::filesystem::remove(file_name);
 
-    thlogfile log;
-    log.set_file_name("test.log");
-    REQUIRE(strcmp(log.get_file_name(), "test.log") == 0);
-    log.set_logging(true);
-    REQUIRE(log.get_logging());
-    log.print("test\n");
-    log.printf("hello, %s\n", "world");
-    log.printf("test2\n");
+    {
+        thlogfile log;
+        log.set_file_name(file_name.c_str());
+        REQUIRE(log.get_file_name() == file_name);
+        log.set_logging(true);
+        REQUIRE(log.get_logging());
+        log.print("test\n");
+        log.printf("hello, %s\n", "world");
+        log.printf("test2\n");
+    }
 
     std::vector<std::string> lines;
-    std::ifstream test_file("test.log");
+    std::ifstream test_file(file_name);
     std::string line;
     while (std::getline(test_file, line))
     {


### PR DESCRIPTION
I have added a method `thlogfile::print(std::string_view)`, which should be a simpler alternative to the variadic template method  `thlogfile::printf(const FormatStr&, const Args&...)`.