### PR TITLE
Removed fmt::sprintf from therror

### DIFF
--- a/thchenc.cxx
+++ b/thchenc.cxx
@@ -79,7 +79,7 @@ void thencode(thbuffer * dest, const char * src, int srcenc)
       
       // longer chars not supported
       else
-        therror(("unicode character over 0xFFFF not supported"));
+        therror("unicode character over 0xFFFF not supported");
     }
     
     srcx++;
@@ -123,7 +123,7 @@ void thdecode(thbuffer * dest, int destenc, const char * src)
         srcp++;
         srcx++;
         if ((srcx >= srcln) || (*srcp < 128))
-          therror(("invalid UTF-8 string -- \"%s\"",src));
+          therror(fmt::format("invalid UTF-8 string -- \"{}\"",src));
         sch += *srcp % 64;
       }
       // three byte UTF-8 character
@@ -132,18 +132,18 @@ void thdecode(thbuffer * dest, int destenc, const char * src)
         srcp++;
         srcx++;
         if ((srcx >= srcln) || (*srcp < 128))
-          therror(("invalid UTF-8 string -- \"%s\"",src));
+          therror(fmt::format("invalid UTF-8 string -- \"{}\"",src));
         sch += 64 * (*srcp % 64);
         srcp++;
         srcx++;
         if ((srcx >= srcln) || (*srcp < 128))
-          therror(("invalid UTF-8 string -- \"%s\"",src));
+          therror(fmt::format("invalid UTF-8 string -- \"{}\"",src));
         sch += *srcp % 64;
       } 
       
       // longer chars not supported
       else
-        therror(("invalid UTF-8 string -- \"%s\"",src));
+        therror(fmt::format("invalid UTF-8 string -- \"{}\"",src));
         
       // now we have whchar_t value of UTF-8 character in sch
       if (sch < thchenc_fucc)

--- a/thcmdline.cxx
+++ b/thcmdline.cxx
@@ -200,7 +200,7 @@ void thcmdline::process(int argc, char * argv[])
         break;
         
       default:
-    	therror(("unknown command line option"));
+    	therror("unknown command line option");
 		break;
         
     }

--- a/thdatabase.cxx
+++ b/thdatabase.cxx
@@ -540,8 +540,8 @@ void thdatabase::end_insert()
   if (this->csurveyptr->id != this->fsurveyptr->id) {
     thdb_revision_set_type::iterator ii = 
         this->revision_set.find(threvision(this->csurveyptr->id, 0));
-    therror(("%s [%lu] -- incomplete survey - endsurvey pair -- %s",
-      ii->srcf.name, ii->srcf.line, this->csurveyptr->full_name))
+    therror(fmt::format("{} [{}] -- incomplete survey - endsurvey pair -- {}",
+      ii->srcf.name, ii->srcf.line, this->csurveyptr->full_name));
   }
 }
 

--- a/thepsparse.cxx
+++ b/thepsparse.cxx
@@ -50,7 +50,7 @@
 #include "thdouble.h"
 #include "thexception.h"
 
-#define IOerr(F) fmt::format("Can't open file {}!\n", (F)).c_str()
+#define IOerr(F) fmt::format("Can't open file {}!\n", (F))
 
 std::map<std::string,std::string> ALL_FONTS, ALL_PATTERNS;
 typedef std::set<unsigned char> FONTCHARS;
@@ -130,7 +130,7 @@ std::string color::to_svg() const {
     g = 1.0 - std::min(1.0, this->b + this->d);
     b = 1.0 - std::min(1.0, this->c + this->d);
   }
-  else therror(("undefined color used"));
+  else therror("undefined color used");
   return fmt::format("#{:02x}{:02x}{:02x}",int(255*r) % 256,
                                            int(255*g) % 256,
                                            int(255*b) % 256);
@@ -438,7 +438,7 @@ void MP_path::print_pdf(std::ofstream & F) const {
   else if (fillstroke == MP_stroke) F << PL("S");
   else if (fillstroke == MP_fillstroke) F << PL("B*");
   else if (fillstroke == MP_clip) F << PL("W* n");
-  else therror(("invalid path drawing operation"));
+  else therror("invalid path drawing operation");
 }
 
 void MP_data::add(int i) {
@@ -848,7 +848,7 @@ void converted_data::print_pdf(std::ofstream & F, std::string name) const {
     else if (mode == 30) outname = tex_Lname(name);
     else if (31 <= mode && mode <= 32) outname = tex_Wname(name);
     else if (mode > 100 && mode < 110) outname = tex_Wname(name);
-    else therror(("invalid conversion mode"));
+    else therror("invalid conversion mode");
     F << "\\xxx\n" << tex_set_ref(outname,"\\pdflastxform") << '\n';
   }
 }
