### PR TITLE
Removed thlogfile::printf()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # common therion objects
 CMNOBJECTS = thdate.o extern/shapelib/shpopen.o extern/shapelib/dbfopen.o extern/shapelib/safileio.o  \
-  thexception.o thbuffer.o thmbuffer.o thlogfile.o thtmpdir.o thlocale.o \
+  thexception.o thbuffer.o thmbuffer.o thlog.o thlogfile.o thtmpdir.o thlocale.o \
   thparse.o thcmdline.o thconfig.o thinput.o thchenc.o thdatabase.o \
   thdataobject.o thdatareader.o thsurvey.o thendsurvey.o thdata.o \
   thperson.o thtf.o thtfangle.o thtflength.o thtfpwf.o \
@@ -843,7 +843,8 @@ $(OUTDIR)/thline.o: thline.cxx thline.h th2ddataobject.h thdataobject.h \
  thpic.h thwarp.h thtrans.h
 $(OUTDIR)/thlocale.o: thlocale.cxx thlocale.h thparse.h thbuffer.h thmbuffer.h \
  thexception.h thlang.h thlangdata.h thinit.h thinput.h
-$(OUTDIR)/thlogfile.o: thlogfile.cxx thlogfile.h thbuffer.h therion.h thinfnan.h
+$(OUTDIR)/thlog.o: thlog.cxx thlog.h thlogfile.h thbuffer.h
+$(OUTDIR)/thlogfile.o: thlogfile.cxx thlogfile.h thbuffer.h therion.h
 $(OUTDIR)/thlookup.o: thlookup.cxx thlookup.h thdataobject.h thdatabase.h \
  thmbuffer.h thbuffer.h thdb1d.h thobjectid.h thinfnan.h thdataleg.h \
  thparse.h thobjectname.h therion.h thobjectsrc.h thdb3d.h loch/lxMath.h \

