### PR TITLE
Option to disable unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(Dependencies)
 include(TherionSources)
 include(ECMEnableSanitizers)
 include(Warnings)
+include(CTest)
 
 # strip binaries in release build
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -s")
@@ -183,27 +184,30 @@ if (BUILD_THERION)
         endif()"
         COMPONENT th-runtime)
 
-    # unit tests
-    add_executable(utest 
-        utest-main.cxx
-        utest-proj.cxx
-        utest-str.cxx
-        utest-thdatastation.cxx
-        utest-thdb2dab.cxx
-        utest-thdouble.cxx
-        utest-thexception.cxx
-        utest-thlayoutln.cxx
-        utest-thlogfile.cxx
-        utest-thobjectid.cxx
-        utest-thobjectsrc.cxx
-        utest-thscrapen.cxx
-        utest-thscraplo.cxx
-    )
-    target_link_libraries(utest PUBLIC therion-common catch2-interface)
-    enable_testing()
-    add_test(NAME utest COMMAND $<TARGET_FILE:utest> WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-    if (ENABLE_CODE_COVERAGE)
-        set_property(TEST utest PROPERTY ENVIRONMENT LLVM_PROFILE_FILE=${COVERAGE_FOLDER}/utest.profraw)
+    if (BUILD_TESTING)
+        include(Catch2)
+
+        add_executable(utest 
+            utest-main.cxx
+            utest-proj.cxx
+            utest-str.cxx
+            utest-thdatastation.cxx
+            utest-thdb2dab.cxx
+            utest-thdouble.cxx
+            utest-thexception.cxx
+            utest-thlayoutln.cxx
+            utest-thlogfile.cxx
+            utest-thobjectid.cxx
+            utest-thobjectsrc.cxx
+            utest-thscrapen.cxx
+            utest-thscraplo.cxx
+        )
+        target_link_libraries(utest PUBLIC therion-common catch2-interface)
+        
+        add_test(NAME utest COMMAND $<TARGET_FILE:utest> WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+        if (ENABLE_CODE_COVERAGE)
+            set_property(TEST utest PROPERTY ENVIRONMENT LLVM_PROFILE_FILE=${COVERAGE_FOLDER}/utest.profraw)
+        endif()
     endif()
 
     # updates thlibrarydata.cxx

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -14,15 +14,21 @@
 # interface library for setting compiler and linker flags
 add_library(code-coverage INTERFACE)
 
-if (ENABLE_CODE_COVERAGE)
-    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        message(FATAL_ERROR "Code coverage requires Clang compiler.")
-    endif()
-
-    set(COVERAGE_FLAGS -fprofile-instr-generate -fcoverage-mapping)
-    target_compile_options(code-coverage INTERFACE ${COVERAGE_FLAGS})
-    target_link_options(code-coverage INTERFACE ${COVERAGE_FLAGS})
+if (NOT ENABLE_CODE_COVERAGE)
+    return()
 endif()
+
+if (NOT BUILD_TESTING)
+    message(FATAL_ERROR "Code coverage requires enabled unit tests.")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "Code coverage requires Clang compiler.")
+endif()
+
+set(COVERAGE_FLAGS -fprofile-instr-generate -fcoverage-mapping)
+target_compile_options(code-coverage INTERFACE ${COVERAGE_FLAGS})
+target_link_options(code-coverage INTERFACE ${COVERAGE_FLAGS})
 
 set(COVERAGE_FOLDER ${CMAKE_BINARY_DIR}/coverage)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -12,7 +12,6 @@ endif()
 # therion dependencies
 if (BUILD_THERION)
     include(PROJ)
-    include(Catch2)
     include(Shapelib)
 endif()
 


### PR DESCRIPTION
Now it is possible to use standard CMake variable [BUILD_TESTING](https://cmake.org/cmake/help/latest/variable/BUILD_TESTING.html) to disable unit tests.