### PR TITLE
Fix Loch help archive creation on macOS (libarchive xattr issue)

### DIFF
--- a/loch/help/CMakeLists.txt
+++ b/loch/help/CMakeLists.txt
@@ -1,24 +1,47 @@
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}
   DESTINATION ${CMAKE_BINARY_DIR}/loch
-  PATTERN "CMakeLists.txt" EXCLUDE)
+  PATTERN "CMakeLists.txt" EXCLUDE
+)
 
 function(add_help DIR)
   set(FULL_PATH ${CMAKE_CURRENT_BINARY_DIR}/${DIR})
-  set(INPUT_FILES ${FULL_PATH}/loch.hhp ${FULL_PATH}/loch.hhc
-                  ${FULL_PATH}/loch.hhk ${FULL_PATH}/loch.htm)
+  set(INPUT_FILES
+    ${FULL_PATH}/loch.hhp
+    ${FULL_PATH}/loch.hhc
+    ${FULL_PATH}/loch.hhk
+    ${FULL_PATH}/loch.htm
+  )
 
-  add_custom_command(
-    OUTPUT ${FULL_PATH}/loch.htb
-    COMMAND ${CMAKE_COMMAND} -E tar cfv loch.htb --format=zip loch.hhp loch.hhc
-            loch.hhk loch.htm
-    DEPENDS ${INPUT_FILES}
-    WORKING_DIRECTORY ${FULL_PATH})
+  # On macOS, CMake's internal tar/zip implementation (libarchive) may fail when
+  # reading extended attributes (xattrs), producing:
+  #   "Could not open extended attribute file"
+  # Use the system zip with -X (exclude extra file attributes) on Apple platforms.
+  if(APPLE)
+    add_custom_command(
+      OUTPUT ${FULL_PATH}/loch.htb
+      COMMAND ${CMAKE_COMMAND} -E rm -f loch.htb
+      COMMAND /usr/bin/zip -X loch.htb loch.hhp loch.hhc loch.hhk loch.htm
+      DEPENDS ${INPUT_FILES}
+      WORKING_DIRECTORY ${FULL_PATH}
+    )
+  else()
+    add_custom_command(
+      OUTPUT ${FULL_PATH}/loch.htb
+      COMMAND ${CMAKE_COMMAND} -E tar cfv loch.htb --format=zip loch.hhp loch.hhc loch.hhk loch.htm
+      DEPENDS ${INPUT_FILES}
+      WORKING_DIRECTORY ${FULL_PATH}
+    )
+  endif()
 
   add_custom_target(hlp_${DIR} ALL DEPENDS ${FULL_PATH}/loch.htb)
   add_dependencies(loch hlp_${DIR})
 
-  install(FILES ${FULL_PATH}/loch.htb DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/therion-viewer/help/${DIR} COMPONENT loch-docs)
+  install(
+    FILES ${FULL_PATH}/loch.htb
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/therion-viewer/help/${DIR}
+    COMPONENT loch-docs
+  )
 endfunction()
 
 add_help("en")


### PR DESCRIPTION
On recent macOS versions,
`cmake -E tar --format=zip` may fail when creating loch.htb
with the error:

  "Could not open extended attribute file"

This appears to be caused by libarchive attempting to read
extended attributes (xattrs) from files on APFS.

To ensure reliable builds on macOS, switch to using the
system `/usr/bin/zip -X` command on Apple platforms.
The `-X` option excludes extra file attributes and avoids
xattr-related failures.

Non-Apple platforms continue using the existing
`cmake -E tar --format=zip` implementation.

Additionally, the archive is explicitly removed before
creation to preserve deterministic build behavior.