@@ -929,7 +929,7 @@ void parse_eps(std::string fname, std::string cname, double dx, double dy,
   data.mode = mode;
 
   std::ifstream F(fname.c_str());
-  if(!F) therror((IOerr(fname)));
+  if(!F) therror(IOerr(fname));
   while(F >> tok) {
     if (comment) {                      // File header
       if (tok == "%%BoundingBox:") {
@@ -954,7 +954,7 @@ void parse_eps(std::string fname, std::string cname, double dx, double dy,
                            // for F and G scraps
           data.MP.add(MP_gsave);
           std::ifstream G(cname.c_str());
-          if(!G) therror((IOerr(cname)));
+          if(!G) therror(IOerr(cname));
           mp_path.clear();
           while(G >> buffer) {
             if (buffer == "m") {
@@ -1144,7 +1144,7 @@ void parse_eps(std::string fname, std::string cname, double dx, double dy,
             }
           } else throw thexception("invalid buffer size");
         } catch (const std::exception& e) {
-          therror((e.what()));
+          therror(e.what());
         }
         if (FORM_GRADIENTS.find(u2str(patt_id)) == FORM_GRADIENTS.end()) {
           FORM_GRADIENTS.insert(u2str(patt_id));
@@ -1369,7 +1369,7 @@ void convert_scraps_new() {
   PATTERNLIST.clear();
 
   std::ifstream P("patterns.dat");
-  if(!P) therror(("Can't open patterns definition file!"));
+  if(!P) therror("Can't open patterns definition file!");
   char buf[5000];
   char delim[] = ":";
   std::string num,pfile,bbox,xstep,ystep,matr;
@@ -1435,7 +1435,7 @@ int thconvert_eps() {
 
 void thgraphics2pdf() {
   std::ofstream TEX("th_formdef.tex");
-  if(!TEX) therror((IOerr("th_formdef.tex")));
+  if(!TEX) therror(IOerr("th_formdef.tex"));
 
   for(const auto &I: SCRAPLIST) {
     I.Fc.print_pdf(TEX, I.name);
@@ -1499,7 +1499,7 @@ void thgraphics2pdf() {
 
 
   std::ofstream F("th_fontdef.tex");
-  if(!F) therror((IOerr("th_fontdef.tex")));
+  if(!F) therror(IOerr("th_fontdef.tex"));
   F << "% FONTS:\n";
   F.setf(std::ios::fixed, std::ios::floatfield);
   F.precision(2);
@@ -1573,7 +1573,7 @@ void thgraphics2pdf() {
   for (auto &i: SCRAPLIST) {
       if (LAYOUT.smooth_shading == shading_mode::off || i.gour_stream == "") continue;
       std::ofstream F_g("th_gour_"+i.name+".dat", std::ios::out | std::ios::binary);
-      if(!F_g) therror((IOerr("th_gour_"+i.name)));
+      if(!F_g) therror(IOerr("th_gour_"+i.name));
       F_g << i.gour_stream;
       F_g.close();
       F << "\\immediate\\pdfobj stream attr {";
@@ -1595,7 +1595,7 @@ void thgraphics2pdf() {
     legend_arr_d.push_back(I->descr);
   }
   std::ofstream LEG("th_legend.tex");
-  if(!LEG) therror((IOerr("th_legend.tex")));
+  if(!LEG) therror(IOerr("th_legend.tex"));
 /*  for(list<legendrecord>::iterator I = LEGENDLIST.begin();
                                    I != LEGENDLIST.end(); I++) {
     LEG << "\\legendsymbolbox{" << tex_get_ref(tex_Lname(I->name)) << "}{" <<
@@ -1630,7 +1630,7 @@ void thgraphics2pdf() {
     legend_color.push_back(lcr);
   }
   std::ofstream LEGCOLOR("th_legendcolor.tex");
-  if(!LEGCOLOR) therror((IOerr("th_legendcolor.tex")));
+  if(!LEGCOLOR) therror(IOerr("th_legendcolor.tex"));
 
   if (LAYOUT.altitudebar == "") {
     legendbox_num = COLORLEGENDLIST.size();

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -156,7 +156,7 @@ int main(int argc, char * argv[]) {
     thconfig_src_list * sources = thcfg.get_sources();
     thconfig_src_list::iterator srcit;
     if (sources->size() == 0)
-      therror(("source files not specified"));
+      therror("source files not specified");
 #ifndef THDEBUG
     thprint("reading source files ... ");
     thtext_inline = true;
@@ -251,7 +251,7 @@ int main(int argc, char * argv[]) {
   }
   catch(const std::exception& e)
   {
-      therror((e.what()));
+      therror(e.what());
   }
 #endif
 

--- a/therion.h
+++ b/therion.h
@@ -58,7 +58,7 @@
  
 #define therror(P) {\
   thprint_error_src();\
-  thprint2err(fmt::sprintf P );\
+  thprint2err(P);\
   thprint2err("\n");\
   thpause_exit();\
   therion_exit_state = 0;\

--- a/thexporter.cxx
+++ b/thexporter.cxx
@@ -174,7 +174,7 @@ void thexporter::export_db(class thdatabase * dp)
 
 	  }
 	  thprint("done.\n");
-	  if (!ok) therror(("CRC32 checks not passed.\n"));
+	  if (!ok) therror("CRC32 checks not passed.\n");
   }
 
   

--- a/thinput.cxx
+++ b/thinput.cxx
@@ -330,12 +330,12 @@ void thinput::open_file(char * fname)
     }
 #ifdef THWIN32
     if (n_rec == THMAXFREC) {
-      therror(("%s [%lu] -- too many file inclusions -- probably input recursion -- %s", \
+      therror(fmt::format("{} [{}] -- too many file inclusions -- probably input recursion -- {}", \
       this->get_cif_name(), this->get_cif_line_number(), fname));
     }
 #else
     if (is_rec) {
-      therror(("%s [%lu] -- recursive file inclusion -- %s", \
+      therror(fmt::format("{} [{}] -- recursive file inclusion -- {}", \
       this->get_cif_name(), this->get_cif_line_number(), fname));
     }
 #endif
@@ -417,7 +417,7 @@ char * thinput::read_line()
     // Check, if reading was OK.
     
     if (this->last_ptr->sh.fail() && (!(this->last_ptr->sh.eof()))) {
-      therror(("%s [%lu] -- line too long", \
+      therror(fmt::format("{} [{}] -- line too long", \
         this->get_cif_name(), this->get_cif_line_number()));
     }
     
@@ -469,7 +469,7 @@ char * thinput::read_line()
         case TT_INPUT:
           if (this->input_sensitivity) {
             if (this->tmpmb.get_size() != 1)
-              therror(("%s [%lu] -- one input file name expected -- %s", \
+              therror(fmt::format("{} [{}] -- one input file name expected -- {}", \
                 this->get_cif_name(), this->get_cif_line_number(), \
                 this->valuebf.get_buffer()))
             else
@@ -479,13 +479,13 @@ char * thinput::read_line()
           
         case TT_ENCODING:
           if (this->tmpmb.get_size() != 1)
-            therror(("%s [%lu] -- encoding name expected -- %s", \
+            therror(fmt::format("{} [{}] -- encoding name expected -- {}", \
               this->get_cif_name(), this->get_cif_line_number(), \
               this->valuebf.get_buffer()));
           this->last_ptr->encoding = \
             thmatch_token(*(this->tmpmb.get_buffer()), thtt_encoding);
           if (this->last_ptr->encoding == TT_UNKNOWN_ENCODING) {
-            therror(("%s [%lu] -- unknown encoding -- %s", \
+            therror(fmt::format("{} [{}] -- unknown encoding -- {}", \
               this->get_cif_name(), this->get_cif_line_number(), \
               this->valuebf.get_buffer()));
             this->last_ptr->encoding = TT_UTF_8;

--- a/thpdf.cxx
+++ b/thpdf.cxx
@@ -54,7 +54,7 @@
 #include "thcs.h"
 #include "thproj.h"
 
-#define IOerr(F) fmt::format("Can't open file {}!\n", (F)).c_str()
+#define IOerr(F) fmt::format("Can't open file {}!\n", (F))
 
 
 
@@ -105,12 +105,12 @@ double HS,VS;
 //////////
 
 std::string black2pdf(double shade, fillstroke fs) {    // shade: 0 = white, 1 = black
-  if (shade < 0 || shade > 1) therror((fmt::format("shade {} out of range <0,1>",shade).c_str()));
+  if (shade < 0 || shade > 1) therror(fmt::format("shade {} out of range <0,1>",shade));
   color c;
   if (LAYOUT.output_colormodel == colormodel::grey) c.set(1-shade);
   else if (LAYOUT.output_colormodel == colormodel::rgb) c.set(1-shade, 1-shade, 1-shade);
   else if (LAYOUT.output_colormodel == colormodel::cmyk) c.set(0, 0, 0, shade);
-  else therror (("invalid color model"));
+  else therror ("invalid color model");
   return c.to_pdfliteral(fs);
 }
 
@@ -204,10 +204,10 @@ void make_sheets() {
     };
 
     if (llx == DBL_MAX || lly == DBL_MAX || urx == -DBL_MAX || ury == -DBL_MAX) 
-      therror(("This can't happen -- no data for a scrap!"));
+      therror("This can't happen -- no data for a scrap!");
     
     std::map<int,layerrecord>::iterator J = LAYERHASH.find(I->layer);
-    if (J == LAYERHASH.end()) therror (("This can't happen!"));
+    if (J == LAYERHASH.end()) therror ("This can't happen!");
 
     if (mode == ATLAS) {
       int Llx = (int) floor((llx-LAYOUT.overlap-LAYOUT.hoffset) / LAYOUT.hsize);
@@ -314,13 +314,13 @@ void find_jumps() {
     }
 
     std::map<int,layerrecord>::iterator lay_it = LAYERHASH.find(sheet_it->layer);
-    if (lay_it == LAYERHASH.end()) therror (("This can't happen!"));
+    if (lay_it == LAYERHASH.end()) therror ("This can't happen!");
 
     if (!lay_it->second.U.empty()) {
       for (std::set<int>::iterator l_it = lay_it->second.U.begin(); 
                               l_it != lay_it->second.U.end(); l_it++) {
         std::map<int,layerrecord>::iterator alt_lay_it = LAYERHASH.find(*l_it);
-        if (alt_lay_it == LAYERHASH.end()) therror(("This can't happen!"));
+        if (alt_lay_it == LAYERHASH.end()) therror("This can't happen!");
         jump = (alt_lay_it->second.Z == 0) ? *l_it : alt_lay_it->second.AltJump;
         std::string U = xyz2str(jump,sheet_it->namex,sheet_it->namey);
         if (SHEET_JMP.count(U) > 0) {
@@ -334,7 +334,7 @@ void find_jumps() {
       for (std::set<int>::iterator l_it = lay_it->second.D.begin(); 
                               l_it != lay_it->second.D.end(); l_it++) {
         std::map<int,layerrecord>::iterator alt_lay_it = LAYERHASH.find(*l_it);
-        if (alt_lay_it == LAYERHASH.end()) therror(("This can't happen!"));
+        if (alt_lay_it == LAYERHASH.end()) therror("This can't happen!");
         jump = (alt_lay_it->second.Z == 0) ? *l_it : alt_lay_it->second.AltJump;
         std::string D = xyz2str(jump,sheet_it->namex,sheet_it->namey);
         if (SHEET_JMP.count(D) > 0) {
@@ -397,7 +397,7 @@ std::set<int> find_excluded_pages(std::string s) {
       for (int k=i; k<=j; k++) excl.insert(k);
       S >> c;   // punctuation character
     }
-    else therror(("Invalid character in the exclusion list!"));
+    else therror("Invalid character in the exclusion list!");
   }
 //cout << '\n';
 //cout << "Excl.list: " << s << '\n';  
@@ -488,7 +488,7 @@ void print_preview(int up,std::ofstream& PAGEDEF,double HSHIFT,double VSHIFT,
 
   if (mode == ATLAS) {
     std::map<int,layerrecord>::iterator lay_it = LAYERHASH.find(sheet_it->layer);
-    if (lay_it == LAYERHASH.end()) therror(("This can't happen!"));
+    if (lay_it == LAYERHASH.end()) therror("This can't happen!");
     used_layers = (up ? lay_it->second.U : lay_it->second.D);
   }
   else {
@@ -502,7 +502,7 @@ void print_preview(int up,std::ofstream& PAGEDEF,double HSHIFT,double VSHIFT,
     }
     else {
       std::map<int,layerrecord>::iterator J = LAYERHASH.find(*I);
-      if (J == LAYERHASH.end()) therror(("This can't happen!"));
+      if (J == LAYERHASH.end()) therror("This can't happen!");
       used_scraps = J->second.allscraps;
     }
     if (!used_scraps.empty()) {
@@ -550,7 +550,7 @@ void print_preview(int up,std::ofstream& PAGEDEF,double HSHIFT,double VSHIFT,
 
 void compose_page(std::list<sheetrecord>::iterator sheet_it, std::ofstream& PAGE) {
   std::map<int,layerrecord>::iterator lay_it = LAYERHASH.find(sheet_it->layer);
-  if (lay_it == LAYERHASH.end()) therror (("This can't happen!"));
+  if (lay_it == LAYERHASH.end()) therror ("This can't happen!");
 
   if (sheet_it->title_before) {
     PAGE << "\\TITLE{" << utf2tex(lay_it->second.T) << "}\n";
@@ -603,7 +603,7 @@ void compose_page(std::list<sheetrecord>::iterator sheet_it, std::ofstream& PAGE
                                     l_it != sheet_it->jumpU.rend(); l_it++) {
       std::list<sheetrecord>::iterator s_it = 
         find_sheet(*l_it,sheet_it->namex,sheet_it->namey);
-      if (s_it == SHEET.end()) therror (("This can't happen!"));
+      if (s_it == SHEET.end()) therror ("This can't happen!");
       PAGE << utf2tex(LAYERHASH.find(*l_it)->second.N) << "|" <<
            s_it->id << "|" << u2str(s_it->id) << "||%\n";
     }
@@ -617,7 +617,7 @@ void compose_page(std::list<sheetrecord>::iterator sheet_it, std::ofstream& PAGE
                                     l_it != sheet_it->jumpD.rend(); l_it++) {
       std::list<sheetrecord>::iterator s_it = 
         find_sheet(*l_it,sheet_it->namex,sheet_it->namey);
-      if (s_it == SHEET.end()) therror (("This can't happen!"));
+      if (s_it == SHEET.end()) therror ("This can't happen!");
       PAGE << utf2tex(LAYERHASH.find(*l_it)->second.N) << "|" <<
            s_it->id << "|" << u2str(s_it->id) << "||%\n";
     }
@@ -1032,7 +1032,7 @@ void print_map(int layer, std::ofstream& PAGEDEF,
           K->P != "" && K->level >= (I->first)) {
         xc = HSHIFT - K->S1; yc = VSHIFT - K->S2;
         std::ifstream G((K->P).c_str());
-        if(!G) therror((IOerr(K->P)));
+        if(!G) therror(IOerr(K->P));
         while(G >> buffer) {
           if ((buffer == "m") || (buffer == "l") || (buffer == "c")) {
             PAGEDEF << "\\PL{"; 
@@ -1048,7 +1048,7 @@ void print_map(int layer, std::ofstream& PAGEDEF,
           }
         }
         G.close();
-        if (!thstack.empty()) therror(("This can't happen -- bad text clipping path!"));
+        if (!thstack.empty()) therror("This can't happen -- bad text clipping path!");
       };
     }
   
@@ -1130,7 +1130,7 @@ void print_navigator(std::ofstream& P, std::list<sheetrecord>::iterator sheet_it
   //P.precision(2);
 
   std::map<int,layerrecord>::iterator lay_it = LAYERHASH.find(sheet_it->layer);
-  if (lay_it == LAYERHASH.end()) therror (("This can't happen!"));
+  if (lay_it == LAYERHASH.end()) therror ("This can't happen!");
 
   NAV_SCRAPS.clear();
   if (!lay_it->second.D.empty()) {
@@ -1271,28 +1271,28 @@ void print_margins(std::ofstream& PAGEDEF) {
 
 void icc_check_file(std::string fname, std::string type) {
   std::ifstream iccfile(fname, std::ios::binary);
-  if(!iccfile) therror((IOerr(fname)));
+  if(!iccfile) therror(IOerr(fname));
   char buffer[5];
   iccfile.seekg(16);
   iccfile.read(buffer,4);
   buffer[4] = '\0';
-  if (type != std::string(buffer)) therror(((std::string("Invalid ICC profile type: expected ")+type+", got "+buffer).c_str()));
+  if (type != std::string(buffer)) therror(fmt::format("Invalid ICC profile type: expected {}, got {}", type, buffer));
 }
 
 void build_pages() {
   
   std::ofstream PAGEDEF("th_pagedef.tex");
-  if(!PAGEDEF) therror(("Can't write file th_pagedef.tex"));
+  if(!PAGEDEF) therror("Can't write file th_pagedef.tex");
   PAGEDEF.setf(std::ios::fixed, std::ios::floatfield);
   PAGEDEF.precision(2);
 
   std::ofstream PAGE("th_pages.tex");
-  if(!PAGE) therror(("Can't write file th_pages.tex"));
+  if(!PAGE) therror("Can't write file th_pages.tex");
   PAGE.setf(std::ios::fixed, std::ios::floatfield);
   PAGE.precision(2);
 
   std::ofstream PDFRES("th_resources.tex");
-  if(!PDFRES) therror(("Can't write file th_resources.tex"));
+  if(!PDFRES) therror("Can't write file th_resources.tex");
 
   PDFRES << "\\pdfminorversion=7%\n";
 
@@ -1510,7 +1510,7 @@ R"(\pdfcompresslevel=9%
     HS = MAXX - MINX;
     VS = MAXY - MINY;
     if (HS>14000 || VS>14000) 
-      therror(("Map is too large for PDF format. Try smaller scale!"));
+      therror("Map is too large for PDF format. Try smaller scale!");
     PAGEDEF << "\\eject\n";
     PAGEDEF << "\\hsize=" << fmt::format("{}",thdouble(HS,prec_xy)) << "bp\n";
     PAGEDEF << "\\vsize=" << fmt::format("{}",thdouble(VS,prec_xy)) << "bp\n";

--- a/thproj.cxx
+++ b/thproj.cxx
@@ -169,7 +169,7 @@ void th_init_proj(PJ * &P, std::string s) {
     // download all tif grids from the Proj CDN
     if (!proj_context_set_enable_network(PJ_DEFAULT_CTX, 1)) {
       proj_destroy(P);
-      therror(("couldn't enable network access for Proj"));
+      therror("couldn't enable network access for Proj");
     }
     for (auto & f: grids) {
 #if PROJ_VER >= 8  // supported since 7.1.0
@@ -180,12 +180,12 @@ void th_init_proj(PJ * &P, std::string s) {
 #endif
       if (!proj_download_file(PJ_DEFAULT_CTX, f.c_str(), 0, NULL, NULL)) {
         proj_destroy(P);
-        therror(("couldn't download the grid"));
+        therror("couldn't download the grid");
       }
     }
     if (proj_context_set_enable_network(PJ_DEFAULT_CTX, 0)) { // disable the network to prevent Proj from automatic caching
       proj_destroy(P);
-      therror(("couldn't disable network access for Proj"));
+      therror("couldn't disable network access for Proj");
     }
     thprint("done\n");
 
@@ -197,7 +197,7 @@ void th_init_proj(PJ * &P, std::string s) {
     std::ostringstream u;
     u << "PROJ library: " << proj_errno(P) << " (" << proj_errno_string(proj_errno(P)) << "): " << s;
     proj_destroy(P);
-    therror((u.str().c_str()));
+    therror(u.str());
   }
 }
 
@@ -213,7 +213,7 @@ void th_init_proj_auto(PJ * &P, int si, int ti) {
 #if PROJ_VER >= 7
   (thcs_cfg.proj_auto_grid == GRID_CACHE && !proj_context_is_network_enabled(PJ_DEFAULT_CTX)) {
     if (!proj_context_set_enable_network(PJ_DEFAULT_CTX, 1)) {
-      therror(("couldn't enable network access for Proj"));
+      therror("couldn't enable network access for Proj");
     }
     proj_grid_cache_set_enable(PJ_DEFAULT_CTX, 1);
     thprint("network access for Proj library enabled...\n");
@@ -240,12 +240,12 @@ void th_init_proj_auto(PJ * &P, int si, int ti) {
     const char * short_name, * url;
     if (proj_list_get_count(ops) < 1) {
       proj_list_destroy(ops);
-      therror(("no usable coordinate transformation found"));
+      therror("no usable coordinate transformation found");
     }
     for (int i = 0; i < 1; i++) {   // let's look just at the first operation instead of up to proj_list_get_count(ops)
       PJ* P_tmp = proj_list_get(PJ_DEFAULT_CTX, ops, i);
 //      if (proj_coordoperation_has_ballpark_transformation(PJ_DEFAULT_CTX, P_tmp))
-//        therror(("no reasonably precise coordinate transformation found"));
+//        therror("no reasonably precise coordinate transformation found");
       if (!proj_coordoperation_is_instantiable(PJ_DEFAULT_CTX, P_tmp)) {
         for (int j = 0; j < proj_coordoperation_get_grid_used_count(PJ_DEFAULT_CTX, P_tmp); j++) {
           proj_coordoperation_get_grid_used(PJ_DEFAULT_CTX, P_tmp, j,
@@ -258,14 +258,14 @@ void th_init_proj_auto(PJ * &P, int si, int ti) {
             case GRID_FAIL:
               proj_destroy(P_tmp);
               proj_list_destroy(ops);
-              therror((s_tmp.c_str()));
+              therror(s_tmp);
               break;
 #if PROJ_VER >= 7
             case GRID_DOWNLOAD:
               if (!proj_context_set_enable_network(PJ_DEFAULT_CTX, 1)) {
                 proj_destroy(P_tmp);
                 proj_list_destroy(ops);
-                therror(("couldn't enable network access for Proj"));
+                therror("couldn't enable network access for Proj");
               }
 #if PROJ_VER >= 8  // supported since 7.1.0
               thprint(fmt::format("downloading the grid {} from {} into {}...\n", url, proj_context_get_url_endpoint(PJ_DEFAULT_CTX),
@@ -276,12 +276,12 @@ void th_init_proj_auto(PJ * &P, int si, int ti) {
               if (!proj_download_file(PJ_DEFAULT_CTX, url, 0, NULL, NULL)) {
                 proj_destroy(P_tmp);
                 proj_list_destroy(ops);
-                therror(("couldn't download the grid"));
+                therror("couldn't download the grid");
               }
               if (proj_context_set_enable_network(PJ_DEFAULT_CTX, 0)) { // disable the network to prevent Proj from automatic caching
                 proj_destroy(P_tmp);
                 proj_list_destroy(ops);
-                therror(("couldn't disable network access for Proj"));
+                therror("couldn't disable network access for Proj");
               }
               thprint("done\n");
               break;
@@ -305,7 +305,7 @@ void th_init_proj_auto(PJ * &P, int si, int ti) {
     std::ostringstream u;
     u << "PROJ library: " << proj_errno(P) << " (" << proj_errno_string(proj_errno(P)) << ")";
     proj_destroy(P);
-    therror((u.str().c_str()));
+    therror(u.str());
   }
   PJ* P_for_GIS = proj_normalize_for_visualization(PJ_DEFAULT_CTX, P);
   if( 0 == P_for_GIS )  {
@@ -313,13 +313,13 @@ void th_init_proj_auto(PJ * &P, int si, int ti) {
     u << "PROJ library: " << proj_errno(P_for_GIS) << " (" << proj_errno_string(proj_errno(P_for_GIS)) << ")";
     proj_destroy(P);
     proj_destroy(P_for_GIS);
-    therror((u.str().c_str()));
+    therror(u.str());
   }
   proj_destroy(P);
   P = P_for_GIS;
 
   if (!cache.add(si,ti,thcs_cfg.bbox,P))
-    therror(("could not add projection to the cache, it's already there -- should not happen"));
+    therror("could not add projection to the cache, it's already there -- should not happen");
 }
 
 void thcs2cs(int si, int ti,
@@ -375,7 +375,7 @@ signed int thcs2zone(int s, double a, double b, double c) {
 double thcsconverg(int s, double a, double b) {
   double c = 0, x, y, z, x2, y2, z2;
   if (thcs_islatlong(thcs_get_params(s)))
-    therror(("can't determine meridian convergence for lat-long systems"));
+    therror("can't determine meridian convergence for lat-long systems");
   thcs2cs(s,TTCS_EPSG + 4326,a,b,c,x,y,z);
   y += 1e-6;
   thcs2cs(TTCS_EPSG + 4326,s,x,y,z,x2,y2,z2);
@@ -427,17 +427,17 @@ std::vector<axis_orient> thcs_axesinfo(int cs, double &scale, bool &gis_ok) {
   if (proj_get_type(P) == PJ_TYPE_BOUND_CRS) {
     P2 = proj_get_source_crs(PJ_DEFAULT_CTX, P);
     proj_destroy(P);
-    if (P2 == nullptr) therror(("invalid bound crs conversion -- should not happen"));
+    if (P2 == nullptr) therror("invalid bound crs conversion -- should not happen");
     P = P2;
   } else if (proj_get_type(P) == PJ_TYPE_COMPOUND_CRS) {
     P2 = proj_crs_get_sub_crs(PJ_DEFAULT_CTX, P, 0);
     proj_destroy(P);
-    if (P2 == nullptr) therror(("invalid compound crs conversion -- should not happen"));
+    if (P2 == nullptr) therror("invalid compound crs conversion -- should not happen");
     P = P2;
   }
   CS = proj_crs_get_coordinate_system(PJ_DEFAULT_CTX, P);
   proj_destroy(P);
-  if (CS == nullptr) therror(("invalid coordinate system -- should not happen"));
+  if (CS == nullptr) therror("invalid coordinate system -- should not happen");
   int count = proj_cs_get_axis_count(PJ_DEFAULT_CTX, CS);
   const char *outdir = nullptr, *unit_name = nullptr;
   double conv_factor = 0;
@@ -451,7 +451,7 @@ std::vector<axis_orient> thcs_axesinfo(int cs, double &scale, bool &gis_ok) {
     // units and scale
     if (axis_units.find(unit_name) != axis_units.end()) {
       if (i == 0) scale = conv_factor;
-      else if (scale != conv_factor) therror(("inconsistent axes scales"));
+      else if (scale != conv_factor) therror("inconsistent axes scales");
     } else {
       scale = 0;
       gis_ok = false;

--- a/thsvg.cxx
+++ b/thsvg.cxx
@@ -140,7 +140,7 @@ void base64_encode(const char * fname, std::ofstream & fout) {
   unsigned char out_buffer[4];
 
   std::ifstream fin(fname, std::ios::binary);
-  if (!fin) therror((fmt::format("Can't read file {}!\n", fname).c_str()));
+  if (!fin) therror(fmt::format("Can't read file {}!\n", fname));
 
   do {
       for (int i = 0; i < 3; i++) in_buffer[i] = '\x0';
@@ -230,7 +230,7 @@ void find_dimensions(double & MINX,double & MINY,double & MAXX,double & MAXY) {
 
 
     if (llx == DBL_MAX || lly == DBL_MAX || urx == -DBL_MAX || ury == -DBL_MAX) 
-      therror(("This can't happen -- no data for a scrap!"));
+      therror("This can't happen -- no data for a scrap!");
     
     std::map<int,layerrecord>::iterator J = LAYERHASH.find(I->layer);
     thassert(J != LAYERHASH.end());

--- a/thtexfonts.cxx
+++ b/thtexfonts.cxx
@@ -96,7 +96,7 @@ void encodings_new::write_enc_files() {
   std::string s, fc;
 
   std::ofstream H ("thfonts.map"); // delete previous file, we will append to it below
-  if (!H) therror(("could not write font mapping data for pdfTeX\n"));
+  if (!H) therror("could not write font mapping data for pdfTeX\n");
   H.close();
 
   int fcount = get_enc_count();
@@ -105,7 +105,7 @@ void encodings_new::write_enc_files() {
     std::string fname_enc = std::string("th_enc")+fc+".enc";
     
     std::ofstream F(fname_enc.c_str());
-    if (!F) therror(("could not write encoding file\n"));
+    if (!F) therror("could not write encoding file\n");
     F << "% LIGKERN uni002D uni002D =: uni2013 ; uni2013 uni002D =: uni2014 ;\n";
     F << "% LIGKERN uni0066 uni0066 =: uniFB00 ; uni0066 uni006C =: uniFB02 ; uni0066 uni0069 =: uniFB01 ; uniFB00 uni0069 =: uniFB03 ; uniFB00 uni006C =: uniFB04 ;\n";
     F << "/" << fname_enc << "[\n";
@@ -135,20 +135,20 @@ void encodings_new::write_enc_files() {
 //        " -fkern --no-default-ligkern --name " + fname_tfm +
 //        type1 + " --warn-missing "+otf_file[i]+" > thotftfm.tmp").c_str()) > 0)
         type1 + otf_file[i]+" > thotftfm.tmp").c_str()) != 0)
-          therror((("can't generate TFM file from "+otf_file[i]+" (LCDF typetools not installed?)").c_str()));
+          therror(fmt::format("can't generate TFM file from {} (LCDF typetools not installed?)", otf_file[i]));
       std::ifstream G ("thotftfm.tmp");
-      if (!G) therror(("could not read font mapping data\n"));
+      if (!G) therror("could not read font mapping data\n");
       while (G) {
         std::getline(G,s);
         if (s.find("<") != std::string::npos) break;
       }
-      if (s.size() < 10) therror(("no usable otftotfm output"));
+      if (s.size() < 10) therror("no usable otftotfm output");
       if (s.substr(s.size()-3,3)=="otf" || s.substr(s.size()-3,3)=="OTF") {
         s.replace(s.rfind("<"), 1, "<<");  // OTF fonts must be fully embedded
       }
       G.close();
       std::ofstream H ("thfonts.map", std::ios::app); 
-      if (!H) therror(("could not write font mapping data for pdfTeX\n"));
+      if (!H) therror("could not write font mapping data for pdfTeX\n");
       H << "\\pdfmapline{+" << s << "}\n";
       H.close();
     }
@@ -239,8 +239,7 @@ unistr utf2uni(std::string s) {
       j += c-128;
       t.push_back(j);
     }
-    else therror (("Invalid utf-8 string!")); // we don't support higher
-                                              // unicode characters
+    else therror ("Invalid utf-8 string!"); // we don't support higher unicode characters
   }
   return t;
 }
@@ -366,7 +365,7 @@ std::string utf2tex(std::string str, bool remove_kerning) {
 //  size_t i=-1,j;
 //  while((i = str.find("<link:",i+1)) != string::npos) {
 //      j = str.find(">",i);
-//      if (j == string::npos) therror(("No closing '>' in <link:...> definition"));
+//      if (j == string::npos) therror("No closing '>' in <link:...> definition");
 //      str = str.replace(j,1,"\x1B\x0B");
 //      str = str.replace(i,6,"\x1B\x0A");
 //  }
@@ -391,7 +390,7 @@ std::string utf2tex(std::string str, bool remove_kerning) {
       out += match.prefix().str() + "\x1B\xE" + (char) (std::max((int) std::round(std::stod(match.str(2)) / 10), 1));
     else if (match.str(1) == match.str(2))   // font size in points; limited to <1,127>
       out += match.prefix().str() + "\x1B\xD" + (char) (std::min(std::max(std::stoi(match.str(2)),1),127));
-    else therror(("invalid font size specification"));
+    else therror("invalid font size specification");
   }
   out.append(it, end);
   str = out;
@@ -617,7 +616,7 @@ int tex2uni(std::string font, int ch) {
       s << "can't map character 0x" << std::uppercase << std::setfill('0') << 
            std::setw(2) << std::hex << ch << 
            " in font '" << font << "' to unicode";
-      therror((s.str().c_str()));
+      therror(s.str());
     }
     return texenc[ch][id];
   } else {  // NFSS
@@ -636,7 +635,7 @@ int tex2uni(std::string font, int ch) {
 
 void print_fonts_setup() {
   std::ofstream P("th_enc.tex");  // included also in MetaPost
-  if(!P) therror(("Can't write file th_enc.tex"));
+  if(!P) therror("Can't write file th_enc.tex");
   P << "\\def\\rms{\\rm}\n";
   P << "\\def\\its{\\it}\n";
   P << "\\def\\bfs{\\bf}\n";

--- a/thtmpdir.cxx
+++ b/thtmpdir.cxx
@@ -123,7 +123,7 @@ void thtmpdir::create() try
 }
 catch (const std::exception& e)
 {
-  therror(("can't create temporary directory -- %s", e.what()));
+  therror(fmt::format("can't create temporary directory -- {}", e.what()));
 }
 
 


### PR DESCRIPTION
`therror` no longer depends on `fmt`.