### PR TITLE
THBOOK: Point height value accepts '+?' and '-?'

### DIFF
--- a/thbook/ch02.tex
+++ b/thbook/ch02.tex
@@ -991,8 +991,8 @@ Point is a command for drawing a point map symbol.
       {\it height:} according to the sign of the value (positive, negative or
       unsigned), this type of symbol represents chimney height, pit depth
       or step height in general. The numeric value can be optionally followed by `|?|',
-      if the value is presumed and units can be added
-      (e.g.~|-value [40? ft]|).
+      if the value is presumed and units can be added (e.g.~|-value [40? ft]|). Values
+      `+?` and `-?` are also accepted. The meaning in these last cases are user dependent.
 
       {\it passage-height:} the following four forms of value are supported:
       |+<number>| (the height of the ceiling), |-<number>| (the depth of the


### PR DESCRIPTION
Explaining that point height values can also be either '+?' or '-?'.

Found out on _cave.th2_ file of 

> Example cave 1 – rather simple example [[tar.gz](https://therion.speleo.sk/downloads/demo.tar.gz) | [zip](https://therion.speleo.sk/downloads/demo.zip)]

available at [https://therion.speleo.sk/download.php](https://therion.speleo.sk/download.php)