### PR TITLE
Removed fmt/printf.h

### DIFF
--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -50,7 +50,7 @@
 #include "lxR2P.h"
 #endif
 
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 #define LXTRCBORDER (this->m_renderData->m_scaleMode == LXRENDER_FIT_SCREEN ? 0 : 16)
 
@@ -1277,9 +1277,9 @@ void lxGLCanvas::RenderOffList()
       // altitude
       if (this->setup->m_stlabel_altitude) {
         if (this->frame->m_iniUnits == 1) {
-          strCBar = fmt::sprintf("%.0f ft", st->pos.z / 0.3048);
+          strCBar = fmt::format("{:.0f} ft", st->pos.z / 0.3048);
         } else {
-          strCBar = fmt::sprintf("%.0f m", st->pos.z);
+          strCBar = fmt::format("{:.0f} m", st->pos.z);
         }
         if (cmnt.length() > 0) cmnt += ":";
         cmnt += strCBar;
@@ -1702,9 +1702,9 @@ void lxGLCanvas::RenderIDepthbar(double size)
     clrOutCntr();
     this->RenderILine(dbw, double(t) * size / 10.0, dbw + dbtw, double(t) * size / 10.0);
     if (this->frame->m_iniUnits == 1) {
-      strCBar = fmt::sprintf("%.0f ft", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])) / 0.3048);
+      strCBar = fmt::format("{:.0f} ft", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])) / 0.3048);
     } else {
-      strCBar = fmt::sprintf("%.0f m", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])));
+      strCBar = fmt::format("{:.0f} m", (clr[0] + double(t) / 10.0 * (clr[1] - clr[0])));
     }
     this->GetFontNumeric()->draw(this->m_indRes * dbw + lxFNTSW, this->m_indRes * (double(t) * size / 10.0) - 0.333 * lxFNTSH, strCBar);
   }
@@ -1762,11 +1762,11 @@ void lxGLCanvas::RenderIScalebar(double size)
 
 
     if (miles)
-      strLen = fmt::sprintf("%.0f mi", sblen);
+      strLen = fmt::format("{:.0f} mi", sblen);
     else if (sblen > 4.0)
-      strLen = fmt::sprintf("%.0f ft", sblen);
+      strLen = fmt::format("{:.0f} ft", sblen);
     else
-      strLen = fmt::sprintf("%g in", 12.0 * sblen);
+      strLen = fmt::format("{:g} in", 12.0 * sblen);
 
   } else {
 
@@ -1780,13 +1780,13 @@ void lxGLCanvas::RenderIScalebar(double size)
     size = sblen / scale / this->m_indRes;
 
     if (sblen >= 10000.0)
-      strLen = fmt::sprintf("%.0f km", sblen / 1000.0);
+      strLen = fmt::format("{:.0f} km", sblen / 1000.0);
     else if (sblen >= 4.0)
-      strLen = fmt::sprintf("%.0f m", sblen);
+      strLen = fmt::format("{:.0f} m", sblen);
     else if (sblen >= 0.01)
-      strLen = fmt::sprintf("%.0f mm", sblen * 1000.0);
+      strLen = fmt::format("{:.0f} mm", sblen * 1000.0);
     else
-      strLen = fmt::sprintf("%g mm", sblen * 1000.0);
+      strLen = fmt::format("{:g} mm", sblen * 1000.0);
   }
 
 

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -42,7 +42,7 @@
 #include "lxGUI.h"
 #include "lxFile.h"
 
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 #define lxRENDERBORDER this->m_glc->TRCGet(TR_TILE_BORDER)
 
@@ -869,7 +869,7 @@ void lxRenderFile::RenderPDFHeader()
   fprintf(this->m_file,"%%PDF-1.4\n");
 
   pdf_obj[4] = ftell(this->m_file);
-  const auto tmp_buff = fmt::sprintf("q\n%.4f 0 0 %.4f 0 0 cm\n/Im1 Do\nQ\n", imw, imh);
+  const auto tmp_buff = fmt::format("q\n{:.4f} 0 0 {:.4f} 0 0 cm\n/Im1 Do\nQ\n", imw, imh);
   fprintf(this->m_file,"4 0 obj <<\n/Length %u\n>>\nstream\n%sendstream\nendobj\n", static_cast<unsigned>(tmp_buff.size()), tmp_buff.c_str());
 
   pdf_obj[3] = ftell(this->m_file);

