### PR TITLE
Enable C++20

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,11 +6,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-22.04, toolchain: gcc.cmake,              pkgs: "libwxgtk3.0-gtk3-dev libvtk9-dev",        args: "-DUSE_BUNDLED_CATCH2=ON"                         }
-          - { os: ubuntu-22.04, toolchain: clang.cmake,            pkgs: "catch2 libwxgtk3.0-gtk3-dev libvtk9-dev", args: ""                                                }
-          - { os: ubuntu-24.04, toolchain: gcc.cmake,              pkgs: "catch2 libwxgtk3.2-dev libvtk9-dev",      args: ""                                                }
-          - { os: ubuntu-24.04, toolchain: clang-sanitizers.cmake, pkgs: "catch2 libwxgtk3.2-dev libvtk9-dev",      args: ""                                                }
-          - { os: ubuntu-24.04, toolchain: clang.cmake,            pkgs: "catch2 libwxgtk3.2-dev libvtk9-dev",      args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug" }
+          - { os: ubuntu-22.04, toolchain: gcc.cmake,              pkgs: "libwxgtk3.0-gtk3-dev libvtk9-dev",        args: "-DUSE_BUNDLED_CATCH2=ON"                                        }
+          - { os: ubuntu-22.04, toolchain: clang.cmake,            pkgs: "catch2 libwxgtk3.0-gtk3-dev libvtk9-dev", args: ""                                                               }
+          - { os: ubuntu-24.04, toolchain: gcc.cmake,              pkgs: "catch2 libwxgtk3.2-dev libvtk9-dev",      args: "-DCMAKE_CXX_FLAGS=\"-Wno-array-bounds -Wno-stringop-overflow\"" }
+          - { os: ubuntu-24.04, toolchain: clang-sanitizers.cmake, pkgs: "catch2 libwxgtk3.2-dev libvtk9-dev",      args: ""                                                               }
+          - { os: ubuntu-24.04, toolchain: clang.cmake,            pkgs: "catch2 libwxgtk3.2-dev libvtk9-dev",      args: "-DENABLE_CLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug"                }
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(PreventInSourceBuilds)
 
 project(therion)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ CXXJFLAGS ?= -DPROJ_VER=$(PROJ_MVER) -I$(shell $(CROSS)pkg-config proj --variabl
 
 
 # compiler settings
-CXXFLAGS = -DIMG_API_VERSION=1 -DP2T_STATIC_EXPORTS -Wall $(CXXPFLAGS) $(CXXBFLAGS) $(CXXJFLAGS) -Iextern -Iextern/shapelib -Iextern/quickhull -Iextern/img -Iextern/stl_reader -I$(shell $(CROSS)pkg-config fmt --variable=includedir) -std=c++17
+CXXFLAGS = -DIMG_API_VERSION=1 -DP2T_STATIC_EXPORTS -Wall $(CXXPFLAGS) $(CXXBFLAGS) $(CXXJFLAGS) -Iextern -Iextern/shapelib -Iextern/quickhull -Iextern/img -Iextern/stl_reader -I$(shell $(CROSS)pkg-config fmt --variable=includedir) -std=c++20
 CCFLAGS = -DIMG_API_VERSION=1 -Wall $(CCPFLAGS) $(CCBFLAGS)
 OBJECTS = $(addprefix $(OUTDIR)/,$(POBJECTS)) $(addprefix $(OUTDIR)/,$(CMNOBJECTS))
 TESTOBJECTS_P = $(addprefix $(OUTDIR)/,$(TESTOBJECTS))

--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -8,7 +8,7 @@ if (MSVC)
     target_compile_options(enable-warnings INTERFACE /W4)
     target_compile_options(disable-warnings INTERFACE /w)
 else()
-    target_compile_options(enable-warnings INTERFACE -Wall -Wextra)
+    target_compile_options(enable-warnings INTERFACE -Wall -Wextra -Wno-deprecated-enum-enum-conversion)
     target_compile_options(disable-warnings INTERFACE -w)
 endif()
 

--- a/loch/Makefile
+++ b/loch/Makefile
@@ -74,7 +74,7 @@ STRIPFLAG = -s
 ##else
 ##VTKLIBS = -lvtkHybrid -lvtkImaging -lvtkIO -lvtkGraphics -lvtkFiltering -lvtkCommon -lfreetype
 ##endif
-##CXXPFLAGS = -DLXLINUX -std=c++17 $(shell wx-config --cxxflags) -Wno-deprecated $(shell pkg-config freetype2 --cflags) -I$(VTKPATH)
+##CXXPFLAGS = -DLXLINUX -std=c++20 $(shell wx-config --cxxflags) -Wno-deprecated $(shell pkg-config freetype2 --cflags) -I$(VTKPATH)
 ##CCPFLAGS = -DLXLINUX  $(shell wx-config --cflags)
 ##LXLIBDIR = linux
 ##PLIBS = $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS) -lGLU -lGL -lpthread -lX11 -lz
@@ -92,7 +92,7 @@ endif
 #endif
 
 CXXPFLAGS = \
-    -std=c++17 \
+    -std=c++20 \
     -Wno-deprecated \
     $(shell $(WX_CONFIG) --cxxflags) \
     $(shell pkg-config freetype2 --cflags) \
@@ -136,7 +136,7 @@ endif
 ##CXX = $(CROSS)c++
 ##CC = $(CROSS)gcc
 ##POBJECTS = loch.res lxR2D.o
-##CXXPFLAGS = -W -Wall -std=c++17 -DLXWIN32 $(shell $(CROSS)wx-config --static --cxxflags) $(shell $(CROSS)pkg-config freetype2 --cflags) -I$(VTKPATH) -Wno-deprecated
+##CXXPFLAGS = -W -Wall -std=c++20 -DLXWIN32 $(shell $(CROSS)wx-config --static --cxxflags) $(shell $(CROSS)pkg-config freetype2 --cflags) -I$(VTKPATH) -Wno-deprecated
 ##CCPFLAGS = -W -Wall -DLXWIN32 $(shell $(CROSS)wx-config --static --cflags)
 ##LXLIBDIR =
 ##PLIBS = $(shell $(CROSS)pkg-config freetype2 --libs) $(shell $(CROSS)wx-config --static --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS)
@@ -147,7 +147,7 @@ endif
 ##CXX = c++
 ##CC = cc
 ##POBJECTS =
-##CXXPFLAGS = -W -Wall -std=c++17 -DLXMACOSX $(shell wx-config --cxxflags) $(shell pkg-config freetype2 --cflags) -I$(VTKPATH) -Wno-deprecated -I/usr/X11R6/include -I/usr/X11R6/include/freetype2
+##CXXPFLAGS = -W -Wall -std=c++20 -DLXMACOSX $(shell wx-config --cxxflags) $(shell pkg-config freetype2 --cflags) -I$(VTKPATH) -Wno-deprecated -I/usr/X11R6/include -I/usr/X11R6/include/freetype2
 ##CCPFLAGS = -W -Wall -DLXMACOSX $(shell wx-config --cflags) -I/usr/X11R6/include
 ##LXLIBDIR =
 ##PLIBS = -lz -L/usr/X11R6/lib $(shell wx-config --libs --gl-libs) -L$(VTKLIBPATH) $(VTKLIBS)


### PR DESCRIPTION
I propose to enable C++20, wait for a while to see if there are any unexpected problems, and then start using its features. I had to silence some warnings:
* `-Wno-array-bounds`, `-Wno-stringop-overflow` - some versions of GCC emit false positives in STL
* `-Wno-deprecated-enum-enum-conversion` - C++20 deprecates mixing enums of different types, this warning is not fixed in older versions of wxWidgets