### PR TITLE
New config command: scrap-sort on/off

### DIFF
--- a/thbook/ch03.tex
+++ b/thbook/ch03.tex
@@ -63,6 +63,17 @@ Inside
 the |layout| specifies coordinate system for subsequent location data (|origin|,
 |grid-origin|).
 
+\subsubchapter `scrap-sort'.
+
+\description
+  Sort scraps by altitude midpoint (default). If turned off, scraps keep their
+  input order. Only applies if no maps are defined.
+\enddescription
+
+\syntax
+  |scrap-sort <on/off>|
+\endsyntax
+
 \subsubchapter `sketch-warp'.
 
 \syntax

--- a/thconfig.cxx
+++ b/thconfig.cxx
@@ -71,6 +71,7 @@ enum {
   TT_MAPS,
   TT_MAPS_OFFSET,
   TT_LOG,
+  TT_SCRAP_SORT,
 };
 
 
@@ -84,6 +85,7 @@ static const thstok thtt_cfg[] = {
   {"log", TT_LOG},
   {"maps", TT_MAPS},
   {"maps-offset", TT_MAPS_OFFSET},
+  {"scrap-sort", TT_SCRAP_SORT},
   {"select", TT_SELECT},
   {"setup3d", TT_SETUP3D},
   {"sketch-colors", TT_SKETCH_COLORS},
@@ -461,6 +463,15 @@ void thconfig::load()
 #endif
               this->search_path.strcat(this->cfg_file.get_cif_path());
             }
+            break;
+
+          case TT_SCRAP_SORT:
+            if (valuemb.get_size() != 1)
+              throw thexception("single scrap-sort switch expected");
+            sv = thmatch_token(valuemb.get_buffer()[0], thtt_bool);
+            if (sv == TT_UNKNOWN_BOOL)
+              throw thexception(fmt::format("invalid scrap-sort switch -- {}", valuemb.get_buffer()[0]));
+            this->scrap_sort = (sv == TT_TRUE);
             break;
             
           case TT_SKETCH_WARP:

--- a/thconfig.h
+++ b/thconfig.h
@@ -91,6 +91,7 @@ class thconfig {
 	crc_generate, ///< Generate CRC files for output files.
 	crc_verify, ///< Verify CRC files for output files.
     log_extend; ///< Log extended elevation construction.
+  bool scrap_sort = true;  ///< Whether scraps should be z-sorted
   thcfg_fstate fstate;  ///< What to do with cfg file.
   thinput cfg_file;  ///< Configuration file input.
   int cfg_fenc;  ///< Configuration file encoding.

--- a/thdb2d00.cxx
+++ b/thdb2d00.cxx
@@ -469,7 +469,7 @@ thdb2dxm * thdb2d::select_projection(thdb2dprj * prj)
         obi++;
       }  
       
-      if (nscraps > 1) {
+      if (nscraps > 1 && thcfg.scrap_sort) {
 
         // zoradime scrapy podla z-ka
         std::vector<thscrap*> sss(nscraps);


### PR DESCRIPTION
New command to turn scrap sorting off.

```
scrap-sort off
```

Scraps are sorted by their station z-midpoints if no maps are defined. I usually have my scraps and th2 files already organized in correct z-order, and automatic sorting can mess that up. So I added a config command to turn off sorting.