### PR TITLE
Simplified printing functions

### DIFF
--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -45,6 +45,7 @@
 #include "thlayout.h"
 #include "thsketch.h"
 #include "thcs.h"
+#include "thlog.h"
 #ifdef THWIN32
 #include <windows.h>
 #endif

--- a/thdb1d.cxx
+++ b/thdb1d.cxx
@@ -50,6 +50,7 @@
 #include "thcsdata.h"
 #include "thgeomagdata.h"
 #include "therion.h"
+#include "thlog.h"
 #include "QuickHull.hpp"
 
 //#define THUSESVX

--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -45,6 +45,7 @@
 #include "thinit.h"
 #include "thfilehandle.h"
 #include "therion.h"
+#include "thlog.h"
 #include <list>
 #include <set>
 #include <iterator>

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -37,6 +37,7 @@
 #include "thlogfile.h"
 #include "thproj.h"
 #include "thdatabase.h"
+#include "thlog.h"
 
 extern const thstok thtt_texts [];
 

--- a/therion.cxx
+++ b/therion.cxx
@@ -34,6 +34,7 @@
 #include "tharea.h"
 #include "thlang.h"
 #include "thparse.h"
+#include "thlog.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -47,6 +48,30 @@ bool thverbose_mode = true;
 bool thtext_inline = false;
 
 char * thexecute_cmd = NULL;
