### PR TITLE
Removed macro lxPI

### DIFF
--- a/loch/lxGLC.cxx
+++ b/loch/lxGLC.cxx
@@ -48,6 +48,8 @@
 
 #include <fmt/format.h>
 
+#include <numbers>
+
 #define LXTRCBORDER (this->m_renderData->m_scaleMode == LXRENDER_FIT_SCREEN ? 0 : 16)
 
 BEGIN_EVENT_TABLE(lxGLCanvas, wxGLCanvas)
@@ -759,17 +761,17 @@ void lxGLCanvas::SetCamera() {
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
   lxVec up = lxVec(
-    sin(this->setup->cam_tilt / 180.0 * lxPI) * sin(this->setup->cam_dir / 180.0 * lxPI),
-    sin(this->setup->cam_tilt / 180.0 * lxPI) * cos(this->setup->cam_dir / 180.0 * lxPI),
-    cos(this->setup->cam_tilt / 180.0 * lxPI)
+    sin(this->setup->cam_tilt / 180.0 * std::numbers::pi) * sin(this->setup->cam_dir / 180.0 * std::numbers::pi),
+    sin(this->setup->cam_tilt / 180.0 * std::numbers::pi) * cos(this->setup->cam_dir / 180.0 * std::numbers::pi),
+    cos(this->setup->cam_tilt / 180.0 * std::numbers::pi)
     );
   //printf("LOOK FROM: %12.2f%12.2f%12.f\n", lxShiftVecXYZ(this->setup->cam_pos,this->shift));
   //printf("       TO: %12.2f%12.2f%12.f\n", lxShiftVecXYZ(this->setup->cam_center,this->shift));
   //printf("       UP: %12.2f%12.2f%12.f\n", lxVecXYZ(up));  
   if (this->setup->cam_anaglyph) {
     lxVec aRPosShift = (this->setup->cam_anaglyph_left ? -1.0 : 1.0) * (this->setup->cam_anaglyph_eyesep * this->setup->cam_dist) * lxVec(
-      -cos(this->setup->cam_dir / 180.0 * lxPI),
-      sin(this->setup->cam_dir / 180.0 * lxPI),
+      -cos(this->setup->cam_dir / 180.0 * std::numbers::pi),
+      sin(this->setup->cam_dir / 180.0 * std::numbers::pi),
       0
       );
     gluLookAt(lxShiftVecXYZ(this->setup->cam_pos,this->shift + aRPosShift),
@@ -1521,8 +1523,8 @@ void lxGLCanvas::RenderICompass(double size) {
   glBegin(GL_TRIANGLE_FAN);
   for(t = 0; t < 360; t++) {
     v2r(
-      (size - hlw) * sin(double(t)/180.0*lxPI),
-      (size - hlw) * cos(double(t)/180.0*lxPI));
+      (size - hlw) * sin(double(t)/180.0*std::numbers::pi),
+      (size - hlw) * cos(double(t)/180.0*std::numbers::pi));
   }
   glEnd();
 
@@ -1531,19 +1533,19 @@ void lxGLCanvas::RenderICompass(double size) {
     glBegin(GL_TRIANGLE_STRIP);
     for(t = 0; t <= 360; t++) {
       v2r(
-        (size - hlw) * sin(double(t)/180.0*lxPI),
-        (size - hlw) * cos(double(t)/180.0*lxPI));
+        (size - hlw) * sin(double(t)/180.0*std::numbers::pi),
+        (size - hlw) * cos(double(t)/180.0*std::numbers::pi));
       v2r(
-        (size + hlw) * sin(double(t)/180.0*lxPI),
-        (size + hlw) * cos(double(t)/180.0*lxPI));
+        (size + hlw) * sin(double(t)/180.0*std::numbers::pi),
+        (size + hlw) * cos(double(t)/180.0*std::numbers::pi));
     }
     glEnd();
   } else {
     glBegin(GL_LINE_STRIP);
     for(t = 0; t <= 360; t++) {
       v2r(
-        (size - hlw) * sin(double(t)/180.0*lxPI),
-        (size - hlw) * cos(double(t)/180.0*lxPI));
+        (size - hlw) * sin(double(t)/180.0*std::numbers::pi),
+        (size - hlw) * cos(double(t)/180.0*std::numbers::pi));
     }
     glEnd();
   }
@@ -1600,8 +1602,8 @@ void lxGLCanvas::RenderIClino(double size)
     v2r(0.0, 0.0);
     for(t = 0; t <= 20; t++) {
       v2r(
-        (-size) * cos(double(t) * (tilt / 20.0) / 180.0 * lxPI),
-        (size) *  sin(double(t) * (tilt / 20.0) / 180.0 * lxPI));
+        (-size) * cos(double(t) * (tilt / 20.0) / 180.0 * std::numbers::pi),
+        (size) *  sin(double(t) * (tilt / 20.0) / 180.0 * std::numbers::pi));
     }
     glEnd();
   }
