### PR TITLE
Enabled pedantic warnings

### DIFF
--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -8,6 +8,12 @@ if (MSVC)
     target_compile_options(enable-warnings INTERFACE /W4)
     target_compile_options(disable-warnings INTERFACE /w)
 else()
-    target_compile_options(enable-warnings INTERFACE -Wall -Wextra -Wno-deprecated-enum-enum-conversion)
+    target_compile_options(enable-warnings INTERFACE
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Wno-deprecated-enum-enum-conversion
+        -Wno-overlength-strings
+    )
     target_compile_options(disable-warnings INTERFACE -w)
 endif()

--- a/src/therion-core/thdataobject.cxx
+++ b/src/therion-core/thdataobject.cxx
@@ -321,9 +321,9 @@ std::string thdataobject::throw_source() const
 void thdataobject::self_print(FILE * outf)
 {
   if (strlen(this->name) > 0)
-    fprintf(outf,"%s (%ld:%p) -- %s\n", this->get_class_name(), this->id, this, this->name);
+    fprintf(outf,"%s (%ld:%p) -- %s\n", this->get_class_name(), this->id, static_cast<void*>(this), this->name);
   else
-    fprintf(outf,"%s (%ld:%p)\n", this->get_class_name(), this->id, this);  
+    fprintf(outf,"%s (%ld:%p)\n", this->get_class_name(), this->id, static_cast<void*>(this));
 
   this->self_print_properties(outf);
 


### PR DESCRIPTION
I have enabled pedantic warnings `-Wpedantic` to ensure portability of the code. I also had to add `-Wno-overlength-strings`, because that warnings is not very useful, and it can't be easily fixed. But I'll think about it.