+
+void thfprint(const bool verbose, FILE* f, std::string_view msg)
+{
+  thlog(msg);
+  if (verbose) {
+    fmt::print(f, "{}", msg);
+  }
+}
+
+void thprint2err(std::string_view msg) noexcept
+{
+  try
+  {
+    thfprint(true, stderr, msg);
+  }
+  catch(const std::exception& e)
+  {
+    std::fprintf(stderr, "error occurred while reporting another error: %s\n", e.what());
+  }
+  catch (...)
+  {
+    std::fprintf(stderr, "unknown error occurred while reporting another error\n");
+  }
+}
 
 void thprint_environment() {
   thprintf("\n\nINIT=%s\n",thcfg.get_initialization_path());

--- a/therion.cxx
+++ b/therion.cxx
@@ -49,7 +49,7 @@ bool thtext_inline = false;
 
 char * thexecute_cmd = NULL;
 
-void thfprint(const bool verbose, FILE* f, std::string_view msg)
+static void thprint_impl(const bool verbose, FILE* f, std::string_view msg)
 {
   thlog(msg);
   if (verbose) {
@@ -57,11 +57,16 @@ void thfprint(const bool verbose, FILE* f, std::string_view msg)
   }
 }
 
+void thprint(std::string_view msg)
+{
+  thprint_impl(thverbose_mode, stdout, msg);
+}
+
 void thprint2err(std::string_view msg) noexcept
 {
   try
   {
-    thfprint(true, stderr, msg);
+    thprint_impl(true, stderr, msg);
   }
   catch(const std::exception& e)
   {

--- a/therion.h
+++ b/therion.h
@@ -94,13 +94,11 @@ extern bool thverbose_mode;
 extern char * thexecute_cmd;
 
 /**
- * @brief Helper function for universal logging.
+ * @brief Print to the logfile and stdout.
  * 
- * @param verbose print also to stdout
- * @param f output
  * @param msg message to print
  */
-void thfprint(bool verbose, FILE* f, std::string_view msg);
+void thprint(std::string_view msg);
 
 /**
  * @brief Print formatted to stdout.
@@ -111,7 +109,7 @@ void thfprint(bool verbose, FILE* f, std::string_view msg);
 template <typename FormatStr, typename... Args>
 void thprintf(const FormatStr& format, const Args&... args)
 {
-  thfprint(thverbose_mode, stdout, fmt::sprintf(format, args...));
+  thprint(fmt::sprintf(format, args...));
 }
 
 

--- a/therion.h
+++ b/therion.h
@@ -33,22 +33,21 @@
 #ifndef therion_h
 #define therion_h
 
-#include "thlog.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <fmt/printf.h>
 
 #ifdef THDEBUG
-#define thprint_error_src() thprintf2err("%s%s (" __FILE__ ":%d): error -- ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__)
+#define thprint_error_src() thprint2err(fmt::sprintf("%s%s (" __FILE__ ":%d): error -- ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__))
 #else
-#define thprint_error_src() thprintf2err("%s%s: error -- ", (thtext_inline ? "\n" : ""), thexecute_cmd)
+#define thprint_error_src() thprint2err(fmt::sprintf("%s%s: error -- ", (thtext_inline ? "\n" : ""), thexecute_cmd))
 #endif
 
 
 #ifdef THDEBUG
-#define thprint_warning_src() thprintf2err("%s%s (" __FILE__ ":%d): warning -- ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__)
+#define thprint_warning_src() thprint2err(fmt::sprintf("%s%s (" __FILE__ ":%d): warning -- ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__))
 #else
-#define thprint_warning_src() thprintf2err("%s%s: warning -- ", (thtext_inline ? "\n" : ""), thexecute_cmd)
+#define thprint_warning_src() thprint2err(fmt::sprintf("%s%s: warning -- ", (thtext_inline ? "\n" : ""), thexecute_cmd))
 #endif
 
 /**
@@ -59,8 +58,8 @@
  
 #define therror(P) {\
   thprint_error_src();\
-  thprintf2err P;\
-  thprintf2err("\n");\
+  thprint2err(fmt::sprintf P );\
+  thprint2err("\n");\
   thpause_exit();\
   therion_exit_state = 0;\
   thexit(EXIT_FAILURE);\
@@ -75,8 +74,8 @@
  
 #define thwarning(P) {\
   thprint_warning_src();\
-  thprintf2err P;\
-  thprintf2err("\n");\
+  thprint2err(fmt::sprintf P );\
+  thprint2err("\n");\
   therion_exit_state = 1;\
 }
 
@@ -99,17 +98,9 @@ extern char * thexecute_cmd;
  * 
  * @param verbose print also to stdout
  * @param f output
- * @param format format string
- * @param args arguments to print
+ * @param msg message to print
  */
-template<typename FormatStr, typename... Args>
-void thfprintf(const bool verbose, FILE* f, const FormatStr& format, const Args&... args)
-{
-  thlog(fmt::sprintf(format, args...));
-  if (verbose) {
-    fmt::fprintf(f, format, args...);
-  }
-}
+void thfprint(bool verbose, FILE* f, std::string_view msg);
 
 /**
  * @brief Print formatted to stdout.
@@ -120,36 +111,19 @@ void thfprintf(const bool verbose, FILE* f, const FormatStr& format, const Args&
 template <typename FormatStr, typename... Args>
 void thprintf(const FormatStr& format, const Args&... args)
 {
-  thfprintf(thverbose_mode, stdout, format, args...);
+  thfprint(thverbose_mode, stdout, fmt::sprintf(format, args...));
 }
 
 
 /**
- * @brief Print formatted to stderr.
+ * @brief Print to stderr.
  * 
  * This function is used for error reporting, so it catches any additional
  * exceptions in order to not interfere with error handling.
  * 
- * @param format format string
- * @param args arguments to print
+ * @param msg message to print
  */
-template <typename FormatStr, typename... Args>
-void thprintf2err(const FormatStr& format, const Args&... args) noexcept
-{
-  try
-  {
-    thfprintf(true, stderr, format, args...);
-  }
-  catch(const std::exception& e)
-  {
-    std::fprintf(stderr, "error occurred while reporting another error: %s\n", e.what());
-  }
-  catch (...)
-  {
-    std::fprintf(stderr, "unknown error occurred while reporting another error\n");
-  }
-} 
-
+void thprint2err(std::string_view msg) noexcept;
 
 /**
  * Wait a bit.
@@ -172,7 +146,7 @@ extern int therion_exit_state;
 void thprint_environment();
 void thprint_xtherion();
 
-#define thassert(expr) {if (!(expr)) {thprintf2err("%s%s (" __FILE__ ":%d): assertion failed ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__);exit(EXIT_FAILURE);}}
+#define thassert(expr) {if (!(expr)) {thprint2err(fmt::sprintf("%s%s (" __FILE__ ":%d): assertion failed ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__));exit(EXIT_FAILURE);}}
 
 #endif
 

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -67,6 +67,7 @@
 #include <stdlib.h>
 #include "loch/lxMath.h"
 #include "thsvg.h"
+#include "thlog.h"
 #include "img.h"
 #include <filesystem>
 

--- a/thproj.cxx
+++ b/thproj.cxx
@@ -29,6 +29,7 @@
 #include "thproj.h"
 #include "thlogfile.h"
 #include "thcs.h"
+#include "thlog.h"
 #include <string>
 #include <cmath>
 #include <map>

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -39,6 +39,7 @@
 #include "thcsdata.h"
 #include "thlogfile.h"
 #include "therion.h"
+#include "thlog.h"
 #include "img.h"
 #include <math.h>
 #include <string>

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -44,6 +44,7 @@
 #include "thepsparse.h"
 #include "thdatabase.h"
 #include "therion.h"
+#include "thlog.h"
 #include <fmt/printf.h>
 
 thsymbolset::thsymbolset()


### PR DESCRIPTION
I have refactored implementation of printing functions. There is new simple funtion `thprint()` which should replace templated `thprintf()`.