@@ -1612,19 +1614,19 @@ void lxGLCanvas::RenderIClino(double size)
     glBegin(GL_TRIANGLE_STRIP);
     for(t = 0; t <= 90; t += 5) {
       v2r(
-        (-1.0) * (size - hlw) * cos(double(t)/180.0*lxPI),
-        (neg ? -1.0 : 1.0) * (size - hlw) * sin(double(t)/180.0*lxPI));
+        (-1.0) * (size - hlw) * cos(double(t)/180.0*std::numbers::pi),
+        (neg ? -1.0 : 1.0) * (size - hlw) * sin(double(t)/180.0*std::numbers::pi));
       v2r(      
-        (-1.0) * (size + hlw) * cos(double(t)/180.0*lxPI),
-        (neg ? -1.0 : 1.0) * (size + hlw) * sin(double(t)/180.0*lxPI));
+        (-1.0) * (size + hlw) * cos(double(t)/180.0*std::numbers::pi),
+        (neg ? -1.0 : 1.0) * (size + hlw) * sin(double(t)/180.0*std::numbers::pi));
     }
     glEnd();
   } else {
     glBegin(GL_LINE_STRIP);
     for(t = 0; t <= 90; t += 5) {
       v2r(
-        (-1.0) * (size) * cos(double(t)/180.0*lxPI),
-        (neg ? -1.0 : 1.0) * (size) * sin(double(t)/180.0*lxPI));
+        (-1.0) * (size) * cos(double(t)/180.0*std::numbers::pi),
+        (neg ? -1.0 : 1.0) * (size) * sin(double(t)/180.0*std::numbers::pi));
     }
     glEnd();
   }

--- a/loch/lxMath.cxx
+++ b/loch/lxMath.cxx
@@ -29,6 +29,7 @@
 #include "lxMath.h"
 
 #include <cmath>
+#include <numbers>
 
 void lxVec::Normalize() 
 {
@@ -53,13 +54,13 @@ double lxVec::Length() {
 
 double lxVec::Azimuth()
 {
-  return atan2(this->x, this->y) / lxPI * 180.0;
+  return atan2(this->x, this->y) / std::numbers::pi * 180.0;
 }
 
 
 double lxVec::Inclination()
 {
-  return atan2(this->z, sqrt(this->x * this->x + this->y * this->y)) / lxPI * 180.0;
+  return atan2(this->z, sqrt(this->x * this->x + this->y * this->y)) / std::numbers::pi * 180.0;
 }
 
 
@@ -153,18 +154,18 @@ void lxVecLimits::Add(double a, double b, double c)
 lxVec lxPol2Vec(const double l, const double a, const double i)
 {
   return lxVec(
-    l * cos(i / 180.0 * lxPI) * sin(a / 180.0 * lxPI),
-    l * cos(i / 180.0 * lxPI) * cos(a / 180.0 * lxPI),
-    l * sin(i / 180.0 * lxPI)
+    l * cos(i / 180.0 * std::numbers::pi) * sin(a / 180.0 * std::numbers::pi),
+    l * cos(i / 180.0 * std::numbers::pi) * cos(a / 180.0 * std::numbers::pi),
+    l * sin(i / 180.0 * std::numbers::pi)
     );
 }
 
 
 lxVec lxVec::Rotated(double a, double i) {
-  double sa = sin(a / 180.0 * lxPI), 
-         ca = cos(a / 180.0 * lxPI), 
-         si = sin(i / 180.0 * lxPI), 
-         ci = cos(i / 180.0 * lxPI);
+  double sa = sin(a / 180.0 * std::numbers::pi), 
+         ca = cos(a / 180.0 * std::numbers::pi), 
+         si = sin(i / 180.0 * std::numbers::pi), 
+         ci = cos(i / 180.0 * std::numbers::pi);
   
   return lxVec(
     this->x * ca      - this->y * sa                    ,      

--- a/loch/lxMath.h
+++ b/loch/lxMath.h
@@ -29,8 +29,6 @@
 #ifndef lxMath_h
 #define lxMath_h
 
-#define lxPI 3.1415926535898
-
 struct lxVec {
 
   double x, y, z;

--- a/loch/lxSetup.cxx
+++ b/loch/lxSetup.cxx
@@ -30,6 +30,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <locale.h>
+#include <numbers>
 
 #include "lxSetup.h"
 #include "lxData.h"
@@ -91,7 +92,7 @@ void lxSetup::SetLens(double lens)
   if (this->cam_lens > 2000.0)
     this->cam_lens = 2000.0;
 
-  this->cam_lens_vfov = atan(12.0 / this->cam_lens) / lxPI * 360.0;
+  this->cam_lens_vfov = atan(12.0 / this->cam_lens) / std::numbers::pi * 360.0;
   this->cam_lens_vfovr = 12.0 / this->cam_lens;
 
 }


### PR DESCRIPTION
Replaced macro `lxPI` with a standard π constant.