### PR TITLE
Allow any projection with point section

### DIFF
--- a/thdb2d.cxx
+++ b/thdb2d.cxx
@@ -1039,12 +1039,7 @@ void thdb2d::process_point_references(thpoint * pp)
         optr = this->db->get_object(pp->station_name,pp->fsptr);
         if (optr != NULL) {
           if (optr->get_class_id() == TT_SCRAP_CMD) {
-            if (auto& scrap = dynamic_cast<thscrap&>(*optr); scrap.proj->type == TT_2DPROJ_NONE) {
-              pp->data = &scrap;
-            } else {
-              extend_error = true;
-              err_code = "not a none scrap projection";
-            }
+            pp->data = dynamic_cast<thscrap*>(optr);
           }
           else {
             extend_error = true;


### PR DESCRIPTION
Now, any scrap can be referenced with `point section`.

In particular, scraps in projection `extended` or `elevation` can make perfect sense for cross-sections. Unlike projection `none`, these projections have altitude context, which allows automatic altitude labels and `map-fg altitude`.

See https://github.com/therion/therion/issues/698