### PR TITLE
Remove LXDEPCHECK

### DIFF
--- a/loch/icase.cxx
+++ b/loch/icase.cxx
@@ -1,12 +1,8 @@
 #include "icase.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <algorithm>
 #include <functional>
 #include <cctype>
-#endif  
-//LXDEPCHECK - standard libraries
 
 using uchar_type = const unsigned char; // we need to convert chars to unsigned chars because of std::tolower's requirements
 using str_it = std::string_view::const_iterator;

--- a/loch/icase.h
+++ b/loch/icase.h
@@ -1,10 +1,6 @@
 #pragma once
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <string_view>
-#endif  
-//LXDEPCHECK - standard libraries
 
 /**
  * @brief Case insensitive comparison of two strings.

--- a/loch/lxAboutDlg.cxx
+++ b/loch/lxAboutDlg.cxx
@@ -2,15 +2,10 @@
 #include "icons/about.xpm"
 #include "../thversion.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/panel.h>
 #include <wx/dialog.h>
 #include <wx/statbmp.h>
 #include <wx/stattext.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 class lxAboutDlg : public wxDialog {
 

--- a/loch/lxAboutDlg.h
+++ b/loch/lxAboutDlg.h
@@ -13,12 +13,7 @@
 #ifndef lxAboutDlg_h
 #define lxAboutDlg_h
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/window.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 void lxShowAboutDialog(wxWindow * parent);
 

--- a/loch/lxData.cxx
+++ b/loch/lxData.cxx
@@ -26,8 +26,6 @@
  * -------------------------------------------------------------------- 
  */
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <stdlib.h>
 #include <wx/txtstrm.h>
 #include <wx/strconv.h>
@@ -50,8 +48,6 @@
 #endif
 
 #include <map>
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxData.h"
 #include "lxLRUD.h"

--- a/loch/lxData.h
+++ b/loch/lxData.h
@@ -29,8 +29,6 @@
 #ifndef lxData_h
 #define lxData_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <limits>   // required to compile with vtk 9.0.1 and gcc 11
 #include <vtkPolyData.h>
 #include <vtkLookupTable.h>
@@ -42,9 +40,6 @@
 #include <wx/string.h>
 #include <vector>
 #include <set>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxMath.h"
 #include "lxImgIO.h"

--- a/loch/lxFile.cxx
+++ b/loch/lxFile.cxx
@@ -1,7 +1,5 @@
 #include "lxFile.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -10,9 +8,6 @@
 #include <list>
 #include <fstream>
 #include <filesystem>
-
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "icase.h"
 #include "lxMath.h"

--- a/loch/lxFile.h
+++ b/loch/lxFile.h
@@ -1,16 +1,11 @@
 #ifndef lxFile_h
 #define lxFile_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <list>
 #include <string>
 #include <cstdio>
 #include <cstdint>
 #include <vector>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 typedef char * lxFileBuff;
 

--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -10,8 +10,6 @@
 * $Revision: $
 */
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <math.h>
 #include <stdlib.h>
 #include <wx/dcclient.h>
@@ -29,8 +27,6 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxGLC.h"
 #include "lxGUI.h"

--- a/loch/lxGLC.h
+++ b/loch/lxGLC.h
@@ -29,14 +29,10 @@
 #ifndef lx_h
 #define lx_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/glcanvas.h>
 #include <wx/timer.h>
 #include <wx/image.h>
 #include "lxOGLFT.h"
-#endif  
-//LXDEPCHECK - standard libraries
 
 enum {
   LXGLCML_NONE,

--- a/loch/lxGUI.cxx
+++ b/loch/lxGUI.cxx
@@ -10,9 +10,6 @@
  * $Revision: $
  */
 
-// Standard libraries
-#ifndef LXDEPCHECK
-
 #include <wx/utils.h>
 #include <wx/filedlg.h>
 #include <wx/toolbar.h>
@@ -27,9 +24,6 @@
 #include <wx/msgdlg.h>
 
 #include <vtkObject.h>
-
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxData.h"
 #include "lxGUI.h"

--- a/loch/lxGUI.h
+++ b/loch/lxGUI.h
@@ -29,15 +29,10 @@
 #ifndef lxGUI_h
 #define lxGUI_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/fileconf.h>
 #include <wx/filename.h>
 #include <wx/docview.h>
 #include <wx/xml/xml.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxGLC.h"
 

--- a/loch/lxImgIO.cxx
+++ b/loch/lxImgIO.cxx
@@ -1,7 +1,5 @@
 #include "lxImgIO.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,10 +12,6 @@
 #ifdef __cplusplus
  }
 #endif
-
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 /******************** JPEG COMPRESSION SAMPLE INTERFACE *******************/
 

--- a/loch/lxImgIO.h
+++ b/loch/lxImgIO.h
@@ -1,13 +1,9 @@
 #ifndef lxImgIO_h
 #define lxImgIO_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <stdlib.h>
 #include <stdio.h>
 #include <vector>
