### PR TITLE
Removed M_PI

### DIFF
--- a/loch/lxR2D.cxx
+++ b/loch/lxR2D.cxx
@@ -5,11 +5,8 @@
 #include "lxR2D.h"
 #include <math.h>
 #include <stdlib.h>
+#include <numbers>
 #include <GL/gl.h>
-
-#if !defined(M_PI)
-#define M_PI 3.14159265F
-#endif
 
 #define colorIndexMode FALSE
 #define doubleBuffered FALSE
@@ -402,8 +399,8 @@ drawTorus(void)
 	int numMinor = 24;
 	float majorRadius = 0.6F;
 	float minorRadius = 0.2F;
-	double majorStep = 2.0F*M_PI / numMajor;
-	double minorStep = 2.0F*M_PI / numMinor;
+	double majorStep = 2.0F*std::numbers::pi / numMajor;
+	double minorStep = 2.0F*std::numbers::pi / numMinor;
 	int i, j;
 
 	for (i=0; i<numMajor; ++i) {

--- a/thproj.cxx
+++ b/thproj.cxx
@@ -40,12 +40,9 @@
 #include <math.h>
 #include <sstream>
 #include <iomanip>
+#include <numbers>
 #ifdef THWIN32
   #include "thconfig.h"
-#endif
-
-#ifndef M_PI
-#define M_PI       3.14159265358979323846
 #endif
 
 std::regex reg_init(R"(^\+init=(epsg|esri):(\d+)$)");
@@ -350,10 +347,10 @@ void thcs2cs(int si, int ti,
   {  // let PROJ find the best transformation
     th_init_proj_auto(P, si, ti);
     if (thcs_islatlong(s) && !proj_angular_input(P, PJ_FWD)) {
-      undo_radians = 180.0 / M_PI;
+      undo_radians = 180.0 / std::numbers::pi;
     }
     if (thcs_islatlong(t) && !proj_angular_output(P, PJ_FWD)) {
-      redo_radians = M_PI / 180.0;
+      redo_radians = std::numbers::pi / 180.0;
     }
   }
   PJ_COORD res;
@@ -369,7 +366,7 @@ void thcs2cs(int si, int ti,
 signed int thcs2zone(int s, double a, double b, double c) {
   double x, y, z;
   thcs2cs(s,TTCS_EPSG + 4326,a,b,c,x,y,z);
-  return (int) (x*180/M_PI+180)/6 + 1;
+  return (int) (x*180/std::numbers::pi+180)/6 + 1;
 }
 
 double thcsconverg(int s, double a, double b) {
@@ -379,7 +376,7 @@ double thcsconverg(int s, double a, double b) {
   thcs2cs(s,TTCS_EPSG + 4326,a,b,c,x,y,z);
   y += 1e-6;
   thcs2cs(TTCS_EPSG + 4326,s,x,y,z,x2,y2,z2);
-  return atan2(x2-a,y2-b)/M_PI*180;
+  return atan2(x2-a,y2-b)/std::numbers::pi*180;
 }
 
 bool thcs_islatlong(std::string s) {

--- a/thwarppme.cxx
+++ b/thwarppme.cxx
@@ -801,8 +801,6 @@ namespace therion
 
       m_kl = ( from.theta_left() - to.theta_left() ) * MORPH_ANGLE_FACTOR;
       m_kr = ( from.theta_right() - to.theta_right() ) * MORPH_ANGLE_FACTOR;
-      // m_kl = fabs(from.theta_left()-M_PI_2) - fabs(to.theta_left()-M_PI_2);
-      // m_kr = fabs(from.theta_right()-M_PI_2) - fabs(to.theta_right()-M_PI_2);
       
       m_dl = from.m_ac / to.m_ac;
       m_dr = from.m_ab / to.m_ab;
@@ -989,8 +987,6 @@ namespace therion
 
       m_kl = ( from.theta_left() - to.theta_left() ) * MORPH_ANGLE_FACTOR;
       m_kr = ( from.theta_right() - to.theta_right() ) * MORPH_ANGLE_FACTOR;
-      // m_kl = fabs(from.theta_left()-M_PI_2) - fabs(to.theta_left()-M_PI_2);
-      // m_kr = fabs(from.theta_right()-M_PI_2) - fabs(to.theta_right()-M_PI_2);
       
       m_dl = from.m_AD_len / to.m_AD_len;
       m_dr = from.m_BC_len / to.m_BC_len;

--- a/thwarppt.cxx
+++ b/thwarppt.cxx
@@ -31,13 +31,10 @@
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
+#include <numbers>
 
 #include "thexception.h"
 #include "thwarppt.h"
-
-#ifndef M_PI
-#define M_PI       3.14159265358979323846
-#endif
 
 typedef unsigned int warpp_t;
 const warpp_t ngbh_mask = ((warpp_t)(0x7))<<(8*sizeof(warpp_t)-3);
@@ -202,9 +199,9 @@ therion::warp::plaquette_algo::insert_zoom_point(
     sa = x2*y1 - y2*x1;
     ca = x1*x2 + y1*y2;
     a = atan2( sa, ca );
-    if ( a < 0.0 ) a += 2*M_PI;
+    if ( a < 0.0 ) a += 2*std::numbers::pi;
     if ( a < a1 ) { a1=a; p1=p; }
-    a = 2*M_PI - a;
+    a = 2*std::numbers::pi - a;
     if ( a < a2 ) { a2=a; p2=p; }
   }
   if ( p1 == NULL || p2 == NULL || p1 == p2 ) return NULL;

--- a/utest-proj.cxx
+++ b/utest-proj.cxx
@@ -4,14 +4,11 @@
 #include <catch2/catch.hpp>
 #endif
 #include <cmath>
+#include <numbers>
 
 #include "thproj.h"
 #include "thcsdata.h"
 #include "thcs.h"
-
-#ifndef M_PI
-#define M_PI       3.14159265358979323846
-#endif
 
 // tests for coordinate systems transformations using Proj library
 
@@ -26,7 +23,7 @@ double dms2dec(int d, int m, double s) {
 }
 
 double deg2rad(double d) {
-  return d / 180.0 * M_PI;
+  return d / 180.0 * std::numbers::pi;
 }
 
 double x,y,z;
@@ -75,7 +72,7 @@ TEST_CASE( "projections: is lat/long", "[proj]" ) {
 
 TEST_CASE( "projections: meridian convergence", "[proj]" ) {
     // therion uses a convention that the convergence is positive west to central meridian
-    CHECK(coord_equal(thcsconverg(TTCS_EPSG + 32634, p1_utm_e, p1_utm_n), -atan(tan(p1_ll_lambda-deg2rad(21.0))*sin(p1_ll_phi))*180/M_PI, 0.1/3600));   // 0.1 deg second
+    CHECK(coord_equal(thcsconverg(TTCS_EPSG + 32634, p1_utm_e, p1_utm_n), -atan(tan(p1_ll_lambda-deg2rad(21.0))*sin(p1_ll_phi))*180/std::numbers::pi, 0.1/3600));   // 0.1 deg second
     // https://geodesyapps.ga.gov.au/geographic-to-grid
     CHECK(coord_equal(thcsconverg(TTCS_EPSG + 32634, 350812.125, 5318235.614),  1.486562, 0.01/3600));  // 48 N, 19 E (central meridian 21 E)
     CHECK(coord_equal(thcsconverg(TTCS_EPSG + 32634, 649187.875, 5318235.614), -1.486562, 0.01/3600));  // 48 N, 23 E


### PR DESCRIPTION
Macro `M_PI` is a non-standard extension, let's replace it with a C++20 constant `std::numbers::pi`.