--- a/cmake/TherionSources.cmake
+++ b/cmake/TherionSources.cmake
@@ -69,6 +69,7 @@ set(THERION_HEADERS
     ${CMAKE_SOURCE_DIR}/thlibrary.h
     ${CMAKE_SOURCE_DIR}/thline.h
     ${CMAKE_SOURCE_DIR}/thlocale.h
+    ${CMAKE_SOURCE_DIR}/thlog.h
     ${CMAKE_SOURCE_DIR}/thlogfile.h
     ${CMAKE_SOURCE_DIR}/thlookup.h
     ${CMAKE_SOURCE_DIR}/thmap.h
@@ -184,6 +185,7 @@ set(THERION_SOURCES
     ${CMAKE_SOURCE_DIR}/thlibrarydata.cxx
     ${CMAKE_SOURCE_DIR}/thline.cxx
     ${CMAKE_SOURCE_DIR}/thlocale.cxx
+    ${CMAKE_SOURCE_DIR}/thlog.cxx
     ${CMAKE_SOURCE_DIR}/thlogfile.cxx
     ${CMAKE_SOURCE_DIR}/thlookup.cxx
     ${CMAKE_SOURCE_DIR}/thmap.cxx

--- a/thcmdline.cxx
+++ b/thcmdline.cxx
@@ -121,12 +121,12 @@ void thcmdline::process(int argc, char * argv[])
         break;
 
       case 'L':
-        thlog().logging_off();
+        get_thlogfile().logging_off();
         break;
         
       case 'l':
-        thlog().logging_on();
-        thlog().set_file_name(optarg);
+        get_thlogfile().logging_on();
+        get_thlogfile().set_file_name(optarg);
         break;
         
       //case 'g':

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -986,17 +986,17 @@ void thconfig::log_outcs(double decsyear, double deceyear) {
   double x, y, z, dec;
   bool firstdec = true;
   if (this->get_outcs_center(x, y, z)) {
-    thlog().printf("output coordinate system: %s\n", thcs_get_name(this->outcs));
-    thlog().printf("meridian convergence (deg): %.4f\n", this->get_outcs_convergence());
+    thlog(fmt::format("output coordinate system: {}\n", thcs_get_name(this->outcs)));
+    thlog(fmt::format("meridian convergence (deg): {:.4}\n", this->get_outcs_convergence()));
     if (!thisnan(decsyear)) {
       long min = long(decsyear), max = long(deceyear + 1.0), yyy;
       for(yyy = min; yyy <= max; yyy++) {
         if (firstdec) {
-          thlog().printf("geomag declinations (deg):\n");
+          thlog("geomag declinations (deg):\n");
           firstdec = false;
         }
         if (this->get_outcs_mag_decl(double(yyy), dec)) {
-          thlog().printf("  %4ld.1.1  %.4f\n", yyy, dec);
+          thlog(fmt::format("  {:4}.1.1  {:.4}\n", yyy, dec));
         }
       }
     }

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -2600,18 +2600,18 @@ void thdb1d::print_loops() {
   thdb1ds * ps;
   unsigned long psid, prev_psid, first_psid;
   
-  thlog().printf("\n\n######################### loop errors ##########################\n");
-  thlog().printf(    "REL-ERR ABS-ERR TOTAL-L STS X-ERROR Y-ERROR Z-ERROR STATIONS\n");
+  thlog("\n\n######################### loop errors ##########################\n");
+  thlog("REL-ERR ABS-ERR TOTAL-L STS X-ERROR Y-ERROR Z-ERROR STATIONS\n");
   for (i = 0; i < nloops; i++) {
     li = lpr[i].li;
-    thlog().printf("%6.2f%% %s%s %s%s %3ld %s%s %s%s %s%s [",
+    thlog(fmt::format("{:6.2}% {}{} {}{} {:3} {}{} {}{} {}{} [",
       li->src_length > 0.0 ? 100.0 * li->err_length / li->src_length : 0.0,
 			thdeflocale.format_length(li->err_length,1,totlen), thdeflocale.format_length_units(),			
 			thdeflocale.format_length(li->src_length,1,totlen), thdeflocale.format_length_units(),			
 			li->nlegs,
 			thdeflocale.format_length(li->err_dx,1,totlen), thdeflocale.format_length_units(),			
 			thdeflocale.format_length(li->err_dy,1,totlen), thdeflocale.format_length_units(),			
-			thdeflocale.format_length(li->err_dz,1,totlen), thdeflocale.format_length_units());
+			thdeflocale.format_length(li->err_dz,1,totlen), thdeflocale.format_length_units()));
     ll = li->first_leg;
     ss = NULL;
     if (ll->reverse)
@@ -2620,10 +2620,10 @@ void thdb1d::print_loops() {
       psid = ll->leg->from.id;
     ps = &(this->station_vec[psid - 1]);
     first_psid = psid;
-    thlog().printf("%s", ps->name);
+    thlog(ps->name);
     if ((ss == NULL) || (ss->id != ps->survey->id)) {
       ss = ps->survey;
-      thlog().printf("@%s", ss->get_full_name());
+      thlog(fmt::format("@{}", ss->get_full_name()));
     }
     prev_psid = psid;
     while (ll != NULL) {
@@ -2635,10 +2635,10 @@ void thdb1d::print_loops() {
 
       if (prev_psid != psid) {
         ps = &(this->station_vec[psid - 1]);
-        thlog().printf(" = %s", ps->name);
+        thlog(fmt::format(" = {}", ps->name));
         if (ss->id != ps->survey->id) {
           ss = ps->survey;
-          thlog().printf("@%s", ss->get_full_name());
+          thlog(fmt::format("@{}", ss->get_full_name()));
         }
       }
 
@@ -2647,20 +2647,20 @@ void thdb1d::print_loops() {
       else
         psid = ll->leg->to.id;
       ps = &(this->station_vec[psid - 1]);
-      thlog().printf(" - %s", ps->name);
+      thlog(fmt::format(" - {}", ps->name));
       if (ss->id != ps->survey->id) {
         ss = ps->survey;
-        thlog().printf("@%s", ss->get_full_name());
+        thlog(fmt::format("@{}", ss->get_full_name()));
       }
       
       if ((ll->next_leg == NULL) && (!li->open)) {
         if (first_psid != psid) {
           psid = first_psid;
           ps = &(this->station_vec[psid - 1]);
-          thlog().printf(" = %s", ps->name);
+          thlog(fmt::format(" = {}", ps->name));
           if (ss->id != ps->survey->id) {
             ss = ps->survey;
-            thlog().printf("@%s", ss->get_full_name());
+            thlog(fmt::format("@{}", ss->get_full_name()));
           }
         }
       }
@@ -2668,9 +2668,9 @@ void thdb1d::print_loops() {
       prev_psid = psid;
       ll = ll->next_leg;
     }
-    thlog().printf("]\n");
+    thlog("]\n");
   }
-  thlog().printf("##################### end of loop errors #######################\n");
+  thlog("##################### end of loop errors #######################\n");
 }
 
 thdb3ddata * thdb1d::get_3d_surface() {

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -51,6 +51,14 @@
 #include <cstdio>
 #include <algorithm>
 
+static void print_double(const double dbl)
+{
+	if (thisnan(dbl))
+		thlog("    -.--");
+	else
+		thlog(fmt::format("{:8.2}", dbl));
+}
+
 class thprjx_link {
 
   public:
@@ -1118,15 +1126,15 @@ void thdb2d::log_distortions() {
       }
       
       std::sort(ss.begin(), ss.end(), [](const auto* s1, const auto* s2){ return s1->maxdist > s2->maxdist; });
-      thlog().printf("\n\n###################### scrap distortions #######################\n");
-      thlog().printf(" PROJECTION: %s%s%s\n", 
+      thlog("\n\n###################### scrap distortions #######################\n");
+      thlog(fmt::format(" PROJECTION: {}{}{}\n", 
         thmatch_string(prj->type,thtt_2dproj), 
         strlen(prj->index) > 0 ? ":" : "",
-        strlen(prj->index) > 0 ? prj->index : "");
-      thlog().printf(" AVERAGE  MAXIMAL  SCRAP\n");
+        strlen(prj->index) > 0 ? prj->index : ""));
+      thlog(" AVERAGE  MAXIMAL  SCRAP\n");
       for(i = 0; i < ns; i++)
-        thlog().printf(" %6.2f%%  %6.2f%%  %s@%s\n",ss[i]->avdist, ss[i]->maxdist, ss[i]->name, ss[i]->fsptr->full_name);
-      thlog().printf("################### end of scrap distortions ###################\n");
+        thlog(fmt::format(" {:6.2}%  {:6.2}%  {}@{}\n",ss[i]->avdist, ss[i]->maxdist, ss[i]->name, ss[i]->fsptr->full_name));
+      thlog("################### end of scrap distortions ###################\n");
     }
     prjli++;
   }
@@ -1141,16 +1149,16 @@ void thdb2d::log_selection(thdb2dxm * maps, thdb2dprj * prj) {
   double z;
   thmap * cm;
   thmap * bm;
-  thlog().printf("\n\n############### export maps & scraps selection #################\n");
+  thlog("\n\n############### export maps & scraps selection #################\n");
   while (cmap != NULL) {
     cm = (thmap *) cmap->map;
     cm->calc_z();
     z = cm->z;
     if (prj->type == TT_2DPROJ_PLAN) z += prj->shift_z;
     if (strlen(cm->name) > 0) {
-    	thlog().printf("M ");
-    	thlog().printf_double("%8.2f", "    -.--", z);
-    	thlog().printf(" %s@%s (%s)\n", cm->name, cm->fsptr ? cm->fsptr->full_name : "",  cm->title ? cm->title : "");
+    	thlog("M ");
+    	print_double(z);
+    	thlog(fmt::format(" {}@{} ({})\n", cm->name, cm->fsptr ? cm->fsptr->full_name : "",  cm->title ? cm->title : ""));
     }
 
 
@@ -1166,18 +1174,18 @@ void thdb2d::log_selection(thdb2dxm * maps, thdb2dprj * prj) {
       if (prj->type == TT_2DPROJ_PLAN) z += prj->shift_z;
       cmi = cbm->bm->first_item;
       if ((cm->id != bm->id) && (strlen(bm->name) > 0)) {
-		  thlog().printf("M ");
-		  thlog().printf_double("%8.2f", "    -.--", z);
-    	  thlog().printf(" %s@%s (%s)\n", bm->name, bm->fsptr ? bm->fsptr->full_name : "",  bm->title ? bm->title : "");
+		    thlog("M ");
+		    print_double(z);
+    	  thlog(fmt::format(" {}@{} ({})\n", bm->name, bm->fsptr ? bm->fsptr->full_name : "",  bm->title ? bm->title : ""));
       }
       if (cbm->mode == TT_MAPITEM_NORMAL) while (cmi != NULL) {
         if (cmi->type == TT_MAPITEM_NORMAL) {
           cs = dynamic_cast<thscrap*>(cmi->object);
           z = cs->z;
           if (prj->type == TT_2DPROJ_PLAN) z += prj->shift_z;
-		  thlog().printf("S ");
-		  thlog().printf_double("%8.2f", "    -.--", z);
-          thlog().printf(" %s@%s (%s)\n", cs->name, cs->fsptr ? cs->fsptr->full_name : "", cs->title ? cs->title : "");
+		      thlog("S ");
+		      print_double(z);
+          thlog(fmt::format(" {}@{} ({})\n", cs->name, cs->fsptr ? cs->fsptr->full_name : "", cs->title ? cs->title : ""));
         }
         cmi = cmi->next_item;
       }
@@ -1185,7 +1193,7 @@ void thdb2d::log_selection(thdb2dxm * maps, thdb2dprj * prj) {
     }
     cmap = cmap->next_item;
   }
-  thlog().printf("########## end of export maps & scraps selection ###############\n");
+  thlog("########## end of export maps & scraps selection ###############\n");
 }
 
 

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -121,8 +121,7 @@ int main(int argc, char * argv[]) {
     // print version information
     thprintf(thversion_format, thversion_text);
     thprintf("\n");
-    thlog().printf("  - using Proj %s, compiled against %s\n", thcs_get_proj_version().c_str(),
-                                                         thcs_get_proj_version_headers().c_str());
+    thlog(fmt::format("  - using Proj {}, compiled against {}\n", thcs_get_proj_version(), thcs_get_proj_version_headers()));
     if (thcs_get_proj_version() != thcs_get_proj_version_headers())
       thwarning(("Proj version mismatch: using %s, compiled against %s", thcs_get_proj_version().c_str(),
                                                          thcs_get_proj_version_headers().c_str()));

--- a/therion.h
+++ b/therion.h
@@ -33,7 +33,7 @@
 #ifndef therion_h
 #define therion_h
 
-#include "thlogfile.h"
+#include "thlog.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <fmt/printf.h>
@@ -105,7 +105,7 @@ extern char * thexecute_cmd;
 template<typename FormatStr, typename... Args>
 void thfprintf(const bool verbose, FILE* f, const FormatStr& format, const Args&... args)
 {
-  thlog().printf(format, args...);
+  thlog(fmt::sprintf(format, args...));
   if (verbose) {
     fmt::fprintf(f, format, args...);
   }

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -89,13 +89,13 @@ thexpmap::~thexpmap() {
 void thexpmap_log_log_file(const char * logfpath, const char * on_title, const char * off_title, bool mpbug) {
   std::string lnbuff;
 //  unsigned long lnum = 0;
-  thlog().printf("%s",on_title);
+  thlog(on_title);
   std::ifstream lf(logfpath);
   if (!(lf.is_open())) {{
     thwarning(("can't open %s file for input", logfpath));
     }
-    thlog().printf("can't open %s file for input",logfpath);
-    thlog().printf("%s",off_title);
+    thlog(fmt::format("can't open {} file for input",logfpath));
+    thlog(off_title);
     return;
   }
   // let's read line by line and print to log file
@@ -111,7 +111,7 @@ void thexpmap_log_log_file(const char * logfpath, const char * on_title, const c
     }
     if (!skip_this) {
       if (!skip_next) {
-        thlog().printf("%s%s", (peoln ? "\n" : ""), lnbuff);
+        thlog(fmt::format("{}{}", (peoln ? "\n" : ""), lnbuff));
         peoln = true;
       } else {
         skip_next = false;
@@ -121,9 +121,9 @@ void thexpmap_log_log_file(const char * logfpath, const char * on_title, const c
     } 
   }
   if (peoln) 
-    thlog().printf("\n");
+    thlog("\n");
   lf.close();
-  thlog().printf("%s",off_title);
+  thlog(off_title);
 }
 
 

--- a/thlog.cxx
+++ b/thlog.cxx
@@ -1,0 +1,7 @@
+#include "thlog.h"
+#include "thlogfile.h"
+
+void thlog(std::string_view msg)
+{
+  get_thlogfile().print(msg);
+}

--- a/thlog.h
+++ b/thlog.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string_view>
+
+void thlog(std::string_view msg);

--- a/thlogfile.cxx
+++ b/thlogfile.cxx
@@ -28,7 +28,6 @@
 
 #include "thlogfile.h"
 #include "therion.h"
-#include "thinfnan.h"
 #include <string.h>
 
 const char * logfilemode = "w";
@@ -120,15 +119,6 @@ void thlogfile::logging_on()
 {
   this->is_logging = true;
 }
-
-void thlogfile::printf_double(const char * format, const char * nanstr, double dbl)
-{
-	if (thisnan(dbl))
-		this->printf(nanstr);
-	else
-		this->printf(format, dbl);
-}
-
    
 void thlogfile::logging_off()
 {
@@ -148,7 +138,7 @@ void thlogfile::log_error() {
 	fprintf(stderr,"error -- unable to write to log file (disk full?, insufficient permissions?)\n");
 }
 
-thlogfile& thlog()
+thlogfile& get_thlogfile()
 {
   static thlogfile log; // global instance
   return log;

--- a/thlogfile.h
+++ b/thlogfile.h
@@ -31,7 +31,7 @@
 
 #include "thbuffer.h"
 #include <stdio.h>
-#include <fmt/printf.h>
+#include <string_view>
 
 /**
  * Log file module.
@@ -87,22 +87,6 @@ class thlogfile {
    * @param msg Message.
    */
   void print(std::string_view msg);
-
-  /**
-   * Print formatted into log file.
-   */
-  template <typename FormatStr, typename... Args>
-  void printf(const FormatStr& format, const Args&... args)
-  {
-    this->print(fmt::sprintf(format, args...));
-  }
-  
-  /**
-   * Print double into log file - take concern of nan.
-   */
-
-  void printf_double(const char * format, const char * nanstr, double dbl);
-
   
   /**
    * Set log file name.
@@ -166,7 +150,7 @@ class thlogfile {
 /**
  * Global log file instance.
  */
-thlogfile& thlog();
+thlogfile& get_thlogfile();
 
 #endif
 

--- a/thproj.cxx
+++ b/thproj.cxx
@@ -508,14 +508,14 @@ int thcs_parse_gridhandling(const char * s) {
 void thcs_log_transf_used() {
 #if PROJ_VER >= 7
   if (precise_transf.size() > 0) {
-    thlog().printf("\n################# custom transformations used ##################\n");
+    thlog("\n################# custom transformations used ##################\n");
     for (auto &j: precise_transf) {
-      thlog().printf("  [%s → %s] definition: [%s]\n", thcs_get_name(j.first.first), thcs_get_name(j.first.second), j.second.c_str());
+      thlog(fmt::format("  [{} → {}] definition: [{}]\n", thcs_get_name(j.first.first), thcs_get_name(j.first.second), j.second));
     }
-    thlog().printf("############ end of custom transformations used ################\n");
+    thlog("############ end of custom transformations used ################\n");
   }
 #endif
-  thlog().printf(cache.log().c_str());
+  thlog(cache.log());
 }
 
 std::string thcs_get_label(int i) {

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -572,7 +572,7 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
   std::string lnbuff;
   std::string numbuff;
   unsigned long lnum = 0;
-  thlog().printf("\n####################### cavern log file ########################\n");
+  thlog("\n####################### cavern log file ########################\n");
   std::ifstream clf(lfnm);
   if (!(clf.is_open()))
     throw thexception("can't open cavern log file for input");
@@ -586,7 +586,7 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
   while (!(clf.eof())) {
     lnum++;
     std::getline(clf, lnbuff);
-    thlog().printf("%2lu> %s\n",lnum,lnbuff);
+    thlog(fmt::format("{:2}> {}\n",lnum,lnbuff));
     // let's scan the line
     chch = lnbuff.c_str();
     nchs = strlen(chch);
@@ -694,8 +694,8 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
 
   }
   clf.close();
-  thlog().printf("######################### transcription ########################\n%s",tsbuff.get_buffer());
-  thlog().printf("#################### end of cavern log file ####################\n");
+  thlog(fmt::format("######################### transcription ########################\n{}",tsbuff.get_buffer()));
+  thlog("#################### end of cavern log file ####################\n");
 }
 
 void thsvxctrl::load_err_file(class thdatabase * dbp, const char * lfnm) {

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -60,13 +60,13 @@ thsymbolset::thsymbolset()
 void thsymbolset_log_log_file(const char * logfpath, const char * on_title, const char * off_title, bool mpbug = false) {
   std::string lnbuff;
 //  unsigned long lnum = 0;
-  thlog().printf("%s",on_title);
+  thlog(on_title);
   std::ifstream lf(logfpath);
   if (!(lf.is_open())) {{
     thwarning(("can't open %s file for input", logfpath));
     }
-    thlog().printf("can't open %s file for input",logfpath);
-    thlog().printf("%s",off_title);
+    thlog(fmt::format("can't open {} file for input",logfpath));
+    thlog(off_title);
     return;
   }
   // let's read line by line and print to log file
@@ -82,7 +82,7 @@ void thsymbolset_log_log_file(const char * logfpath, const char * on_title, cons
     }
     if (!skip_this) {
       if (!skip_next) {
-        thlog().printf("%s%s", (peoln ? "\n" : ""), lnbuff);
+        thlog(fmt::format("{}{}", (peoln ? "\n" : ""), lnbuff));
         peoln = true;
       } else {
         skip_next = false;
@@ -92,9 +92,9 @@ void thsymbolset_log_log_file(const char * logfpath, const char * on_title, cons
     }
   }
   if (peoln)
-    thlog().printf("\n");
+    thlog("\n");
   lf.close();
-  thlog().printf("%s",off_title);
+  thlog(off_title);
 }
 
 

--- a/utest-thlogfile.cxx
+++ b/utest-thlogfile.cxx
@@ -9,17 +9,22 @@
 #include <fstream>
 #include <filesystem>
 
-TEST_CASE("thlog()")
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST_CASE("get_thlogfile()")
 {
     // tests (with the help of code coverage) that the thlogfile instance
     // is created and correctly destroyed at the end of the program
-    [[maybe_unused]] auto& log = thlog();
+    [[maybe_unused]] auto& log = get_thlogfile();
 }
 
 TEST_CASE("thlogfile")
 {
     static const std::string file_name = "test.log";
+
     std::filesystem::remove(file_name);
+    REQUIRE_FALSE(std::filesystem::exists(file_name));
 
     {
         thlogfile log;
@@ -28,8 +33,8 @@ TEST_CASE("thlogfile")
         log.set_logging(true);
         REQUIRE(log.get_logging());
         log.print("test\n");
-        log.printf("hello, %s\n", "world");
-        log.printf("test2\n");
+        log.print("hello, world\n"s);
+        log.print("test2\n"sv);
     }
 
     std::vector<std::string> lines;


### PR DESCRIPTION
I have removed variadic template method `thlogfile::printf()`, so the interface is much simpler now. I have also simplified logging to the global `thlogfile` instance with the `thlog()` function.