-#endif  
-//LXDEPCHECK - standard libraries
 
 extern const char * lxImgIOError;
 

--- a/loch/lxLRUD.cxx
+++ b/loch/lxLRUD.cxx
@@ -1,14 +1,10 @@
 #include "lxLRUD.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <map>
 #include <vector>
 #include <list>
 #include <algorithm>
 #include <math.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 static const double lxVecPrec = 0.01;
 

--- a/loch/lxLRUD.h
+++ b/loch/lxLRUD.h
@@ -1,11 +1,6 @@
 #ifndef lxLRUD_h
 #define lxLRUD_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
-#endif  
-//LXDEPCHECK - standard libraries
-
 #include "lxTriGeom.h"
 
 #include <any>

--- a/loch/lxMath.cxx
+++ b/loch/lxMath.cxx
@@ -28,11 +28,7 @@
 
 #include "lxMath.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <cmath>
-#endif  
-//LXDEPCHECK - standard libraries
 
 void lxVec::Normalize() 
 {

--- a/loch/lxMath.h
+++ b/loch/lxMath.h
@@ -29,11 +29,6 @@
 #ifndef lxMath_h
 #define lxMath_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
-#endif  
-//LXDEPCHECK - standard libraries
-
 #define lxPI 3.1415926535898
 
 struct lxVec {

--- a/loch/lxOGLFT.h
+++ b/loch/lxOGLFT.h
@@ -22,8 +22,6 @@
 #ifndef OGLFT_H
 #define OGLFT_H
 
-#ifndef LXDEPCHECK
-
 #ifndef OGLFT_NO_WX
 #include <wx/colour.h>
 #else
@@ -59,9 +57,6 @@
 #include FT_GLYPH_H
 #include FT_OUTLINE_H
 #include FT_TRIGONOMETRY_H
-
-#endif  
-
 
 //! All of OGLFT C++ objects are in this namespace.
 

--- a/loch/lxOptDlg.cxx
+++ b/loch/lxOptDlg.cxx
@@ -1,8 +1,6 @@
 #include "lxWX.h"
 #include "lxGUI.h"
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/dirdlg.h>
 #include <wx/valgen.h>
 #include <wx/statbox.h>
@@ -10,9 +8,6 @@
 #include <wx/button.h>
 #include <wx/choice.h>
 #include <wx/valtext.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 enum {
   LXOD_START = 6000,

--- a/loch/lxOptDlg.h
+++ b/loch/lxOptDlg.h
@@ -13,12 +13,7 @@
 #ifndef lxOptDlg_h
 #define lxOptDlg_h
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/window.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 void lxShowOptionsDialog(wxWindow * parent);
 

--- a/loch/lxPres.cxx
+++ b/loch/lxPres.cxx
@@ -1,5 +1,3 @@
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/statline.h>
 #include <wx/xml/xml.h>
 #include <wx/filedlg.h>
@@ -7,8 +5,6 @@
 #include <wx/listbox.h>
 #include <wx/button.h>
 #include <cstdint>
-#endif
-//LXDEPCHECK - standard libraries
 
 #include "lxPres.h"
 #include "lxSetup.h"

--- a/loch/lxPres.h
+++ b/loch/lxPres.h
@@ -13,14 +13,8 @@
 #ifndef lxPres_h
 #define lxPres_h
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/minifram.h>
 #include <wx/treectrl.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxWX.h"
 

--- a/loch/lxRender.cxx
+++ b/loch/lxRender.cxx
@@ -3,9 +3,6 @@
 * Loch printing implementation.
 */
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <stdio.h>
 #include <stdlib.h>
 #include <wx/spinctrl.h>
@@ -28,11 +25,6 @@
 #ifdef __cplusplus
  }
 #endif
-
-
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxRender.h"
 #include "lxWX.h"

--- a/loch/lxRender.h
+++ b/loch/lxRender.h
@@ -6,11 +6,7 @@
 #ifndef lxRender_h
 #define lxRender_h  
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/window.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 enum {
 	LXRENDER_FIT_SCREEN,

--- a/loch/lxSScene.cxx
+++ b/loch/lxSScene.cxx
@@ -1,11 +1,7 @@
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/statline.h>
 #include <wx/listbox.h>
 #include <wx/stattext.h>
 #include <wx/button.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxData.h"
 #include "lxSScene.h"

--- a/loch/lxSScene.h
+++ b/loch/lxSScene.h
@@ -13,13 +13,7 @@
 #ifndef lxSScene_h
 #define lxSScene_h
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/minifram.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxWX.h"
 

--- a/loch/lxSStats.cxx
+++ b/loch/lxSStats.cxx
@@ -1,11 +1,7 @@
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/statline.h>
 #include <wx/busyinfo.h>
 #include <wx/button.h>
 #include <vtkMassProperties.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxSStats.h"
 #include "lxSetup.h"

--- a/loch/lxSStats.h
+++ b/loch/lxSStats.h
@@ -13,14 +13,8 @@
 #ifndef lxSStats_h
 #define lxSStats_h
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/minifram.h>
 #include <wx/textctrl.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxWX.h"
 

--- a/loch/lxSTree.cxx
+++ b/loch/lxSTree.cxx
@@ -1,10 +1,6 @@
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/statline.h>
 #include <wx/busyinfo.h>
 #include <wx/button.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxData.h"
 #include "lxSTree.h"

--- a/loch/lxSTree.h
+++ b/loch/lxSTree.h
@@ -13,14 +13,8 @@
 #ifndef lxSTree_h
 #define lxSTree_h
 
-
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/minifram.h>
 #include <wx/treectrl.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxWX.h"
 

--- a/loch/lxSView.cxx
+++ b/loch/lxSView.cxx
@@ -1,13 +1,8 @@
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/choice.h>
 #include <wx/listbox.h>
 #include <wx/stattext.h>
 #include <wx/button.h>
 #include <cmath>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxSView.h"
 #include "lxSetup.h"
@@ -152,7 +147,6 @@ void lxViewpointSetupDlg::OnSlider(wxScrollEvent& event)
   wxCommandEvent tmpEvent(wxEVT_COMMAND_TEXT_UPDATED);
   switch (event.GetId()) {
     case LXVSTP_FACINGSLIDE:
-#ifndef LXDEPCHECK
       lxFTextCtrl(LXVSTP_FACING)->ChangeValue(wxString::Format(_T("%d"), event.GetInt()));
       tmpEvent.SetId(LXVSTP_FACING);
       break;
@@ -167,7 +161,6 @@ void lxViewpointSetupDlg::OnSlider(wxScrollEvent& event)
     case LXVSTP_DISTSLIDE:
       lxFTextCtrl(LXVSTP_DIST)->ChangeValue(wxString::Format(_T("%d"), int(pow(200.0 * this->m_mainFrame->setup->data_limits_diam, (double(event.GetInt()) / 1000.0)))));
       tmpEvent.SetId(LXVSTP_DIST);
-#endif      
       break;
     case LXVSTP_ROTSPEED:
       this->m_mainFrame->canvas->m_sCameraAutoRotateAngle = (event.GetInt() >= 0 ? 1.0 : -1.0) * 

--- a/loch/lxSView.h
+++ b/loch/lxSView.h
@@ -13,11 +13,7 @@
 #ifndef lxSView_h
 #define lxSView_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/minifram.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxWX.h"
 

--- a/loch/lxSetup.cxx
+++ b/loch/lxSetup.cxx
@@ -26,14 +26,10 @@
  * -------------------------------------------------------------------- 
  */
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <stdlib.h>
 #include <math.h>
 #include <stdio.h>
 #include <locale.h>
-#endif  
-//LXDEPCHECK - standard libraries
 
 #include "lxSetup.h"
 #include "lxData.h"

--- a/loch/lxSetup.h
+++ b/loch/lxSetup.h
@@ -13,12 +13,7 @@
 #ifndef lxSetup_h
 #define lxSetup_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/xml/xml.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #include "lxMath.h"
 #include <set>

--- a/loch/lxTR.h
+++ b/loch/lxTR.h
@@ -68,10 +68,6 @@
 #ifndef lxTR_h
 #define lxTR_h
 
-
-/* Standard libraries */
-#ifndef LXDEPCHECK
-
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>
@@ -87,8 +83,6 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif
-#endif  
-/* LXDEPCHECK - standard libraries */
 
 #define TR_VERSION "1.1"
 #define TR_MAJOR_VERSION 1

--- a/loch/lxWX.cxx
+++ b/loch/lxWX.cxx
@@ -1,13 +1,10 @@
 #include "lxWX.h"
 
-#ifndef LXDEPCHECK
 #include <wx/string.h>
 #include <wx/intl.h>
 #include <wx/msgdlg.h>
 #include <wx/textctrl.h>
 #include <wx/frame.h>
-#endif
-
 
 wxStaticBox * lxStaticBox;
 wxStaticBoxSizer * lxStaticBoxSizer;

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -1,8 +1,6 @@
 #ifndef lxWX_h
 #define lxWX_h
 
-// Standard libraries
-#ifndef LXDEPCHECK
 #include <wx/spinctrl.h>
 #include <wx/slider.h>
 #include <wx/gbsizer.h>
@@ -10,9 +8,6 @@
 #include <wx/checkbox.h>
 #include <wx/panel.h>
 #include <wx/textctrl.h>
-#endif  
-//LXDEPCHECK - standard libraries
-
 
 #ifdef __WXGTK__
 #define lxBORDER 3


### PR DESCRIPTION
Removed defines `LXDEPCHECK` because they are unused now.