### PR TITLE
Fix new clang tidy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ if (BUILD_THERION)
     # therion lib
     add_library(therion-common STATIC ${THERION_HEADERS} ${THERION_SOURCES})
     target_include_directories(therion-common BEFORE PUBLIC "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
+    target_include_directories(therion-common SYSTEM PUBLIC ${CMAKE_SOURCE_DIR}/extern/stl_reader)
     target_link_libraries(therion-common PUBLIC proj-interface shp-interface poly2tri common-utils QuickHull)
     target_compile_definitions(therion-common PUBLIC "TH${THPLATFORM}" $<$<BOOL:${ENABLE_THDEBUG}>:THDEBUG>)
     add_dependencies(therion-common 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ CXXJFLAGS ?= -DPROJ_VER=$(PROJ_MVER) -I$(shell $(CROSS)pkg-config proj --variabl
 
 
 # compiler settings
-CXXFLAGS = -DIMG_API_VERSION=1 -DP2T_STATIC_EXPORTS -Wall $(CXXPFLAGS) $(CXXBFLAGS) $(CXXJFLAGS) -Iextern -Iextern/shapelib -Iextern/quickhull -Iextern/img -I$(shell $(CROSS)pkg-config fmt --variable=includedir) -std=c++17
+CXXFLAGS = -DIMG_API_VERSION=1 -DP2T_STATIC_EXPORTS -Wall $(CXXPFLAGS) $(CXXBFLAGS) $(CXXJFLAGS) -Iextern -Iextern/shapelib -Iextern/quickhull -Iextern/img -Iextern/stl_reader -I$(shell $(CROSS)pkg-config fmt --variable=includedir) -std=c++17
 CCFLAGS = -DIMG_API_VERSION=1 -Wall $(CCPFLAGS) $(CCBFLAGS)
 OBJECTS = $(addprefix $(OUTDIR)/,$(POBJECTS)) $(addprefix $(OUTDIR)/,$(CMNOBJECTS))
 TESTOBJECTS_P = $(addprefix $(OUTDIR)/,$(TESTOBJECTS))

--- a/thscan.cxx
+++ b/thscan.cxx
@@ -37,7 +37,7 @@
 #include "thinfnan.h"
 #include "thproj.h"
 #include "therion.h"
-#include "extern/stl_reader/stl_reader.h"
+#include "stl_reader.h"
 #include <algorithm>
 #include <filesystem>
 #include <list>

--- a/thscan.h
+++ b/thscan.h
@@ -76,7 +76,7 @@ class thscan : public thdataobject {
   thtflength units; //< Source units.
 
   int datasrc_cs; //< Source CS
-  int datasrc_coords[3]; //< Source coordinates order.
+  int datasrc_coords[3] = {}; //< Source coordinates order.
 
   thdb3ddata d3d; //< Output model.
   bool d3dok; //< Output data.


### PR DESCRIPTION
Fixed clang-tidy warnings which appeared with the 3D scan implementation.