--- a/thexpmap.cxx
+++ b/thexpmap.cxx
@@ -71,8 +71,6 @@
 #include "img.h"
 #include <filesystem>
 
-#include <fmt/printf.h>
-
 namespace fs = std::filesystem;
 
 thexpmap::thexpmap() {
@@ -1718,7 +1716,7 @@ if (ENC_NEW.NFSS==0) {
                   // pred orezanim
                   if (exps.F > 0) {
                     fprintf(plf,"\t\t F => \"data.%ld\",\n",exps.F);
-                    SCRAPITEM->F = fmt::sprintf("data.%ld",exps.F);
+                    SCRAPITEM->F = fmt::format("data.{}",exps.F);
                   }
 //                  else
 //                    fprintf(plf,"\t\t F => \"data.0\",\n");
@@ -1726,11 +1724,11 @@ if (ENC_NEW.NFSS==0) {
                   // orezavacia cesta a outlines
                   if (exps.B > 0) {
                     fprintf(plf,"\t\t B => \"data.%ld\",\n",exps.B);
-                    SCRAPITEM->B = fmt::sprintf("data.%ld",exps.B);
+                    SCRAPITEM->B = fmt::format("data.{}",exps.B);
                     fprintf(plf,"\t\t I => \"data.%ldbg\",\n",exps.B);
-                    SCRAPITEM->I = fmt::sprintf("data.%ldbg",exps.B);
+                    SCRAPITEM->I = fmt::format("data.{}bg",exps.B);
                     fprintf(plf,"\t\t C => \"data.%ldclip\",\n",exps.B);
-                    SCRAPITEM->C = fmt::sprintf("data.%ldclip",exps.B);
+                    SCRAPITEM->C = fmt::format("data.{}clip",exps.B);
                   }
 //                  else {
 //                    fprintf(plf,"\t\t B => \"data.0\",\n");
@@ -1741,16 +1739,16 @@ if (ENC_NEW.NFSS==0) {
                   // po orezani
                   if (exps.E > 0) {
                     fprintf(plf,"\t\t E => \"data.%ld\",\n",exps.E);
-                    SCRAPITEM->E = fmt::sprintf("data.%ld",exps.E);
+                    SCRAPITEM->E = fmt::format("data.{}",exps.E);
                   }
 //                  else
 //                    fprintf(plf,"\t\t E => \"data.0\",\n");
     
                   if (exps.X > 0) {
                     fprintf(plf,"\t\t X => \"data.%ld\",\n",exps.X);
-                    SCRAPITEM->X = fmt::sprintf("data.%ld",exps.X);
+                    SCRAPITEM->X = fmt::format("data.{}",exps.X);
                     fprintf(plf,"\t\t P => \"data.%ldbbox\",\n",exps.X);
-                    SCRAPITEM->P = fmt::sprintf("data.%ldbbox",exps.X);
+                    SCRAPITEM->P = fmt::format("data.{}bbox",exps.X);
                   }
 
                   if (export_outlines_only) {
@@ -1784,11 +1782,11 @@ if (ENC_NEW.NFSS==0) {
                     active_clr.set_color(this->layout->color_model, SCRAPITEM->col_scrap);
       
                     fprintf(plf,"\t\t B => \"data.%ld\",\n",exps.B);
-                    SCRAPITEM->B = fmt::sprintf("data.%ld",exps.B);
+                    SCRAPITEM->B = fmt::format("data.{}",exps.B);
                     fprintf(plf,"\t\t I => \"data.%ldbg\",\n",exps.B);
-                    SCRAPITEM->I = fmt::sprintf("data.%ldbg",exps.B);
+                    SCRAPITEM->I = fmt::format("data.{}bg",exps.B);
                     fprintf(plf,"\t\t C => \"data.%ldclip\",\n",exps.B);
-                    SCRAPITEM->C = fmt::sprintf("data.%ldclip",exps.B);
+                    SCRAPITEM->C = fmt::format("data.{}clip",exps.B);
                     //fprintf(plf,"\t\t B => \"data.%ld\",\n",exps.B);
                     //fprintf(plf,"\t\t I => \"data.%ldbg\",\n",exps.B);
                     //fprintf(plf,"\t\t C => \"data.%ldclip\",\n",exps.B);
@@ -1837,10 +1835,10 @@ if (ENC_NEW.NFSS==0) {
   	  break;
   }
 
-  LAYOUT.northarrow = fmt::sprintf("data.%d",sfig);
+  LAYOUT.northarrow = fmt::format("data.{}",sfig);
   fprintf(mpf,"beginfig(%d);\ns_northarrow(%g);\nendfig;\n",sfig++,this->layout->rotate + rotate_plus);
 
-  LAYOUT.scalebar = fmt::sprintf("data.%d",sfig);
+  LAYOUT.scalebar = fmt::format("data.{}",sfig);
   fprintf(mpf,"beginfig(%d);\ns_scalebar(%g, %g, \"%s\");\nendfig;\n",
     sfig++, sblen, 1.0 / this->layout->units.convert_length(1.0), utf2tex(this->layout->units.format_i18n_length_units()).c_str());
 
@@ -1853,7 +1851,7 @@ if (ENC_NEW.NFSS==0) {
     switch (this->layout->color_crit) {
       case TT_LAYOUT_CCRIT_ALTITUDE:
       case TT_LAYOUT_CCRIT_DEPTH:
-    	  LAYOUT.altitudebar = fmt::sprintf("data.%d",sfig);
+    	  LAYOUT.altitudebar = fmt::format("data.{}",sfig);
     	  sv_min = this->layout->m_lookup->m_table.begin()->m_valueDbl;
     	  for(const auto& ti : this->layout->m_lookup->m_table) {
     		  sv_max = ti.m_valueDbl;
@@ -2066,7 +2064,7 @@ if (ENC_NEW.NFSS==0) {
   if (this->layout->grid != TT_LAYOUT_GRID_OFF) {
 
 #define expgridscrap(varname,Xpos,Ypos) \
-    LAYOUT.varname = fmt::sprintf("data.%d",sfig); \
+    LAYOUT.varname = fmt::format("data.{}",sfig); \
     fprintf(mpf,"beginfig(%d);\n%s(%d, %d, %.5f, %.5f);\nendfig;\n", \
     sfig++, grid_macro, Xpos, Ypos, ghs, gvs);
     
@@ -2916,7 +2914,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
         if (out->layout->is_debug_stationnames() && (slp->station_name.id != 0)) {
           tmps = &(thdb.db1d.station_vec[slp->station_name.id - 1]);
           out->symset->export_mp_symbol_options(dbg_stnms, SYMP_STATIONNAME);
-          dbg_stnms.push_back(fmt::sprintf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, p_label_mode_debugstation);",
+          dbg_stnms.push_back(fmt::format("p_label.urt(btex \\thstationname {} etex, ({:.2f}, {:.2f}), 0.0, p_label_mode_debugstation);",
             utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
             thxmmxst(out, slp->stx, slp->sty)));
         }
@@ -2995,7 +2993,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
                 }
                 if (out->layout->is_debug_stationnames() && (tmps != NULL)) {
                       out->symset->export_mp_symbol_options(dbg_stnms, SYMP_STATIONNAME);
-                      dbg_stnms.push_back(fmt::sprintf("p_label.urt(btex \\thstationname %s etex, (%.2f, %.2f), 0.0, p_label_mode_debugstation);",
+                      dbg_stnms.push_back(fmt::format("p_label.urt(btex \\thstationname {} etex, ({:.2f}, {:.2f}), 0.0, p_label_mode_debugstation);",
                       utf2tex(thobjectname_print_full_name(tmps->name, tmps->survey, layout->survey_level)), 
                       thxmmxst(out, ptp->point->xt, ptp->point->yt)));
                 }

--- a/thexpmodel.cxx
+++ b/thexpmodel.cxx
@@ -48,8 +48,6 @@
 #include "therion.h"
 #include <filesystem>
 
-#include <fmt/printf.h>
-
 thexpmodel::thexpmodel() {
   this->format = TT_EXPMODEL_FMT_UNKNOWN;
   this->items = TT_EXPMODEL_ITEM_ALL;
@@ -749,7 +747,7 @@ void thexpmodel::export_vrml_file(class thdatabase * dbp) {
               "Shape {\nappearance Appearance {\n" \
               "\tmaterial Material {\n\t\tdiffuseColor 0.3 1.0 0.1\n\t\ttransparency 0.5\n\t}\n");
             if (has_texture) {
-              const auto tifn = fmt::sprintf("%s.img%d.%s", fnm, imgn++, srfc->pict_type == TT_IMG_TYPE_JPEG ? "jpg" : "png");
+              const auto tifn = fmt::format("{}.img{}.{}", fnm, imgn++, srfc->pict_type == TT_IMG_TYPE_JPEG ? "jpg" : "png");
               auto texf = thopen_file(tifn, "wb");
               auto xf = thopen_file(srfc->pict_name, "rb");
               if (texf != NULL) {

--- a/thimport.cxx
+++ b/thimport.cxx
@@ -39,8 +39,7 @@
 #include <map>
 #include <list>
 #include <filesystem>
-
-#include <fmt/printf.h>
+#include <algorithm>
 
 constexpr auto ANON_STATION_NAME = "-";
 
@@ -570,9 +569,9 @@ void thimport::import_file_img()
         }
         orig_name = stnm;
         if (svxs2ths.find(orig_name) == svxs2ths.end()) {
-          xb = fmt::sprintf("%.16g", imgpt.x + this->calib_x);
-          yb = fmt::sprintf("%.16g", imgpt.y + this->calib_y);
-          zb = fmt::sprintf("%.16g", imgpt.z + this->calib_z);
+          xb = fmt::format("{:.16g}", imgpt.x + this->calib_x);
+          yb = fmt::format("{:.16g}", imgpt.y + this->calib_y);
+          zb = fmt::format("{:.16g}", imgpt.z + this->calib_z);
           tmpsurvey = this->db->csurveyptr;
           new_name = this->station_name(stnm, pimg->separator, &tmpsst);
           if (tmpsst.survey != NULL) {

--- a/thlayoutclr.cxx
+++ b/thlayoutclr.cxx
@@ -30,7 +30,7 @@
 #include "thexception.h"
 #include "thepsparse.h"
 #include <cmath>
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 
 bool thlayout_color::is_defined() {
@@ -109,11 +109,11 @@ void thlayout_color::encode_to_str(int output_model, std::string & str) {
 std::string thlayout_color::print_to_str(int output_model) {
 	this->fill_missing_color_models();
 	if ((output_model & TT_LAYOUTCLRMODEL_CMYK) > 0)
-		return fmt::sprintf("(%.5f,%.5f,%.5f,%.5f)", this->C, this->M, this->Y, this->K);
+		return fmt::format("({:.5f},{:.5f},{:.5f},{:.5f})", this->C, this->M, this->Y, this->K);
 	else if ((output_model & TT_LAYOUTCLRMODEL_GRAY) > 0)
-		return fmt::sprintf("(%.5f)", this->W);
+		return fmt::format("({:.5f})", this->W);
 	else
-		return fmt::sprintf("(%.5f,%.5f,%.5f)", this->R, this->G, this->B);
+		return fmt::format("({:.5f},{:.5f},{:.5f})", this->R, this->G, this->B);
 }
 
 void thlayout_color::RGBtoGRAYSCALE() {

--- a/thobjectname.cxx
+++ b/thobjectname.cxx
@@ -31,7 +31,7 @@
 #include "thdataobject.h"
 #include "thsurvey.h"
 
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 thobjectname::thobjectname()
 {
@@ -106,7 +106,7 @@ std::string thobjectname::print_name()
     survey_str = this->survey;
   }
   if (!name_str.empty() && !survey_str.empty()) {
-    return fmt::sprintf("%s@%s", name_str, survey_str);
+    return fmt::format("{}@{}", name_str, survey_str);
   }
   if (!name_str.empty()) {
     return name_str;
@@ -130,7 +130,7 @@ std::string thobjectname_print_full_name(const char * oname_ptr, thsurvey * psrv
   size_t start = 0;
   if (!oname.empty() && !sname.empty() && (slevel != 0)) {
     const char sep = (oname.find('@') == oname.npos) ? '@' : '.';
-    rv = fmt::sprintf("%s%c%s", oname, sep, sname);
+    rv = fmt::format("{}{}{}", oname, sep, sname);
     start = oname.size() + 1;
   } else if (!oname.empty()) {
     rv = oname;

--- a/thpic.cxx
+++ b/thpic.cxx
@@ -35,8 +35,7 @@
 #include "thconfig.h"
 #include "therion.h"
 #include <filesystem>
-
-#include <fmt/printf.h>
+#include <algorithm>
 
 namespace fs = std::filesystem;
 
@@ -152,7 +151,7 @@ const char * thpic::convert(const char * type, const char * ext, const std::stri
   int retcode;
   bool isspc;
   const char * tmpf;
-  const auto tmpfn = fmt::sprintf("pic%04ld.%s", thpic_convert_number++, ext);
+  const auto tmpfn = fmt::format("pic{:04d}.{}", thpic_convert_number++, ext);
   isspc = (strcspn(thini.get_path_convert()," \t") < strlen(thini.get_path_convert()));
   ccom = "";
   if (isspc) ccom += "\"";
@@ -245,7 +244,7 @@ void thpic::rgba_save(const char * type, const char * ext, int colors)
   thpic tmp;
   tmp.width = this->width;
   tmp.height = this->height;
-  auto tmpfn = fmt::sprintf("pic%04ld.rgba", thpic_convert_number++);
+  auto tmpfn = fmt::format("pic{:04d}.rgba", thpic_convert_number++);
   tmp.fname = thdb.strstore(thtmp.get_file_name(tmpfn.c_str()));
   this->rgbafn = tmp.fname;
   FILE * f;
@@ -256,7 +255,7 @@ void thpic::rgba_save(const char * type, const char * ext, int colors)
     this->fname = tmp.convert(type, ext, fmt::format("-define png:exclude-chunks=date,time -depth 8 -size {}x{} -density 300 +dither -colors {}", this->width, this->height, colors));
   else
     this->fname = tmp.convert(type, ext, fmt::format("-define png:exclude-chunks=date,time -depth 8 -size {}x{} -density 300", this->width, this->height));
-  tmpfn = fmt::sprintf("pic%04ld.%s", thpic_convert_number - 1, ext);
+  tmpfn = fmt::format("pic{:04d}.{}", thpic_convert_number - 1, ext);
   this->texfname = thdb.strstore(tmpfn.c_str());
 }
 

--- a/thselector.cxx
+++ b/thselector.cxx
@@ -39,8 +39,6 @@
 #include "thmap.h"
 #include "therion.h"
 
-#include <fmt/printf.h>
-
 thselector::thselector() {
   this->number = 0;
   this->cfgptr = NULL;
@@ -381,7 +379,7 @@ void thselector::dump_selection_db (FILE * cf, thdatabase * db)
   while (prjli != db->db2d.prj_list.end()) {
 	  std::string projdir;
 		if ((prjli->type == TT_2DPROJ_ELEV) && (prjli->pp1 != 0.0)) {
-			projdir = fmt::sprintf("\\[%.1f\\]", prjli->pp1);
+			projdir = fmt::format("\\[{:.1f}\\]", prjli->pp1);
 		}
     fprintf(cf,"xth_cp_map_tree_insert projection 0 p%d {} 0",prjli->id); 
     if (strlen(prjli->index) > 0)

--- a/thsvxctrl.cxx
+++ b/thsvxctrl.cxx
@@ -44,8 +44,6 @@
 #include <string>
 #include <fstream>
 
-#include <fmt/printf.h>
-
 #define THPI 3.1415926535898
 
 thsvxctrl::thsvxctrl()
@@ -654,7 +652,7 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
                   fonline = true;
                   tsbuff.strcat("\n");
                 }
-                numbuff = fmt::sprintf("%2ld> input:%ld -- %s [%ld]\n",lnum,csn,srcmi->second->name,srcmi->second->line);
+                numbuff = fmt::format("{:2d}> input:{} -- {} [{}]\n",lnum,csn,srcmi->second->name,srcmi->second->line);
                 tsbuff.strcat(numbuff.c_str());
               }
               break;
@@ -662,14 +660,14 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
               csn--;
               if ((csn >= 0) && (csn < long(lsid))) {
                 if (fonline) {
-                  numbuff = fmt::sprintf("%2ld> ",lnum);
+                  numbuff = fmt::format("{:2d}> ",lnum);
                   tsbuff.strcat(numbuff.c_str());
                   fonline = false;
                 }
                 else {
                   tsbuff.strcat(" -- ");
                 }
-                numbuff = fmt::sprintf("%ld : ",(csn+1));
+                numbuff = fmt::format("{} : ",(csn+1));
                 stp = & (dbp->db1d.station_vec[(unsigned int)csn]);
                 tsbuff.strcat(numbuff.c_str());
                 tsbuff.strcat(stp->name);

--- a/thsymbolset.cxx
+++ b/thsymbolset.cxx
@@ -46,7 +46,6 @@
 #include "therion.h"
 #include "thlog.h"
 #include <fstream>
-#include <fmt/printf.h>
 
 thsymbolset::thsymbolset()
 {
@@ -1017,7 +1016,7 @@ void thsymbolset::export_pdf(class thlayout * layout, FILE * mpf, unsigned & sfi
     LEGENDITEM->idfig = (unsigned) sfig; \
     LEGENDITEM->idsym = (unsigned) mid; \
     LEGENDITEM->idnum = (unsigned) symn; \
-    LEGENDITEM->fname = fmt::sprintf("data.%d",sfig); \
+    LEGENDITEM->fname = fmt::format("data.{}",sfig); \
     LEGENDITEM->name = thlegend_u2string(unsigned(symn++)); \
     LEGENDITEM->descr = txt; \
     sfig++;
@@ -1810,7 +1809,7 @@ void export_all_symbols()
           if (thsymsets_count[iset] > 0) {
             fx = thsymsets_figure[sx][iset];
             if (fx > 0) {
-              fname = fmt::sprintf("%s/data.%d", thtmp.get_dir_name(),fx);
+              fname = fmt::format("{}/data.{}", thtmp.get_dir_name(),fx);
               parse_eps(fname,"",0,0,a,b,c,d,svgpict,30);
               hf << "<td>\n";
          	    svgpict.print_svg(hf);
@@ -1821,7 +1820,7 @@ void export_all_symbols()
           }
         }
       } else {
-        fname = fmt::sprintf("%s/data.%d", thtmp.get_dir_name(),thsymsets_figure[sx][thsymsets_size]);
+        fname = fmt::format("{}/data.{}", thtmp.get_dir_name(),thsymsets_figure[sx][thsymsets_size]);
         parse_eps(fname,"",0,0,a,b,c,d,svgpict,30);
         hf << "<td bgcolor=\"#cccccc\" colspan=\"" << thsymsets_size << "\">";
         svgpict.print_svg(hf);

--- a/thwarpp.cxx
+++ b/thwarpp.cxx
@@ -34,8 +34,6 @@
 #include "thdatabase.h"
 #include "thdataleg.h"
 
-#include <fmt/printf.h>
-
 thwarpp::~thwarpp() {}
 
 
@@ -142,7 +140,7 @@ thpic * thwarpp::morph(thsketch * sketch, double scale) {
 	    thprint(fmt::format("warning: extra point from {} but no station\n",
 	      pointp->from_name.name ));
 	  } else {
-            s  = fmt::sprintf("%ld_E_%d",fuid, ++n_extra);
+            s  = fmt::format("{}_E_{}",fuid, ++n_extra);
             s2 = std::to_string(fuid);
 	    thdb2dpt * pt = pointp->point;
 	    // assert( pt != NULL );


### PR DESCRIPTION
I have removed all the remaining usages of the header `fmt/printf.h` and the function `fmt::sprintf()`. From now on we should stick to the modern `fmt::format()`, which is simpler, type-safe, and faster to compile, compilation speedup is 10-20%.