### PR TITLE
thbuffer refactoring

### DIFF
--- a/src/therion-core/th2ddataobject.cxx
+++ b/src/therion-core/th2ddataobject.cxx
@@ -176,8 +176,8 @@ void th2dsplitTT(char * src, char ** type, char ** subtype)
   sl = strlen(src);
   sTTtype.guarantee(sl+1);
   sTTsubtype.guarantee(sl+1);
-  t = sTTtype.get_buffer();
-  st = sTTsubtype.get_buffer();
+  t = sTTtype.data();
+  st = sTTsubtype.data();
   t[0] = 0;
   st[0] = 0;
   tl = 0;

--- a/src/therion-core/thattr.cxx
+++ b/src/therion-core/thattr.cxx
@@ -439,7 +439,7 @@ void thattr::export_dbf(const char * fname, int encoding)
             break;
           case THATTR_STRING:
             thdecode(&enc, encoding, ca->m_val_string.c_str());
-            DBFWriteStringAttribute(h, (int) oi->m_id, cf->m_xdbf_field, enc.get_buffer());
+            DBFWriteStringAttribute(h, (int) oi->m_id, cf->m_xdbf_field, enc.c_str());
             //DBFWriteStringAttribute(h, (int) oi->m_id, cf->m_xdbf_field, ca->m_val_string.c_str());
             break;
         }
@@ -486,7 +486,7 @@ void thattr::export_mp_object_begin(FILE * f, long user_id)
       news = ca->m_val_string;
       thdecode_mp(&enc, news.c_str());
       fprintf(f,"string %s;\n", cf->m_xmp_name.c_str());
-      fprintf(f,"%s := \"%s\";\n", cf->m_xmp_name.c_str(), enc.get_buffer());
+      fprintf(f,"%s := \"%s\";\n", cf->m_xmp_name.c_str(), enc.c_str());
     }
   }
 }
@@ -742,8 +742,8 @@ void thattr::export_html(const char * fname, const char * title, int /*encoding*
       } else {
         ca = &(ai->second);
         if (ca->m_type == THATTR_DOUBLE) {
-          std::snprintf(valb.get_buffer(), 127, cf->m_double_format.c_str(), ca->m_val_double);
-          value = valb.get_buffer();
+          std::snprintf(valb.data(), 127, cf->m_double_format.c_str(), ca->m_val_double);
+          value = valb.c_str();
         } else
           value = ca->m_val_string.c_str();
       }

--- a/src/therion-core/thbuffer.cxx
+++ b/src/therion-core/thbuffer.cxx
@@ -58,7 +58,7 @@ void thbuffer::enlarge(size_t min_size)
 }
 
 
-char * thbuffer::strncpy(const char * src, size_t n)
+char * thbuffer::assign(const char * src, size_t n)
 {
   if (n >= this->size)
     this->enlarge(n);
@@ -68,7 +68,7 @@ char * thbuffer::strncpy(const char * src, size_t n)
 }
 
 
-char * thbuffer::strcpy(const char * src)
+char * thbuffer::assign(const char * src)
 {
   size_t srclen = strlen(src);
   if (srclen >= this->size)
@@ -77,7 +77,7 @@ char * thbuffer::strcpy(const char * src)
 }
 
 
-char * thbuffer::strcat(const char * src)
+char * thbuffer::append(const char * src)
 {
   size_t newlen = strlen(src) + strlen(this->buff);
   if (newlen >= this->size)
@@ -86,7 +86,7 @@ char * thbuffer::strcat(const char * src)
 }
 
 
-char * thbuffer::strncat(const char * src, size_t n)
+char * thbuffer::append(const char * src, size_t n)
 {
   size_t newlen = n + 1 + strlen(this->buff);
   if (newlen >= this->size)
@@ -107,7 +107,7 @@ thbuffer::operator char** ()
 }
 
 
-char * thbuffer::get_buffer()
+char * thbuffer::data()
 {
   return this->buff;
 }
@@ -115,21 +115,21 @@ char * thbuffer::get_buffer()
 
 thbuffer & thbuffer::operator=(const char * src)
 {
-  this->strcpy(src);
+  this->assign(src);
   return *this;
 }
 
 
 thbuffer & thbuffer::operator=(thbuffer const & srcbf)
 {
-  this->strcpy(srcbf.buff);
+  this->assign(srcbf.buff);
   return *this;
 }
 
 
 thbuffer & thbuffer::operator+=(const char * src)
 {
-  this->strcat(src);
+  this->append(src);
   return *this;
 }
 

--- a/src/therion-core/thbuffer.cxx
+++ b/src/therion-core/thbuffer.cxx
@@ -95,12 +95,6 @@ char * thbuffer::append(const char * src, size_t n)
 }
 
 
-thbuffer::operator char* ()
-{
-  return this->buff;
-}
-
-
 thbuffer::operator char** ()
 {
   return &(this->buff);

--- a/src/therion-core/thbuffer.cxx
+++ b/src/therion-core/thbuffer.cxx
@@ -58,40 +58,43 @@ void thbuffer::enlarge(size_t min_size)
 }
 
 
-char * thbuffer::assign(const char * src, size_t n)
+thbuffer & thbuffer::assign(const char * src, size_t n)
 {
   if (n >= this->size)
     this->enlarge(n);
   ::strncpy(this->buff, src, n);
   this->buff[n] = 0;
-  return this->buff;
+  return *this;
 }
 
 
-char * thbuffer::assign(const char * src)
+thbuffer & thbuffer::assign(const char * src)
 {
   size_t srclen = strlen(src);
   if (srclen >= this->size)
     this->enlarge(srclen);
-  return ::strcpy(this->buff, src);
+  ::strcpy(this->buff, src);
+  return *this;
 }
 
 
-char * thbuffer::append(const char * src)
+thbuffer & thbuffer::append(const char * src)
 {
   size_t newlen = strlen(src) + strlen(this->buff);
   if (newlen >= this->size)
     this->enlarge(newlen);
-  return ::strcat(this->buff, src);
+  ::strcat(this->buff, src);
+  return *this;
 }
 
 
-char * thbuffer::append(const char * src, size_t n)
+thbuffer & thbuffer::append(const char * src, size_t n)
 {
   size_t newlen = n + 1 + strlen(this->buff);
   if (newlen >= this->size)
     this->enlarge(newlen);
-  return ::strncat(this->buff, src, n);
+  ::strncat(this->buff, src, n);
+  return *this;
 }
 
 

--- a/src/therion-core/thbuffer.h
+++ b/src/therion-core/thbuffer.h
@@ -130,10 +130,10 @@ class thbuffer {
   
   
   /**
-   * Type conversion to char*.
+   * @deprecated Use c_str() or data() instead.
    */
    
-  operator char* ();
+  operator char* () = delete;
   
   
   /**
@@ -162,6 +162,7 @@ class thbuffer {
    */
    
   thbuffer & operator+=(const char * src);
+  thbuffer & operator+=(const thbuffer& src) { return operator+=(src.buff); }
   
 
 };

--- a/src/therion-core/thbuffer.h
+++ b/src/therion-core/thbuffer.h
@@ -37,8 +37,6 @@
  
 class thbuffer {
 
-  public:
-
   char * buff;  ///< Buffer.
   size_t size;  ///< Buffer size.
 
@@ -73,11 +71,17 @@ class thbuffer {
   
   
   /**
+   * True if strlen() == 0
+   */
+  bool empty() const { return !buff[0]; };
+
+
+  /**
    * Copy given string to buffer and return pointer to it.
    * @param src Given string.
    */
    
-  char * strcpy(const char * src);
+  char * assign(const char * src);
 
 
   /**
@@ -88,7 +92,7 @@ class thbuffer {
    * @param n Source length.
    */
    
-  char * strncpy(const char * src, size_t n);
+  char * assign(const char * src, size_t n);
   
   
   /**
@@ -96,7 +100,7 @@ class thbuffer {
    * @param src Given string.
    */
    
-  char * strcat(const char * src);
+  char * append(const char * src);
   
   
   /**
@@ -105,7 +109,7 @@ class thbuffer {
    * @param src Given string.
    */
    
-  char * strncat(const char * src, size_t n);
+  char * append(const char * src, size_t n);
   
 
   /**
@@ -121,7 +125,8 @@ class thbuffer {
    * Return pointer to the buffer.
    */
    
-  char * get_buffer();
+  char * data();
+  const char * c_str() const { return buff; }
   
   
   /**

--- a/src/therion-core/thbuffer.h
+++ b/src/therion-core/thbuffer.h
@@ -162,7 +162,7 @@ class thbuffer {
    */
    
   thbuffer & operator+=(const char * src);
-  thbuffer & operator+=(const thbuffer& src) { return operator+=(src.buff); }
+  thbuffer & operator+=(const thbuffer& src) { return *this += src.buff; }
   
 
 };

--- a/src/therion-core/thbuffer.h
+++ b/src/therion-core/thbuffer.h
@@ -81,7 +81,7 @@ class thbuffer {
    * @param src Given string.
    */
    
-  char * assign(const char * src);
+  thbuffer & assign(const char * src);
 
 
   /**
@@ -92,7 +92,7 @@ class thbuffer {
    * @param n Source length.
    */
    
-  char * assign(const char * src, size_t n);
+  thbuffer & assign(const char * src, size_t n);
   
   
   /**
@@ -100,7 +100,7 @@ class thbuffer {
    * @param src Given string.
    */
    
-  char * append(const char * src);
+  thbuffer & append(const char * src);
   
   
   /**
@@ -109,7 +109,7 @@ class thbuffer {
    * @param src Given string.
    */
    
-  char * append(const char * src, size_t n);
+  thbuffer & append(const char * src, size_t n);
   
 
   /**

--- a/src/therion-core/thbuffer.h
+++ b/src/therion-core/thbuffer.h
@@ -73,7 +73,7 @@ class thbuffer {
   /**
    * True if strlen() == 0
    */
-  bool empty() const { return !buff[0]; };
+  [[nodiscard]] bool empty() const { return !buff[0]; };
 
 
   /**

--- a/src/therion-core/thchenc.cxx
+++ b/src/therion-core/thchenc.cxx
@@ -36,7 +36,7 @@ void thencode(thbuffer * dest, const char * src, int srcenc)
   // check if source is not UTF-8
   if (srcenc == TT_UTF_8) {
     thdecode(dest,TT_ASCII,src);
-    dest->strcpy(src);
+    dest->assign(src);
     return;
   }
   
@@ -44,7 +44,7 @@ void thencode(thbuffer * dest, const char * src, int srcenc)
   unsigned char * srcp, * dstp;
   // check buffer size
   dest->guarantee(srcln + srcln + srcln + srcln + srcln + srcln);
-  dstp = (unsigned char *) dest->get_buffer();
+  dstp = (unsigned char *) dest->c_str();
   srcp = (unsigned char *) src;
   
   while (srcx < srcln) {
@@ -96,14 +96,14 @@ void thdecode(thbuffer * dest, int destenc, const char * src)
 {
   // chack if source is not UTF-8
   if (destenc == TT_UTF_8) {
-    dest->strcpy(src);
+    dest->assign(src);
     return;
   }
   
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
   dest->guarantee(srcln);  // check buffer size
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   srcp = (unsigned char*) src;
   char32_t sch = 0;    
   

--- a/src/therion-core/thconfig.cxx
+++ b/src/therion-core/thconfig.cxx
@@ -125,7 +125,7 @@ const char * THCCC_SOURCE = "# Name of the source file.\n";
 thconfig::thconfig()
 {
 
-  this->install_path.strcpy("");
+  this->install_path.assign("");
   this->install_tex = false;
   this->install_tcltk = false;
   this->install_im = false;
@@ -179,16 +179,16 @@ thconfig::thconfig()
     }
   }
   if (loaded_ok) {
-    if (RegQueryValueEx(key,"InstallDir",NULL,&type,(BYTE *)tmpbf->get_buffer(),&length) != ERROR_SUCCESS) {
-      tmpbf->strcpy("");
+    if (RegQueryValueEx(key,"InstallDir",NULL,&type,(BYTE *)tmpbf->data(),&length) != ERROR_SUCCESS) {
+      tmpbf->assign("");
       this->install_path = "";
     } else {
-      this->install_path = tmpbf->get_buffer();
-      if (RegQueryValueEx(key,"TeX",NULL,&type,(BYTE *)tmpbf->get_buffer(),&length) == ERROR_SUCCESS)
+      this->install_path = tmpbf->c_str();
+      if (RegQueryValueEx(key,"TeX",NULL,&type,(BYTE *)tmpbf->data(),&length) == ERROR_SUCCESS)
         this->install_tex = true;
-      if (RegQueryValueEx(key,"TclTk",NULL,&type,(BYTE *)tmpbf->get_buffer(),&length) == ERROR_SUCCESS)
+      if (RegQueryValueEx(key,"TclTk",NULL,&type,(BYTE *)tmpbf->data(),&length) == ERROR_SUCCESS)
         this->install_tcltk = true;
-      if (RegQueryValueEx(key,"ImageMagick",NULL,&type,(BYTE *)tmpbf->get_buffer(),&length) == ERROR_SUCCESS)
+      if (RegQueryValueEx(key,"ImageMagick",NULL,&type,(BYTE *)tmpbf->data(),&length) == ERROR_SUCCESS)
         this->install_im = true;
     }
   	RegCloseKey(key);
@@ -231,8 +231,8 @@ thconfig::thconfig()
     if (sp != NULL) {
 #ifdef THWIN32
       this->search_path += "\\.therion;";
-      if (strlen(this->install_path.get_buffer()) > 0) {
-        this->search_path += this->install_path.get_buffer();
+      if (!this->install_path.empty()) {
+        this->search_path += this->install_path.c_str();
       } else {
         this->search_path += wincfg;
       }
@@ -244,8 +244,8 @@ thconfig::thconfig()
     }
     else {
 #ifdef THWIN32
-      if (strlen(this->install_path.get_buffer()) > 0) {
-        this->search_path += this->install_path.get_buffer();
+      if (!this->install_path.empty()) {
+        this->search_path += this->install_path.c_str();
       } else {
         this->search_path += wincfg;
       }
@@ -279,8 +279,8 @@ thconfig::thconfig()
     if (sp != NULL) {
 #ifdef THWIN32
       this->init_path += "\\.therion;";
-      if (strlen(this->install_path.get_buffer()) > 0) {
-        this->init_path += this->install_path.get_buffer();
+      if (!this->install_path.empty()) {
+        this->init_path += this->install_path.c_str();
       } else {
         this->init_path += winini;
       }
@@ -292,8 +292,8 @@ thconfig::thconfig()
     }
     else {
 #ifdef THWIN32
-      if (strlen(this->install_path.get_buffer()) > 0) {
-        this->init_path += this->install_path.get_buffer();
+      if (!this->install_path.empty()) {
+        this->init_path += this->install_path.c_str();
       } else {
         this->init_path += winini;
       }
@@ -326,7 +326,7 @@ char * thconfig::get_file_name()
 }
   
 
-void thconfig::append_source(char * fname, long startln, long endln)
+void thconfig::append_source(const char * fname, long startln, long endln)
 {
   thconfig_src xsrc;
   xsrc.fname = this->src_fnames.append(fname);
@@ -431,7 +431,7 @@ void thconfig::load()
     this->cfg_file.print_if_opened(thconfig_pifo, &fstarted);
     this->cfg_file.reset();
     try {
-      char * cfgln = this->cfg_file.read_line();
+      const char * cfgln = this->cfg_file.read_line();
       while(cfgln != NULL) {
         this->cfg_fenc = this->cfg_file.get_cif_encoding();
         thsplit_args(&valuemb, this->cfg_file.get_value());
@@ -459,11 +459,11 @@ void thconfig::load()
                 throw thexception("one file name expected");
               this->append_source(valuemb.get_buffer()[0]);
 #ifdef THWIN32
-              this->search_path.strcat(";");
+              this->search_path.append(";");
 #else
-              this->search_path.strcat(":");
+              this->search_path.append(":");
 #endif
-              this->search_path.strcat(this->cfg_file.get_cif_path());
+              this->search_path.append(this->cfg_file.get_cif_path());
             }
             break;
 
@@ -706,7 +706,7 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
     }
 
     thencode(&this->bf1, this->cfg_file.get_line(), this->cfg_file.get_cif_encoding());  
-    this->cfg_dblines.append(this->bf1.get_buffer());  
+    this->cfg_dblines.append(this->bf1.c_str());  
 
     // analyze the commands options
 
@@ -760,25 +760,25 @@ void thconfig::load_dbcommand(thmbuffer * valmb) {
             this->cfg_file.get_cif_line_number(),endlnopt));
                       
         thencode(&this->bf1, ln, this->cfg_file.get_cif_encoding());  
-        this->cfg_dblines.append(this->bf1.get_buffer());  
+        this->cfg_dblines.append(this->bf1.c_str());  
 
         thsplit_word(&this->bf1, &this->bf2, ln);
              
         // if end_command option, set turn off inside_cmd
         // and insert object into database
-        if (strcmp(this->bf1.get_buffer(), endlnopt) == 0) {
+        if (strcmp(this->bf1.c_str(), endlnopt) == 0) {
           inside_cmd = false;
           this->cfg_file.cmd_sensitivity_on();
           continue;   
         }
   
         // let's parse if an option line
-        optd = objptr->get_cmd_option_desc(this->bf1.get_buffer());
+        optd = objptr->get_cmd_option_desc(this->bf1.c_str());
         if (optd.id != TT_DATAOBJECT_UNKNOWN) {
-          thsplit_args(&this->mbf1, this->bf2.get_buffer());
+          thsplit_args(&this->mbf1, this->bf2.c_str());
           if (this->mbf1.get_size() < optd.nargs)
             throw thexception(fmt::format("not enough option arguments -- {} -- must be {}",
-              this->bf1.get_buffer(), optd.nargs));
+              this->bf1.c_str(), optd.nargs));
           optd.nargs = this->mbf1.get_size();
           objptr->set(optd, this->mbf1.get_buffer(), 
             this->cfg_file.get_cif_encoding(),
@@ -813,7 +813,7 @@ void thconfig::save()
   if ((this->fstate == THCFG_UPDATE) || (this->fstate == THCFG_GENERATE)) {
   
 #ifdef THDEBUG
-    thprint(fmt::format("\nwriting configuration file -- {}\n", this->fname.get_buffer()));
+    thprint(fmt::format("\nwriting configuration file -- {}\n", this->fname.c_str()));
 #else
     thprint("writing configuration file ... ");
     thtext_inline = true;
@@ -821,9 +821,9 @@ void thconfig::save()
 
     // OK, let's open configuration file for output
     FILE * cf;
-    cf = fopen(this->fname.get_buffer(),"w");
+    cf = fopen(this->fname.c_str(),"w");
     if (cf == NULL) {
-      thwarning(fmt::format("can't open configuration file for output -- {}", this->fname.get_buffer()));
+      thwarning(fmt::format("can't open configuration file for output -- {}", this->fname.c_str()));
       return;
     }
   
@@ -852,7 +852,7 @@ void thconfig::save()
     bool some_layout = false;
     for(sid = 0; sid < this->cfg_dblines.get_size(); sid++, srcn++) {
       thdecode(&(this->bf1), this->cfg_fenc, *srcn);
-      fprintf(cf, "%s\n", this->bf1.get_buffer());
+      fprintf(cf, "%s\n", this->bf1.c_str());
       some_layout = true;
     }
     if (some_layout)
@@ -915,7 +915,7 @@ void thconfig::xth_save()
     FILE * cf;
     cf = fopen(".xtherion.dat","w");
     if (cf == NULL) {
-      thwarning(fmt::format("can't open xtherion file for output -- {}.xth", this->fname.get_buffer()));
+      thwarning(fmt::format("can't open xtherion file for output -- {}.xth", this->fname.c_str()));
       return;
     }
   

--- a/src/therion-core/thconfig.cxx
+++ b/src/therion-core/thconfig.cxx
@@ -320,9 +320,9 @@ void thconfig::set_file_name(char * fn)
 }
 
    
-char * thconfig::get_file_name()
+const char * thconfig::get_file_name() const
 {
-  return this->fname;
+  return this->fname.c_str();
 }
   
 
@@ -384,14 +384,14 @@ void thconfig::set_search_path(char * pth)
 }
 
   
-char * thconfig::get_search_path()
+const char * thconfig::get_search_path() const
 {
-  return this->search_path;
+  return this->search_path.c_str();
 }
 
-char * thconfig::get_initialization_path()
+const char * thconfig::get_initialization_path() const
 {
-  return this->init_path;
+  return this->init_path.c_str();
 }
 
 
@@ -427,7 +427,7 @@ void thconfig::load()
   if ((this->fstate == THCFG_UPDATE) || (this->fstate == THCFG_READ)) {
     this->cfg_file.cmd_sensitivity_on();
     this->cfg_file.sp_scan_off();
-    this->cfg_file.set_file_name(this->fname);
+    this->cfg_file.set_file_name(this->fname.c_str());
     this->cfg_file.print_if_opened(thconfig_pifo, &fstarted);
     this->cfg_file.reset();
     try {

--- a/src/therion-core/thconfig.h
+++ b/src/therion-core/thconfig.h
@@ -149,7 +149,7 @@ class thconfig {
    * Set input file name.
    */
   
-  void append_source(char * fname, long startln = -1, long endln = -1);
+  void append_source(const char * fname, long startln = -1, long endln = -1);
   
   
   /**

--- a/src/therion-core/thconfig.h
+++ b/src/therion-core/thconfig.h
@@ -142,7 +142,7 @@ class thconfig {
    * Retrieve config file name.
    */
    
-  char * get_file_name();
+  const char * get_file_name() const;
   
   
   /**
@@ -187,9 +187,9 @@ class thconfig {
    
   void set_search_path(char * pth);
   
-  char * get_search_path();
+  const char * get_search_path() const;
   
-  char * get_initialization_path();
+  const char * get_initialization_path() const;
   
   /**
    * Load input from configuration file.

--- a/src/therion-core/thdata.cxx
+++ b/src/therion-core/thdata.cxx
@@ -195,7 +195,7 @@ static const thstok thdata_end_cmds[] = {
 };
 
 
-bool thdata::get_cmd_ends_match(char * cmd) {
+bool thdata::get_cmd_ends_match(const char * cmd) {
   return (thmatch_token(cmd,thdata_end_cmds) == TT_DATA_CMD);
 }
 
@@ -371,7 +371,7 @@ void thdata::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long 
       if ((indataline & THOP_INLINE) == 0)
         throw thexception("not a command line option -- team");
       thencode(&(this->db->buff_enc), *args, argenc);
-      temp_person.parse(this->db, this->db->buff_enc.get_buffer());
+      temp_person.parse(this->db, this->db->buff_enc.data());
       this->team_set.insert(temp_person);
       // check person roles
       if (cod.nargs > 1) {
@@ -410,7 +410,7 @@ void thdata::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long 
       if ((indataline & THOP_INLINE) == 0)
         throw thexception("not a command line option -- explo-team");
       thencode(&(this->db->buff_enc), *args, argenc);
-      temp_person.parse(this->db, this->db->buff_enc.get_buffer());
+      temp_person.parse(this->db, this->db->buff_enc.data());
       this->discovery_team_set.insert(temp_person);
       break;
 
@@ -2410,7 +2410,7 @@ void thdata::set_data_station(int nargs, char ** args, int argenc)
       case 1:
         if (strlen(args[1]) > 0) {
           thencode(&(this->db->buff_enc), args[1], argenc);
-          it->comment = this->db->strstore(this->db->buff_enc.get_buffer());
+          it->comment = this->db->strstore(this->db->buff_enc.c_str());
         }
         break;
       default:
@@ -2460,7 +2460,7 @@ void thdata::set_data_station(int nargs, char ** args, int argenc)
           //    it->code = NULL;
           //  } else {
           //    thencode(&(this->db->buff_enc), args[ai], argenc);
-          //    it->code = this->db->strstore(this->db->buff_enc.get_buffer());
+          //    it->code = this->db->strstore(this->db->buff_enc.data());
           //  }
           //  break;
           case TT_DATASFLAG_EXPLORED:
@@ -2502,7 +2502,7 @@ void thdata::set_data_station(int nargs, char ** args, int argenc)
             ai++;            
             if (strlen(args[ai]) > 0) {
               thencode(&(this->db->buff_enc), args[ai], argenc);
-              it->attr[attrname] = this->db->strstore(this->db->buff_enc.get_buffer());
+              it->attr[attrname] = this->db->strstore(this->db->buff_enc.c_str());
             } else {
               it->attr.erase(attrname);
             }

--- a/src/therion-core/thdata.h
+++ b/src/therion-core/thdata.h
@@ -301,7 +301,7 @@ class thdata : public thdataobject {
    * Whether cmd is end.
    */
    
-  bool get_cmd_ends_match(char * cmd) override;
+  bool get_cmd_ends_match(const char * cmd) override;
   
   
   /**

--- a/src/therion-core/thdatabase.cxx
+++ b/src/therion-core/thdatabase.cxx
@@ -332,10 +332,10 @@ void thdatabase::insert(std::unique_ptr<thdataobject> unique_optr)
             survey_optr->full_name = survey_optr->name;
             survey_optr->reverse_full_name = survey_optr->name;
           } else {
-            this->buff_tmp.strcpy(survey_optr->name);
-            this->buff_tmp.strcat(".");
-            this->buff_tmp.strcat(this->csurveyptr->full_name);
-            survey_optr->full_name = this->strstore(this->buff_tmp.get_buffer());
+            this->buff_tmp.assign(survey_optr->name);
+            this->buff_tmp.append(".");
+            this->buff_tmp.append(this->csurveyptr->full_name);
+            survey_optr->full_name = this->strstore(this->buff_tmp.c_str());
             survey_optr->reverse_full_name = this->strstore(survey_optr->full_name);
             survey_optr->full_name_reverse();
           }
@@ -383,12 +383,12 @@ thsurvey * thdatabase::get_survey_noexc(const char * sn, thsurvey * ps)
   thdb_survey_map_type::iterator si;
   
   if (sn != NULL) {
-    this->buff_tmp.strcpy(sn);
+    this->buff_tmp.assign(sn);
     if ((ps != NULL) && (ps->id != this->fsurveyptr->id)) {
-      this->buff_tmp.strcat(".");
-      this->buff_tmp.strcat(ps->full_name);
+      this->buff_tmp.append(".");
+      this->buff_tmp.append(ps->full_name);
     }
-    si = this->survey_map.find(thsurveyname(this->buff_tmp.get_buffer()));
+    si = this->survey_map.find(thsurveyname(this->buff_tmp.c_str()));
     if (si != this->survey_map.end())
       return si->second->get_nss();
     else
@@ -409,12 +409,12 @@ thsurvey * thdatabase::get_exact_survey_noexc(const char * sn, thsurvey * ps)
   thdb_survey_map_type::iterator si;
   
   if (sn != NULL) {
-    this->buff_tmp.strcpy(sn);
+    this->buff_tmp.assign(sn);
     if ((ps != NULL) && (ps->id != this->fsurveyptr->id)) {
-      this->buff_tmp.strcat(".");
-      this->buff_tmp.strcat(ps->full_name);
+      this->buff_tmp.append(".");
+      this->buff_tmp.append(ps->full_name);
     }
-    si = this->survey_map.find(thsurveyname(this->buff_tmp.get_buffer()));
+    si = this->survey_map.find(thsurveyname(this->buff_tmp.c_str()));
     if (si != this->survey_map.end())
       return si->second;
     else
@@ -574,12 +574,12 @@ class thdataobject * thdatabase::revise(char * nn, class thsurvey * fathersptr,
   if ((this->mbuff_tmp.get_size() == 2)) {
     divname = this->mbuff_tmp.get_buffer();
     objname = divname[0];
-    this->buff_tmp.strcpy(divname[1]);
+    this->buff_tmp.assign(divname[1]);
     if ((fathersptr != NULL) && (fathersptr->level > 1)) {
-      this->buff_tmp.strcat(".");
-      this->buff_tmp.strcat(fathersptr->full_name);
+      this->buff_tmp.append(".");
+      this->buff_tmp.append(fathersptr->full_name);
     }
-    sfullname = this->buff_tmp.get_buffer();
+    sfullname = this->buff_tmp.data();
     thsurveyname xxx = thsurveyname(sfullname);
     iii = this->survey_map.find(xxx);
     if (iii == this->survey_map.end())

--- a/src/therion-core/thdataobject.cxx
+++ b/src/therion-core/thdataobject.cxx
@@ -124,7 +124,7 @@ bool thdataobject::get_cmd_ends_state() {
 }
 
 
-bool thdataobject::get_cmd_ends_match(char * /*cmd*/) {
+bool thdataobject::get_cmd_ends_match(const char * /*cmd*/) {
   return false;
 }
 
@@ -223,7 +223,7 @@ void thdataobject::set(thcmd_option_desc cod, char ** args, int argenc, unsigned
           if (cod.nargs > 1)
             throw thexception("multiple option arguments -- title");
           thencode(&(this->db->buff_enc), *args, argenc);
-          this->title = this->db->strstore(this->db->buff_enc.get_buffer());
+          this->title = this->db->strstore(this->db->buff_enc.c_str());
           break;
         default:
           throw thexception("title specification not allowed for this object");
@@ -239,7 +239,7 @@ void thdataobject::set(thcmd_option_desc cod, char ** args, int argenc, unsigned
             throw thexception("too many option arguments -- author");
           this->dotmp_date.parse(args[0]);
           thencode(&(this->db->buff_enc), args[1], argenc);
-          this->dotmp_person.parse(this->db, this->db->buff_enc.get_buffer());
+          this->dotmp_person.parse(this->db, this->db->buff_enc.c_str());
           this->dotmp_author = thdataobject_author(this->dotmp_person,
               this->revision);
           this->author_map[this->dotmp_author].join(this->dotmp_date);
@@ -260,7 +260,7 @@ void thdataobject::set(thcmd_option_desc cod, char ** args, int argenc, unsigned
           thencode(&(this->db->buff_enc), args[1], argenc);
           this->dotmp_copyright = 
             thdataobject_copyright(
-            this->db->strstore(this->db->buff_enc.get_buffer(), true), 
+            this->db->strstore(this->db->buff_enc.c_str(), true), 
             this->revision);
           this->copyright_map[this->dotmp_copyright].join(this->dotmp_date);
           break;
@@ -279,7 +279,7 @@ void thdataobject::set(thcmd_option_desc cod, char ** args, int argenc, unsigned
       if (cod.nargs != 2)
         throw thexception("invalid attribute specification -- should be <name> <value>");
       thencode(&(this->db->buff_enc), args[1], argenc);
-      this->parse_attribute(args[0], this->db->buff_enc.get_buffer());
+      this->parse_attribute(args[0], this->db->buff_enc.c_str());
       break;
         
     default:
@@ -407,7 +407,7 @@ void thdataobject::start_insert()
 }
 
 
-void thdataobject::read_cs(char * src_x, char * src_y, double & dst_x, double & dst_y, bool adj_bbox)
+void thdataobject::read_cs(const char * src_x, const char * src_y, double & dst_x, double & dst_y, bool adj_bbox)
 {
 	  // 1. Check compatibility with output CS.
 	  if (thcfg.outcs_def.is_valid()) {
@@ -529,7 +529,7 @@ void thdataobject::convert_cs(int src_cs, double src_x, double src_y, double & d
 }
 
 
-void thdataobject::parse_attribute(char * name, char * value) {
+void thdataobject::parse_attribute(const char * name, const char * value) {
 
   // check name
   if ((name == NULL) || (strlen(name) == 0))

--- a/src/therion-core/thdataobject.h
+++ b/src/therion-core/thdataobject.h
@@ -346,7 +346,7 @@ class thdataobject {
    * Whether cmd is end.
    */
    
-  virtual bool get_cmd_ends_match(char * cmd);
+  virtual bool get_cmd_ends_match(const char * cmd);
   
   
   /**
@@ -457,7 +457,7 @@ class thdataobject {
    * Read coordinates and estimate approximate location for PROJ conversions.
    */
 
-  void read_cs(char * src_x, char * src_y, double & dst_x, double & dst_y, bool adj_bbox = true);
+  void read_cs(const char * src_x, const char * src_y, double & dst_x, double & dst_y, bool adj_bbox = true);
 
 
   /**
@@ -476,7 +476,7 @@ class thdataobject {
    * Parse object attributes.
    */
 
-  void parse_attribute(char * name, char * value);
+  void parse_attribute(const char * name, const char * value);
 
 };
 

--- a/src/therion-core/thdatareader.cxx
+++ b/src/therion-core/thdatareader.cxx
@@ -104,8 +104,8 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
              
         // if end_command option, set turn off inside_cmd
         // and insert object into database
-        if ((advanced_end_search && objptr->get_cmd_ends_match(this->bf1.get_buffer())) || 
-            (strcmp(this->bf1.get_buffer(), endlnopt) == 0)) {
+        if ((advanced_end_search && objptr->get_cmd_ends_match(this->bf1.c_str())) || 
+            (strcmp(this->bf1.c_str(), endlnopt) == 0)) {
           inside_cmd = false;
           //this->inp.cmd_sensitivity_on();
           if (!configure_cmd)
@@ -118,12 +118,12 @@ void thdatareader::read(const char * ifname, long lnstart, long lnend, const cha
         }
   
         // let's parse if an option line
-        optd = objptr->get_cmd_option_desc(this->bf1.get_buffer());
+        optd = objptr->get_cmd_option_desc(this->bf1.c_str());
         if (optd.id != TT_DATAOBJECT_UNKNOWN) {
-          thsplit_args(&this->mbf1, this->bf2.get_buffer());
+          thsplit_args(&this->mbf1, this->bf2.c_str());
           if (this->mbf1.get_size() < optd.nargs)
             throw thexception(fmt::format("not enough option arguments -- {} -- must be {}",
-              this->bf1.get_buffer(), optd.nargs));
+              this->bf1.c_str(), optd.nargs));
           optd.nargs = this->mbf1.get_size();
           objptr->set(optd, this->mbf1.get_buffer(), 
             this->inp.get_cif_encoding(),

--- a/src/therion-core/thdb1d.cxx
+++ b/src/therion-core/thdb1d.cxx
@@ -3100,7 +3100,7 @@ void thdb1d::process_xelev()
                   tmpbf += "@";
                   tmpbf += xi->to.survey;
                 }
-                throw thexception(fmt::format("survey shot not found -- {}", tmpbf.get_buffer()));
+                throw thexception(fmt::format("survey shot not found -- {}", tmpbf.c_str()));
               } else {
                 // the leg is in carrow - set its extend
                 if ((xi->extend & TT_EXTENDFLAG_DIRECTION) != 0) {

--- a/src/therion-core/thdb1d.cxx
+++ b/src/therion-core/thdb1d.cxx
@@ -3069,7 +3069,7 @@ void thdb1d::process_xelev()
   thdata * dp;
   thdb1d_tree_node * nodes = this->get_tree_nodes(), * from_node, * to_node;
   thdb1d_tree_arrow * carrow;
-  thbuffer tmpbf;
+  std::string tmpbf;
   thdb_object_list_type::iterator obi = this->db->object_list.begin();
   while (obi != this->db->object_list.end()) {
     switch ((*obi)->get_class_id()) {

--- a/src/therion-core/thdb2d.cxx
+++ b/src/therion-core/thdb2d.cxx
@@ -3545,7 +3545,7 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
 #ifdef THDEBUG
   thprint("running metapost\n");
 #endif
-  retcode = system(com.get_buffer());
+  retcode = system(com.c_str());
   thexpmap_log_log_file("data.log",
   "####################### metapost log file ########################\n",
   "#################### end of metapost log file ####################\n",true);
@@ -3560,7 +3560,7 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
   double n[6] = {};
   com.guarantee(256);
   std::unique_ptr<thline> cln;
-  char * buff = com.get_buffer();
+  char * buff = com.data();
   ti = todo.begin();
   while ((fscanf(af.get(),"%32s",buff) > 0) && (ti != todo.end())) {
     if (cnt < 6) {

--- a/src/therion-core/thdb2dji.cxx
+++ b/src/therion-core/thdb2dji.cxx
@@ -55,8 +55,8 @@ thdb2dji::thdb2dji()
 void thdb2dji::parse_item(char * istr)
 {
 /*
-  thdb.buff_tmp.strcpy(istr);
-  char * p_name = thdb.buff_tmp.get_buffer(), * s_name = "", * tmpch;
+  thdb.buff_tmp.assign(istr);
+  char * p_name = thdb.buff_tmp.data(), * s_name = "", * tmpch;
   tmpch = p_name;
   size_t snl = strlen(istr), sni;
   for(sni = 0; sni < snl; sni++, tmpch++)
@@ -76,12 +76,12 @@ void thdb2dji::parse_item(char * istr)
       throw thexception(fmt::format("line mark not a keyword -- {}",istr));
   }
   /*
-  thdb.buff_enc.strcpy(pars[0]);
+  thdb.buff_enc.assign(pars[0]);
   if (strlen(s_name) > 0) {
     thdb.buff_enc += "@";
     thdb.buff_enc += s_name;
   }*/
-//  thparse_objectname(this->name, & thdb.buff_stations, thdb.buff_enc.get_buffer());
+//  thparse_objectname(this->name, & thdb.buff_stations, thdb.buff_enc.data());
   thparse_objectname(this->name, & thdb.buff_stations, pars[0]);
 }
 

--- a/src/therion-core/therion.cxx
+++ b/src/therion-core/therion.cxx
@@ -151,7 +151,7 @@ void thprint_xtherion() {
         tss += " \"";
         tss += tsrc;
         tss += "\" [encoding convertfrom utf-8 \"";
-        tss += tdst.get_buffer();
+        tss += tdst.c_str();
         tss += "\"]\n";
       }
       l++;

--- a/src/therion-core/thexpdb.cxx
+++ b/src/therion-core/thexpdb.cxx
@@ -174,8 +174,8 @@ void thexpdb::export_sql_file(class thdatabase * dbp)
             thdecode(&(dbp->buff_enc),enc,str); \
           else \
             dbp->buff_enc = ""; \
-          thdecode_sql(&(dbp->buff_tmp),dbp->buff_enc.get_buffer());}
-#define ESTR (dbp->buff_tmp.get_buffer())
+          thdecode_sql(&(dbp->buff_tmp),dbp->buff_enc.c_str());}
+#define ESTR (dbp->buff_tmp.c_str())
 
 #define CHECK_STRLEN(var,str) {if (strlen(str) > var) var = strlen(str);}
 #define INSERTPERSON \

--- a/src/therion-core/thexpmap.cxx
+++ b/src/therion-core/thexpmap.cxx
@@ -3510,7 +3510,7 @@ void thexpmap::export_uni_scrap(FILE * out, class thscrap * scrap)
 			stnbuff = "";
 		}
 		stnbuff += scrap->name;
-		img_write_item(pimg, img_LABEL, 0, stnbuff, avx/avn, avy/avn, avz/avn);
+		img_write_item(pimg, img_LABEL, 0, stnbuff.c_str(), avx/avn, avy/avn, avz/avn);
 	}
 		
 }

--- a/src/therion-core/thexpmap.cxx
+++ b/src/therion-core/thexpmap.cxx
@@ -201,8 +201,8 @@ void thexpmap::parse_options(int & argx, int nargs, char ** args)
       this->layout->set(thcmd_option_desc(TT_LAYOUT_COPY), &(args[argx]), this->cfgptr->cfg_file.get_cif_encoding(), 0); // = thdb.strstore(args[argx],true);
       this->layoutopts += " -layout ";
       thencode(&(this->cfgptr->bf1), args[argx], this->cfgptr->cfg_file.get_cif_encoding());
-      thdecode_arg(&(this->cfgptr->bf2), this->cfgptr->bf1.get_buffer());
-      this->layoutopts += this->cfgptr->bf2.get_buffer();
+      thdecode_arg(&(this->cfgptr->bf2), this->cfgptr->bf1.c_str());
+      this->layoutopts += this->cfgptr->bf2.c_str();
       argx++;
       break;
 
@@ -256,9 +256,9 @@ void thexpmap::parse_layout_option(int & argx, int nargs, char ** args) {
 
   for (i = 0; i < o.nargs; i++) {
     thencode(&(this->cfgptr->bf1), args[argx], this->cfgptr->cfg_file.get_cif_encoding());
-    thdecode_arg(&(this->cfgptr->bf2), this->cfgptr->bf1.get_buffer());
+    thdecode_arg(&(this->cfgptr->bf2), this->cfgptr->bf1.c_str());
     this->layoutopts += " ";
-    this->layoutopts += this->cfgptr->bf2.get_buffer();
+    this->layoutopts += this->cfgptr->bf2.c_str();
     argx++;
   }  
  
@@ -277,8 +277,8 @@ void thexpmap::dump_body(FILE * xf)
   thexport::dump_body(xf);
   if (this->format != TT_EXPMAP_FMT_UNKNOWN)
     fprintf(xf," -format %s", thmatch_string(this->format, thtt_expmap_fmt));
-  thdecode(&(this->cfgptr->bf1), this->cfgptr->cfg_fenc, this->layoutopts.get_buffer());
-  fprintf(xf,"%s",this->cfgptr->bf1.get_buffer());
+  thdecode(&(this->cfgptr->bf1), this->cfgptr->cfg_fenc, this->layoutopts.c_str());
+  fprintf(xf,"%s",this->cfgptr->bf1.c_str());
 }
 
 
@@ -557,7 +557,7 @@ void thexpmap::export_xvi(class thdb2dprj * prj)
       stvec[(j)].x -= shx; \
       stvec[(j)].y -= shy; \
       if (!cs->is_temporary()) { \
-        fprintf(pltf,"  {%12.2f %12.2f %s}\n", stvec[(j)].x, stvec[(j)].y, stname.get_buffer()); \
+        fprintf(pltf,"  {%12.2f %12.2f %s}\n", stvec[(j)].x, stvec[(j)].y, stname.c_str()); \
       } \
     }
 
@@ -2134,14 +2134,14 @@ if (ENC_NEW.NFSS==0) {
       thbuffer texb;
       texb.guarantee(128);
       thdecode(& texb,TT_ISO8859_2,(strlen(cmap->map->title) > 0 ? cmap->map->title : cmap->map->name));      
-      thdecode_tex(& encb, texb.get_buffer());
-      fprintf(plf,"\t\tN => '%s',\n",encb.get_buffer());
+      thdecode_tex(& encb, texb.c_str());
+      fprintf(plf,"\t\tN => '%s',\n",encb.c_str());
       LAYER_ITER->second.N = (strlen(cmap->map->title) > 0 ? cmap->map->title : cmap->map->name);
       LAYER_ITER->second.Nraw = cmap->map->name;
       if ((chtitle != NULL) && ((cmap->next_item == NULL) || (cmap->next_item->title))) {
         thdecode(& texb,TT_ISO8859_2,chtitle);      
-        thdecode_tex(& encb, texb.get_buffer());
-        fprintf(plf,"\t\tT => '%s',\n",encb.get_buffer());
+        thdecode_tex(& encb, texb.c_str());
+        fprintf(plf,"\t\tT => '%s',\n",encb.c_str());
         LAYER_ITER->second.T = chtitle;
         chtitle = NULL;
       }
@@ -2224,10 +2224,10 @@ if (ENC_NEW.NFSS==0) {
   //QUICK_MAP_EXPORT:
 
   //if (strlen(this->layout->doc_title) == 0) {
-  tit.strcpy(thdb.db2d.get_projection_title(prj));
-    //LAYOUT.doc_title = tit.get_buffer();
+  tit.assign(thdb.db2d.get_projection_title(prj));
+    //LAYOUT.doc_title = tit.c_str();
   //} else
-  //  tit.strcpy(LAYOUT.doc_title.c_str());
+  //  tit.assign(LAYOUT.doc_title.c_str());
     
   tf = fopen(thtmp.get_file_name("th_texts.tex"),"w");
   fprintf(tf,"\\legendtitle={%s}\n",utf2tex(thT("title legend",this->layout->lang)).c_str());
@@ -2267,8 +2267,8 @@ if (ENC_NEW.NFSS==0) {
   }
 
   // ak neni atlas, tak nastavi legendcavename
-  fprintf(tf,"\\cavename={%s}\n",ths2tex(tit.get_buffer(), this->layout->lang).c_str());
-  ldata.cavename = tit.get_buffer();
+  fprintf(tf,"\\cavename={%s}\n",ths2tex(tit.c_str(), this->layout->lang).c_str());
+  ldata.cavename = tit.c_str();
   ldata.comment = "";
 
   if (strlen(this->layout->doc_comment) > 0) {
@@ -2360,7 +2360,7 @@ if (ENC_NEW.NFSS==0) {
 #ifdef THDEBUG
     thprint("running metapost\n");
 #endif
-    retcode = system(com.get_buffer());
+    retcode = system(com.c_str());
     thexpmap_log_log_file("data.log",
     "####################### metapost log file ########################\n",
     "#################### end of metapost log file ####################\n",true);
@@ -2397,7 +2397,7 @@ if (ENC_NEW.NFSS==0) {
 #ifdef THDEBUG
       thprint("running pdftex\n");
 #endif
-      retcode = system(com.get_buffer());
+      retcode = system(com.c_str());
       thexpmap_log_log_file("data.log",
       "######################## pdftex log file #########################\n",
       "##################### end of pdftex log file #####################\n",false);
@@ -3070,7 +3070,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
                 fprintf(out->file,",");
                 lp->export_nextcp_mp(out);
                 thdb.buff_enc.guarantee(4096);
-                //sprintf(thdb.buff_enc.get_buffer(),"%.0f",lp->rsize - out->layout->goz);
+                //sprintf(thdb.buff_enc.data(),"%.0f",lp->rsize - out->layout->goz);
                 fprintf(out->file,",btex \\thwallaltitude %s etex);\n",utf2tex(out->layout->units.format_length(lp->rsize - out->layout->goz)).c_str());
 //                fprintf(out->file,",\"%.0f\");\n",lp->rsize);
               }
@@ -3219,7 +3219,7 @@ void thexpmap::export_pdf_set_colors(class thdb2dxm * maps, class thdb2dprj * /*
       clr.alpha_correct(tmp_alpha);
       clr.set_color(this->layout->color_model, clrec.col_legend);
 //      opacity_correction(clrec.R, clrec.G, clrec.B);
-      //sprintf(tmpb.get_buffer(), "%.0f", curz - this->layout->goz);
+      //sprintf(tmpb.data(), "%.0f", curz - this->layout->goz);
       clrec.texname = utf2tex(this->layout->units.format_length(curz - this->layout->goz));
       clrec.texname += "\\thinspace ";			
       clrec.texname += utf2tex(this->layout->units.format_i18n_length_units());
@@ -3340,7 +3340,7 @@ void thexpmap::export_uni(class thdb2dxm * maps, class thdb2dprj * /*prj*/) // T
   img_output_version = 4;
   thbuffer fname;
   fname = "cave";
-  pimg = img_open_write(fnm, fname.get_buffer(), 1);
+  pimg = img_open_write(fnm, fname.c_str(), 1);
   if (pimg == NULL) {
     thwarning(fmt::format("can't open {} for output",fnm))
     return;

--- a/src/therion-core/thexpmap.cxx
+++ b/src/therion-core/thexpmap.cxx
@@ -534,7 +534,7 @@ void thexpmap::export_xvi(class thdb2dprj * prj)
   xmin -= shx; xmax -= shx; gxo -= shx;
   ymin -= shy; ymax -= shy; gyo -= shy;
 
-  thbuffer stname;
+  std::string stname;
   thsurvey * css;
   fprintf(pltf,"set XVIstations {\n");
   for(i = 0; i < nstvec; i++) {
@@ -1208,7 +1208,7 @@ void thexpmap::export_pdf(thdb2dxm * maps, thdb2dprj * prj) {
   unsigned sscrap = 0;
   thexpmap_xmps exps;
   const char * chtitle;
-  thbuffer tit;
+  std::string tit;
   bool quick_map_exp = false;
   double origin_shx, origin_shy, new_shx, new_shy, srot = 0.0, crot = 1.0, rrot = 0.0;
   thexpmapmpxs out;
@@ -2295,7 +2295,7 @@ if (ENC_NEW.NFSS==0) {
 
   // teraz sa hodi do temp adresara - spusti metapost, thpdf, a pdftex a skopiruje vysledok
   auto tmp_handle = thtmp.switch_to_tmpdir();
-  thbuffer com;
+  std::string com;
   
   // vypise kodovania
   print_fonts_setup();
@@ -3338,9 +3338,7 @@ void thexpmap::export_uni(class thdb2dxm * maps, class thdb2dprj * /*prj*/) // T
 
   img * pimg;
   img_output_version = 4;
-  thbuffer fname;
-  fname = "cave";
-  pimg = img_open_write(fnm, fname.c_str(), 1);
+  pimg = img_open_write(fnm, "cave", 1);
   if (pimg == NULL) {
     thwarning(fmt::format("can't open {} for output",fnm))
     return;
@@ -3442,7 +3440,7 @@ void thexpmap::export_uni_scrap(FILE * out, class thscrap * scrap)
 	
 	img * pimg;
 	pimg = (img *) out;
-	thbuffer stnbuff;
+	std::string stnbuff;
 	
 	double avx = 0.0, avy = 0.0, avz = 0.0, avn = 0.0;
 #define avadd(x,y,z) {avx	+= x; avy += y; avz += z; avn += 1.0;}

--- a/src/therion-core/thexpmodel.cxx
+++ b/src/therion-core/thexpmodel.cxx
@@ -331,9 +331,9 @@ void thexpmodel::export_3d_file(class thdatabase * dbp)
         x_exp |= img_SFLAG_ENTRANCE;
       if (((tmps->flags & TT_STATIONFLAG_FIXED) != 0) && ((tmps->flags & TT_STATIONFLAG_NOTFIXED) == 0))
         x_exp |= img_SFLAG_FIXED;
-      stnbuf.strcpy(dbp->db1d.station_vec[i].survey->get_reverse_full_name());
-      if (strlen(stnbuf.get_buffer()) > 0) stnbuf.strcat(".");
-      stnbuf.strcat(dbp->db1d.station_vec[i].name);
+      stnbuf.assign(dbp->db1d.station_vec[i].survey->get_reverse_full_name());
+      if (!stnbuf.empty()) stnbuf.append(".");
+      stnbuf.append(dbp->db1d.station_vec[i].name);
       if (!tmps->is_temporary())
         img_write_item(pimg, img_LABEL, x_exp, stnbuf,
           dbp->db1d.station_vec[i].x, dbp->db1d.station_vec[i].y, dbp->db1d.station_vec[i].z);

--- a/src/therion-core/thexpmodel.cxx
+++ b/src/therion-core/thexpmodel.cxx
@@ -314,7 +314,7 @@ void thexpmodel::export_3d_file(class thdatabase * dbp)
   }
 
   cis_exp = s_exp;
-  thbuffer stnbuf;
+  std::string stnbuf;
   thdb1ds * tmps;
   for(i = 0; i < nstat; i++, cis_exp++) {
     if ((*cis_exp != 0) || (s_exp[dbp->db1d.station_vec[i].uid - 1] != 0) || 

--- a/src/therion-core/thexpmodel.cxx
+++ b/src/therion-core/thexpmodel.cxx
@@ -335,7 +335,7 @@ void thexpmodel::export_3d_file(class thdatabase * dbp)
       if (!stnbuf.empty()) stnbuf.append(".");
       stnbuf.append(dbp->db1d.station_vec[i].name);
       if (!tmps->is_temporary())
-        img_write_item(pimg, img_LABEL, x_exp, stnbuf,
+        img_write_item(pimg, img_LABEL, x_exp, stnbuf.c_str(),
           dbp->db1d.station_vec[i].x, dbp->db1d.station_vec[i].y, dbp->db1d.station_vec[i].z);
       else {
         x_exp |= img_SFLAG_ANON;

--- a/src/therion-core/thexport.cxx
+++ b/src/therion-core/thexport.cxx
@@ -134,7 +134,7 @@ void thexport::dump_body(FILE * xf)
 {
   if (this->outpt_def) {
     thdecode_arg(&(this->cfgptr->bf1), this->outpt);
-    fprintf(xf," -output %s",this->cfgptr->bf1.get_buffer());
+    fprintf(xf," -output %s",this->cfgptr->bf1.c_str());
   }  
 }
 
@@ -142,7 +142,7 @@ void thexport::dump_body(FILE * xf)
 const char * thexport::get_output(const char * defname)
 {
   static thbuffer outptfname;
-  outptfname = this->cfgpath.get_buffer();
+  outptfname = this->cfgpath.c_str();
   if (this->outpt_def) {
     if (thpath_is_absolute(this->outpt))
       return this->outpt;
@@ -151,7 +151,7 @@ const char * thexport::get_output(const char * defname)
   } else {
     outptfname += defname;
   }
-  return outptfname.get_buffer();
+  return outptfname.c_str();
 }
 
 // Generates a lookup table for the checksums of all 8-bit values.

--- a/src/therion-core/thexpshp.cxx
+++ b/src/therion-core/thexpshp.cxx
@@ -65,7 +65,7 @@ bool thexpshpf::open()
   fp = this->m_xshp->m_dirname;
   fp += "/";
   fp += this->m_fnm;
-  this->m_fpath = thdb.strstore(fp);
+  this->m_fpath = thdb.strstore(fp.c_str());
 
   this->m_hndl = SHPCreate(this->m_fpath, this->m_type);
   if (this->m_hndl == NULL)

--- a/src/therion-core/thexpshp.cxx
+++ b/src/therion-core/thexpshp.cxx
@@ -61,7 +61,7 @@ bool thexpshpf::open()
 
   // set file path
   this->m_is_open = false;
-  thbuffer fp;
+  std::string fp;
   fp = this->m_xshp->m_dirname;
   fp += "/";
   fp += this->m_fnm;
@@ -372,9 +372,6 @@ void thexpshpf::polygon_close_ring()
 
 void thexpshp::xscrap2d(thscrap * scrap, thdb2dxm * xmap, thdb2dxs * /*xbasic*/) // TODO unused parameter xbasic
 {
-	
-	thbuffer stnbuff;
-
   // export scrap outline
   this->m_fscrap.object_clear();
   thscraplo * lo = scrap->get_outline(), * lo2;

--- a/src/therion-core/thexpuni.cxx
+++ b/src/therion-core/thexpuni.cxx
@@ -351,9 +351,6 @@ void thexpuni::polygon_close_ring()
 
 void thexpuni::parse_scrap(thscrap * scrap)
 {
-	
-	thbuffer stnbuff;
-
   // export scrap outline
   this->clear();
   thscraplo * lo = scrap->get_outline(), * lo2;

--- a/src/therion-core/thgrade.cxx
+++ b/src/therion-core/thgrade.cxx
@@ -205,7 +205,7 @@ void thgrade::self_print_library(std::ostream& out) {
   fmt::print(out, "\toname = \"{}\";\n", this->get_name());
   fmt::print(out, "\tpgrade->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,0,0);\n");
   thdecode_c(&(this->db->buff_enc), this->get_title());
-  fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.c_str());
   fmt::print(out, "\tpgrade->set(thcmd_option_desc(TT_DATAOBJECT_TITLE,1),oname,TT_UTF_8,0);\n");
   fmt::print(out, "\tpgrade->dls_length = {};\n", thprintinfnan(this->dls_length));
   fmt::print(out, "\tpgrade->dls_bearing = {};\n", thprintinfnan(this->dls_bearing));

--- a/src/therion-core/thimport.cxx
+++ b/src/therion-core/thimport.cxx
@@ -392,7 +392,7 @@ const char * thimport::station_name(const char * sn, const char separator, struc
       }
       break;      
     default:
-      l = (long)strlen(bx);
+      l = (long)strlen(bx.c_str());
       rv = buff;
       for(i = 0; i < l; i++) {
         if ((buff[i] == separator) && ((i + 1) < l)) {

--- a/src/therion-core/thimport.cxx
+++ b/src/therion-core/thimport.cxx
@@ -279,7 +279,7 @@ const char * thimport::station_name(const char * sn, const char separator, struc
   static thsurvey * prevpsurvey;
   long i, l;
   bx = sn;
-  char * buff = bx.get_buffer(), * rv;
+  const char * buff = bx.c_str(), * rv;
     
   switch (this->format) {
     case TT_IMPORT_FMT_3D:
@@ -359,13 +359,13 @@ const char * thimport::station_name(const char * sn, const char separator, struc
               nsurvey = this->db->get_survey_noexc(cbf[active_survey], csurvey);
             }
             if (nsurvey != NULL) {
-              if (strlen(prevsurvey.get_buffer()) == 0) {
+              if (prevsurvey.empty()) {
                 prevsurvey = cbf[active_survey];
               } else {
-                bx = prevsurvey.get_buffer();
+                bx = prevsurvey.c_str();
                 prevsurvey = cbf[active_survey];
                 prevsurvey += ".";
-                prevsurvey += bx.get_buffer();
+                prevsurvey += bx.c_str();
               }
               csurvey = nsurvey;
               prevpsurvey = csurvey;
@@ -383,12 +383,12 @@ const char * thimport::station_name(const char * sn, const char separator, struc
           bx += cbf[i];
         }
         sst->survey = prevpsurvey;
-        sst->name = bx.get_buffer();
-        if (strlen(prevsurvey.get_buffer()) > 0) {
+        sst->name = bx.c_str();
+        if (!prevsurvey.empty()) {
           bx += "@";
           bx += prevsurvey;
         }
-        return bx.get_buffer();
+        return bx.c_str();
       }
       break;      
     default:
@@ -600,7 +600,7 @@ void thimport::import_file_img()
           args[1] = xb.data();
           args[2] = yb.data();
           args[3] = zb.data();
-          args[0] = n1.get_buffer();
+          args[0] = n1.data();
           tmpdata->cs = this->cs;
           // only fix the first station, use equate for the others
           if (svxpos2ths[tmppos].size() == 1 || this->fsptr == nullptr) {
@@ -610,13 +610,13 @@ void thimport::import_file_img()
           }
           // ak bude entrance, vlozi aj station
           if ((pimg->flags & img_SFLAG_ENTRANCE) != 0) {
-            args[0] = n2.get_buffer();
+            args[0] = n2.data();
 	    args[1] = strcpy(a1, "");
             args[2] = strcpy(a2, "entrance");
             tmpdata->set_data_station(3, args, TT_UTF_8);
           }
           if ((pimg->flags & img_SFLAG_FIXED) == 0) {
-            args[0] = n2.get_buffer();
+            args[0] = n2.data();
             args[1] = strcpy(a1, "");
             args[2] = strcpy(a2, "not");
             args[3] = strcpy(a3, "fixed");

--- a/src/therion-core/thinit.cxx
+++ b/src/therion-core/thinit.cxx
@@ -184,17 +184,17 @@ static const thstok thtt_loopc[] = {
 
 
 #ifdef THWIN32
-thbuffer short_path_buffer;
 void thinit__make_short_path(thbuffer * bf) {
-  DWORD rv;
-  size_t sl;
-  sl = strlen(bf->get_buffer());
-  if (sl == 0)
+  if (bf->empty())
     return;
-  short_path_buffer.guarantee(2 * sl);
-  rv = GetShortPathName(bf->get_buffer(), short_path_buffer.get_buffer(), (DWORD) short_path_buffer.size);
-  if ((rv > 0) && (rv < (DWORD) short_path_buffer.size)) {
-    bf->strcpy(short_path_buffer.get_buffer());
+  DWORD short_buf_size = GetShortPathName(bf->c_str(), nullptr, 0);
+  if (short_buf_size > 0) {
+    auto short_buf = std::string(short_buf_size, '\0');
+    DWORD rv = GetShortPathName(bf->c_str(), short_buf.data(), short_buf_size);
+    if (rv != 0) {
+      thassert(rv < short_buf_size);
+      bf->assign(short_buf.c_str());
+    }
   }
 }
 #endif
@@ -220,10 +220,10 @@ void thinit::copy_fonts() {
 
 #ifdef THWIN32
   FILE * f = fopen(thtmp.get_file_name("pltotf.bat"),"w");
-  fprintf(f,"@\"%s\\bin\\windows\\pltotf.exe\" %%1 %%2\n",thcfg.install_path.get_buffer());
+  fprintf(f,"@\"%s\\bin\\windows\\pltotf.exe\" %%1 %%2\n",thcfg.install_path.c_str());
   fclose(f);
   f = fopen(thtmp.get_file_name("cfftot1.bat"),"w");
-  fprintf(f,"@\"%s\\bin\\windows\\cfftot1.exe\" %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n",thcfg.install_path.get_buffer());
+  fprintf(f,"@\"%s\\bin\\windows\\cfftot1.exe\" %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n",thcfg.install_path.c_str());
   fclose(f);
 #endif
   thprint("done.\n");
@@ -241,35 +241,35 @@ void thinit::check_font_path(const char * fname, int index) {
 
   static thbuffer pfull, pshort, tmpb;
 
-  pshort.strcpy("");
-  pfull.strcpy("");
+  pshort.assign("");
+  pfull.assign("");
   long i, l;
   tmpb = fname;
-  char * buff = tmpb.get_buffer();
+  char * buff = tmpb.data();
   l = (long) strlen(buff);
   bool search_sn = true;
   if (l == 0) throw thexception("missing font file name");
   for(i = (l-1); i >= 0; i--) {
     if ((buff[i] == '/') || (buff[i] == '\\')) {
       if (search_sn) {
-        pshort.strcpy(&(buff[i+1]));
+        pshort.assign(&(buff[i+1]));
         search_sn = false;
       }
       buff[i] = '/';
     }
   }
   
-  if (strlen(pshort.get_buffer()) == 0) throw thexception(fmt::format("invalid font name -- {}", fname));
+  if (pshort.empty()) throw thexception(fmt::format("invalid font name -- {}", fname));
 
   if ( 
 #ifdef THWIN32
       ((l > 1) && (buff[1] == ':')) ||
 #endif
       buff[0] == '/') {
-    pfull.strcpy(buff);
+    pfull.assign(buff);
   } else {
     if (strlen(this->ini_file.get_cif_path()) > 0) {
-      pfull.strcpy(this->ini_file.get_cif_path());
+      pfull.assign(this->ini_file.get_cif_path());
       pfull += "/";
     } else {
       pfull = "";
@@ -280,9 +280,9 @@ void thinit::check_font_path(const char * fname, int index) {
   // checkne ci TTF
   if ((l > 3) && icase_equals(&(buff[l-4]), ".ttf")) ENC_NEW.t1_convert = 0;
 
-  font_src[index] = pfull.get_buffer();
-  font_dst[index] = pshort.get_buffer();
-  ENC_NEW.otf_file[index] = pshort.get_buffer();
+  font_src[index] = pfull.c_str();
+  font_dst[index] = pshort.c_str();
+  ENC_NEW.otf_file[index] = pshort.c_str();
 
 }
 
@@ -317,7 +317,7 @@ void thinit::load()
     if (RegOpenKey(HKEY_CURRENT_USER,"survex.source\\shell\\Process\\command",&key) != ERROR_SUCCESS)
       loaded_ok = false;
   }
-  if (!loaded_ok || (RegQueryValueEx(key,NULL,NULL,&type,(BYTE *)this->path_cavern.get_buffer(),&length) != ERROR_SUCCESS)) {
+  if (!loaded_ok || (RegQueryValueEx(key,NULL,NULL,&type,(BYTE *)this->path_cavern.data(),&length) != ERROR_SUCCESS)) {
     loaded_ok = false;
   RegCloseKey(key);
   }
@@ -326,15 +326,15 @@ void thinit::load()
   if (type != REG_SZ)
     loaded_ok = false;
   if (loaded_ok) {
-    thsplit_args(&mbf,this->path_cavern.get_buffer());
+    thsplit_args(&mbf,this->path_cavern.c_str());
     this->path_cavern = *(mbf.get_buffer());
     // VG 120416: Replace "aven.exe" with "cavern.exe". New Survex versions write up aven, but therion needs cavern
     // See http://mailman.speleo.sk/pipermail/therion/2015-September/006072.html
-    int pathlen = strlen(this->path_cavern.get_buffer());
+    int pathlen = strlen(this->path_cavern.c_str());
     int suflen = strlen("aven.exe");
-    if ((pathlen > suflen) && (strncmp(this->path_cavern.get_buffer() + pathlen - suflen, "aven.exe", suflen ) == 0)) {
-      this->path_cavern.get_buffer()[pathlen - strlen("aven.exe")] = 0;
-      this->path_cavern.strcat("cavern.exe");
+    if ((pathlen > suflen) && (strncmp(this->path_cavern.c_str() + pathlen - suflen, "aven.exe", suflen ) == 0)) {
+      this->path_cavern.data()[pathlen - strlen("aven.exe")] = 0;
+      this->path_cavern.append("cavern.exe");
     }
   } else {
     this->path_cavern = "cavern";
@@ -350,7 +350,7 @@ void thinit::load()
 #ifdef THDEBUG
 	  thprint("testing cavern\n");
 #endif
-	  if (system(svxcom.get_buffer()) == EXIT_SUCCESS) {
+	  if (system(svxcom.c_str()) == EXIT_SUCCESS) {
 			this->loopc = THINIT_LOOPC_SURVEX;
 		} else {
 			this->loopc = THINIT_LOOPC_THERION;
@@ -360,9 +360,9 @@ void thinit::load()
 //  this->path_3dtopos = "3dtopos";
 #ifdef THWIN32
   if (thcfg.install_tex) {
-    this->path_mpost = thcfg.install_path.get_buffer();
-    this->path_pdftex = thcfg.install_path.get_buffer();
-    this->path_otftotfm = thcfg.install_path.get_buffer();
+    this->path_mpost = thcfg.install_path.c_str();
+    this->path_pdftex = thcfg.install_path.c_str();
+    this->path_otftotfm = thcfg.install_path.c_str();
     this->path_mpost += "\\bin\\windows\\mpost.exe";
     this->path_pdftex += "\\bin\\windows\\pdftex.exe";
     this->path_otftotfm += "\\bin\\windows\\otftotfm.exe";
@@ -377,9 +377,9 @@ void thinit::load()
 
 #ifdef THWIN32
   if (thcfg.install_im) {
-    this->path_convert = thcfg.install_path.get_buffer();
+    this->path_convert = thcfg.install_path.c_str();
     this->path_convert += "\\bin\\convert.exe";
-    this->path_identify = thcfg.install_path.get_buffer();
+    this->path_identify = thcfg.install_path.c_str();
     this->path_identify += "\\bin\\identify.exe";
   } else {
 #endif  
@@ -482,23 +482,23 @@ void thinit::load()
         case TTIC_PATH_CAVERN:
           if (strlen(args[1]) < 1)
             throw thexception("invalid path");
-          this->path_cavern.strcpy(args[1]);
+          this->path_cavern.assign(args[1]);
           break;
           
         case TTIC_PATH_CONVERT:
           if (strlen(args[1]) < 1)
             throw thexception("invalid path");
-          this->path_convert.strcpy(args[1]);
+          this->path_convert.assign(args[1]);
           break;
           
         case TTIC_PATH_IDENTIFY:
           if (strlen(args[1]) < 1)
             throw thexception("invalid path");
-          this->path_identify.strcpy(args[1]);
+          this->path_identify.assign(args[1]);
           break;
 
         case TTIC_TMP_PATH:
-          this->tmp_path.strcpy(args[1]);
+          this->tmp_path.assign(args[1]);
           break;
 
         case TTIC_LANG:
@@ -537,23 +537,23 @@ void thinit::load()
             break;
 
         case TTIC_TMP_REMOVE_SCRIPT:
-          this->tmp_remove_script.strcpy(args[1]);
+          this->tmp_remove_script.assign(args[1]);
           break;
 
         case TTIC_PATH_MPOST:
           if (strlen(args[1]) < 1)
             throw thexception("invalid path");
-          this->path_mpost.strcpy(args[1]);
+          this->path_mpost.assign(args[1]);
           break;
 
         case TTIC_OPT_MPOST:
-          this->opt_mpost.strcpy(args[1]);
+          this->opt_mpost.assign(args[1]);
           break;
 
         case TTIC_PATH_PDFTEX:
           if (strlen(args[1]) < 1)
             throw thexception("invalid path");
-          this->path_pdftex.strcpy(args[1]);
+          this->path_pdftex.assign(args[1]);
           break;
           
         case TTIC_PATH_SOURCE:
@@ -691,7 +691,7 @@ void thinit::load()
       com += "\"";
     //  com += " --interaction nonstopmode data.tex";
       com += " --no-mktex=tfm fonttest.tex";
-      retcode = system(com.get_buffer());
+      retcode = system(com.c_str());
       thprint(fmt::format("checking optional fonts {} {} {} {} {} ...", J->rm, J->it, J->bf, J->ss, J->si));
       if (retcode != EXIT_SUCCESS) {
         thprint(" NOT INSTALLED\n");
@@ -715,52 +715,52 @@ void thinit::load()
 }
 
 
-char * thinit::get_path_cavern()
+const char * thinit::get_path_cavern()
 {
-  return this->path_cavern.get_buffer();
+  return this->path_cavern.c_str();
 }
 
 
-char * thinit::get_path_convert()
+const char * thinit::get_path_convert()
 {
-  return this->path_convert.get_buffer();
+  return this->path_convert.c_str();
 }
 
 
-char * thinit::get_path_identify()
+const char * thinit::get_path_identify()
 {
-  return this->path_identify.get_buffer();
+  return this->path_identify.c_str();
 }
 
-//char * thinit::get_path_3dtopos()
+//const char * thinit::get_path_3dtopos()
 //{
-//  return this->path_3dtopos.get_buffer();
+//  return this->path_3dtopos.c_str();
 //}
 
-char * thinit::get_path_mpost()
+const char * thinit::get_path_mpost()
 {
-  return this->path_mpost.get_buffer();
+  return this->path_mpost.c_str();
 }
 
-char * thinit::get_opt_mpost()
+const char * thinit::get_opt_mpost()
 {
-  return this->opt_mpost.get_buffer();
+  return this->opt_mpost.c_str();
 }
 
-char * thinit::get_path_pdftex()
+const char * thinit::get_path_pdftex()
 {
-  return this->path_pdftex.get_buffer();
+  return this->path_pdftex.c_str();
 }
 
-char * thinit::get_path_otftotfm()
+const char * thinit::get_path_otftotfm()
 {
-  return this->path_otftotfm.get_buffer();
+  return this->path_otftotfm.c_str();
 }
 
 void thinit::set_proj_lib_path([[maybe_unused]] bool use_env) {  // set PROJ library resources path; we need use_env for testing different versions of Proj
 #ifdef THWIN32
   if (!use_env || (std::getenv("PROJ_LIB") == nullptr && std::getenv("PROJ_DATA") == nullptr)) {
-    const auto path = fmt::format("{:s}\\lib\\proj-{:d}", thcfg.install_path.get_buffer(), PROJ_VER);
+    const auto path = fmt::format("{:s}\\lib\\proj-{:d}", thcfg.install_path.c_str(), PROJ_VER);
     // Proj's method to get user-writable directory (filemanager.cpp)
     std::string local_path;
     const char *local_app_data = std::getenv("LOCALAPPDATA");

--- a/src/therion-core/thinit.h
+++ b/src/therion-core/thinit.h
@@ -101,38 +101,38 @@ class thinit {
    * Return cavern executable path.
    */
    
-  char * get_path_cavern();
+  const char * get_path_cavern();
 
   /**
    * Return ImageMagick convert executable path.
    */
    
-  char * get_path_convert();
+  const char * get_path_convert();
 
   /**
    * Return ImageMagick identify executable path.
    */
-  char * get_path_identify();
+  const char * get_path_identify();
 
   /**
    * Return metapost options.
    */
 
-  char * get_opt_mpost();
+  const char * get_opt_mpost();
   
   
   /**
    * Return metapost executable path.
    */
    
-  char * get_path_mpost();
-  char * get_path_otftotfm();
+  const char * get_path_mpost();
+  const char * get_path_otftotfm();
 
   /**
    * Return pdftex executable path.
    */
    
-  char * get_path_pdftex();
+  const char * get_path_pdftex();
 
   int get_lang();
 

--- a/src/therion-core/thinput.cxx
+++ b/src/therion-core/thinput.cxx
@@ -126,7 +126,7 @@ void ifile::close()
 bool ifile::is_equal(ifile* f)
 {
   try {
-    return fs::equivalent(name.get_buffer(), f->name.get_buffer());
+    return fs::equivalent(name.c_str(), f->name.c_str());
   } catch(const std::exception& e) {
     thwarning(fmt::format("unable to compare files -- {}", e.what()))
     return false;
@@ -211,7 +211,7 @@ void thinput::set_file_name(const char * fname)
 }
 
 
-char * thinput::get_file_name()
+const char * thinput::get_file_name()
 {
   return this->file_name;
 }
@@ -234,7 +234,7 @@ void thinput::set_file_suffix(const char * fsx)
 }
 
 
-void thinput::open_file(char * fname)
+void thinput::open_file(const char * fname)
 {
   char * srcfile = nullptr;
   if (this->last_ptr->sh.is_open())
@@ -269,8 +269,8 @@ void thinput::open_file(char * fname)
   while ((!ifptr->sh.is_open()) && (ix < paths)) {
 
     // let's try the name without suffixes
-    ifptr_psz = strlen(ifptr->path.get_buffer());
-    ifptr_plc = (ifptr_psz > 0 ? ifptr->path.get_buffer()[ifptr_psz-1] : 0);
+    ifptr_psz = strlen(ifptr->path.c_str());
+    ifptr_plc = (ifptr_psz > 0 ? ifptr->path.c_str()[ifptr_psz-1] : 0);
     if (ifptr_psz > 0) {
       ifptr->name = ifptr->path;
       if (ifptr_plc != '/')
@@ -343,7 +343,7 @@ void thinput::open_file(char * fname)
       this->last_ptr = ifptr;
       if (this->pifo) {
         if (this->pifoproc != nullptr)
-          this->pifoproc(ifptr->name.get_buffer());
+          this->pifoproc(ifptr->name.data());
         if (this->pifoid != nullptr)
           *(this->pifoid) = true;
         this->pifo = false;
@@ -351,7 +351,7 @@ void thinput::open_file(char * fname)
         this->pifoproc = nullptr;
       }
 #ifdef THDEBUG
-      thprint(fmt::format("open file -- {}\n", this->last_ptr->name.get_buffer()));
+      thprint(fmt::format("open file -- {}\n", this->last_ptr->name.c_str()));
 #endif
     }
   }
@@ -363,7 +363,7 @@ void thinput::close_file()
 {
   if (this->last_ptr->sh.is_open()) {
 #ifdef THDEBUG
-    thprint(fmt::format("close file -- {}\n", this->last_ptr->name.get_buffer()));
+    thprint(fmt::format("close file -- {}\n", this->last_ptr->name.c_str()));
 #endif
     this->last_ptr->close();
     if (this->last_ptr->prev_ptr != nullptr) {
@@ -436,19 +436,19 @@ char * thinput::read_line()
     // join backslash ended lines together
     if (*idxptr == '\\') {
       if (mline) {
-        this->linebf.strncat(this->lnbuffer.get(), lnlen - 1);
+        this->linebf.append(this->lnbuffer.get(), lnlen - 1);
       }
       else {
-        this->linebf.strncpy(this->lnbuffer.get(), lnlen - 1);
+        this->linebf.assign(this->lnbuffer.get(), lnlen - 1);
         mline = true;
       }
       continue;
     }
     else {
       if (mline)
-        this->linebf.strncat(this->lnbuffer.get(), lnlen);
+        this->linebf.append(this->lnbuffer.get(), lnlen);
       else
-        this->linebf.strncpy(this->lnbuffer.get(), lnlen);
+        this->linebf.assign(this->lnbuffer.get(), lnlen);
     }
     
     mline = false;
@@ -456,22 +456,22 @@ char * thinput::read_line()
     // we've something regular in the linebf
     // split into cmd & value & interpret commands 
     if (this->cmd_sensitivity) {
-      thsplit_word(&this->cmdbf, &this->valuebf, this->linebf.get_buffer());
-      thsplit_args(&this->tmpmb, this->valuebf.get_buffer());
+      thsplit_word(&this->cmdbf, &this->valuebf, this->linebf.c_str());
+      thsplit_args(&this->tmpmb, this->valuebf.c_str());
       
       // check if comment
-      if (*(this->cmdbf.get_buffer()) == '#')
+      if (*(this->cmdbf.c_str()) == '#')
         continue;
         
       // interpret commands
-      switch (thmatch_token(this->cmdbf.get_buffer(), thtt_input)) {
+      switch (thmatch_token(this->cmdbf.c_str(), thtt_input)) {
       
         case TT_INPUT:
           if (this->input_sensitivity) {
             if (this->tmpmb.get_size() != 1)
               therror(fmt::format("{} [{}] -- one input file name expected -- {}", \
                 this->get_cif_name(), this->get_cif_line_number(), \
-                this->valuebf.get_buffer()))
+                this->valuebf.c_str()))
             else
               this->open_file(*(this->tmpmb.get_buffer()));
           }
@@ -481,13 +481,13 @@ char * thinput::read_line()
           if (this->tmpmb.get_size() != 1)
             therror(fmt::format("{} [{}] -- encoding name expected -- {}", \
               this->get_cif_name(), this->get_cif_line_number(), \
-              this->valuebf.get_buffer()));
+              this->valuebf.c_str()));
           this->last_ptr->encoding = \
             thmatch_token(*(this->tmpmb.get_buffer()), thtt_encoding);
           if (this->last_ptr->encoding == TT_UNKNOWN_ENCODING) {
             therror(fmt::format("{} [{}] -- unknown encoding -- {}", \
               this->get_cif_name(), this->get_cif_line_number(), \
-              this->valuebf.get_buffer()));
+              this->valuebf.c_str()));
             this->last_ptr->encoding = TT_UTF_8;
           }
           continue;
@@ -507,7 +507,7 @@ char * thinput::read_line()
     }
     // otherwise check if comment
     else {
-      idxptr = this->linebf.get_buffer();
+      idxptr = this->linebf.data();
       lnlen = (long)strlen(idxptr);
       while ((lnlen > 0) && (*idxptr < 33)) {
         lnlen--;
@@ -523,40 +523,40 @@ char * thinput::read_line()
   }
   
   if (ln_state == 1)
-    return this->linebf.get_buffer();
+    return this->linebf.data();
   else
     return nullptr;
 }
 
 
-char * thinput::get_cmd()
+const char * thinput::get_cmd()
 {
-  return this->cmdbf.get_buffer();
+  return this->cmdbf.c_str();
 }
 
-char * thinput::get_line()
+const char * thinput::get_line()
 {
-  return this->linebf.get_buffer();
-}
-
-
-char * thinput::get_value()
-{
-  return this->valuebf.get_buffer();
-}
-
-char * thinput::get_cif_name()
-{
-  return this->last_ptr->name.get_buffer();
+  return this->linebf.c_str();
 }
 
 
+const char * thinput::get_value()
+{
+  return this->valuebf.c_str();
+}
 
-char * thinput::get_cif_path()
+const char * thinput::get_cif_name()
+{
+  return this->last_ptr->name.c_str();
+}
+
+
+
+const char * thinput::get_cif_path()
 {
   static thbuffer cifpath;
-  thsplit_fpath(&cifpath, this->last_ptr->name.get_buffer());
-  return cifpath.get_buffer();
+  thsplit_fpath(&cifpath, this->last_ptr->name.c_str());
+  return cifpath.c_str();
 }
 
 std::string thinput::get_cif_abspath(const char * fname_ptr)
@@ -569,7 +569,7 @@ std::string thinput::get_cif_abspath(const char * fname_ptr)
   auto pict_path = std::filesystem::current_path(ec);
   thassert(!ec);
 
-  const auto& last_name = this->last_ptr->name.get_buffer();
+  const auto& last_name = this->last_ptr->name.c_str();
   if (fs::path(last_name).is_absolute())
     pict_path = last_name;
   else 

--- a/src/therion-core/thinput.cxx
+++ b/src/therion-core/thinput.cxx
@@ -213,7 +213,7 @@ void thinput::set_file_name(const char * fname)
 
 const char * thinput::get_file_name()
 {
-  return this->file_name;
+  return this->file_name.c_str();
 }
 
 
@@ -236,9 +236,9 @@ void thinput::set_file_suffix(const char * fsx)
 
 void thinput::open_file(const char * fname)
 {
-  char * srcfile = nullptr;
+  const char * srcfile = nullptr;
   if (this->last_ptr->sh.is_open())
-    srcfile = this->last_ptr->name;
+    srcfile = this->last_ptr->name.c_str();
   
   // as first, let's find appropriate ifile
   ifile * ifptr;
@@ -280,7 +280,7 @@ void thinput::open_file(const char * fname)
     else
       ifptr->name = fname;
     ifptr->sh.clear();
-    ifptr->sh.open(ifptr->name); //, ios::in | ios::nocreate
+    ifptr->sh.open(ifptr->name.c_str()); //, ios::in | ios::nocreate
     
     // if not successful, try with suffixes
     sfxid = 0;
@@ -295,7 +295,7 @@ void thinput::open_file(const char * fname)
         ifptr->name = fname;
       ifptr->name += sfx[sfxid];
       ifptr->sh.clear();
-      ifptr->sh.open(ifptr->name); //, ios::in | ios::nocreate
+      ifptr->sh.open(ifptr->name.c_str()); //, ios::in | ios::nocreate
       sfxid++;
     }
     
@@ -385,7 +385,7 @@ void thinput::reset()
   
   // set pointer to the first ifile
   this->last_ptr = this->first_ptr.get();
-  this->open_file(this->file_name);  
+  this->open_file(this->file_name.c_str());  
 }
 
 

--- a/src/therion-core/thinput.h
+++ b/src/therion-core/thinput.h
@@ -67,7 +67,7 @@ private:
   ifile * last_ptr;  ///< Pointer to the last file.
 
 private:
-  void open_file(char * fname);
+  void open_file(const char * fname);
   void close_file();
   
 public:
@@ -134,7 +134,7 @@ public:
   /**
    * Retrieve main input file name.
    */
-  char * get_file_name();
+  const char * get_file_name();
   
   /**
    * Set search path.
@@ -176,29 +176,29 @@ public:
 	 *
 	 * Applicable only in when cmd_sensitivity is on.
 	 */
-	char * get_cmd();
+	const char * get_cmd();
 	
 	/**
 	 * Return line string.
    */
-	char * get_line();
+	const char * get_line();
 	
 	/**
 	 * Return value string.
 	 *
 	 * Applicable only in when cmd_sensitivity is on.
 	 */
-  char * get_value();
+  const char * get_value();
 
   /**
    * Return full current input file name.
    */  
-  char * get_cif_name();
+  const char * get_cif_name();
 
   /**
    * Return current input file path.
    */  
-  char * get_cif_path();
+  const char * get_cif_path();
   
   /**
    * Return current absolute input file path.

--- a/src/therion-core/thlayout.cxx
+++ b/src/therion-core/thlayout.cxx
@@ -458,7 +458,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
             throw thexception(fmt::format("unknown option -- {}", *args));
           }
           thencode(&(this->db->buff_enc), *args, argenc);
-          last_line->line = this->db->strstore(this->db->buff_enc.get_buffer());
+          last_line->line = this->db->strstore(this->db->buff_enc.c_str());
           last_line->code = this->ccode;
           last_line->path = this->db->strstore((this->m_pconfig == NULL) ? "" : this->m_pconfig->cfg_file.get_cif_abspath().c_str(), true);
           break;
@@ -467,7 +467,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
             if (!th_is_keyword(*args))
               throw thexception(fmt::format("invalid keyword -- {}", args[0]));
             thencode(&(this->db->buff_enc), *args, argenc);
-            last_line->line = this->db->strstore(this->db->buff_enc.get_buffer());
+            last_line->line = this->db->strstore(this->db->buff_enc.c_str());
           }
           last_line->code = TT_LAYOUT_CODE_SYMBOL_DEFAULTS;
           break;
@@ -480,7 +480,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
           if (!th_is_keyword(args[2]))
             throw thexception(fmt::format("invalid keyword -- {}", args[2]));
           thencode(&(this->db->buff_enc), args[2], argenc);
-          last_line->line = this->db->strstore(this->db->buff_enc.get_buffer());
+          last_line->line = this->db->strstore(this->db->buff_enc.c_str());
           last_line->code = TT_LAYOUT_CODE_SYMBOL_ASSIGN;
           break;
 //        case TT_LAYOUT_MAP_ITEM:
@@ -490,7 +490,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 //          if (!th_is_keyword(args[1]))
 //            ththrow("invalid keyword -- %s", args[1]);
 //          thencode(&(this->db->buff_enc), args[1], argenc);
-//          this->last_line->line = this->db->strstore(this->db->buff_enc.get_buffer());
+//          this->last_line->line = this->db->strstore(this->db->buff_enc.c_str());
 //          this->last_line->code = TT_LAYOUT_CODE_MAP_ITEM;
 //          break;
         case TT_LAYOUT_SYMBOL_HIDE:
@@ -1016,7 +1016,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
     case TT_LAYOUT_DOC_TITLE:
       if (strlen(args[0]) > 0) {
         thencode(&(this->db->buff_enc), args[0], argenc);
-        this->doc_title = this->db->strstore(this->db->buff_enc.get_buffer());
+        this->doc_title = this->db->strstore(this->db->buff_enc.c_str());
       } else
         this->doc_title = "";
       this->def_doc_title = 2;  
@@ -1025,7 +1025,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
     case TT_LAYOUT_DOC_COMMENT:
       if (strlen(args[0]) > 0) {
         thencode(&(this->db->buff_enc), args[0], argenc);
-        this->doc_comment = this->db->strstore(this->db->buff_enc.get_buffer());
+        this->doc_comment = this->db->strstore(this->db->buff_enc.c_str());
       } else
         this->doc_comment = "";
       this->def_doc_comment = 2;  
@@ -1034,7 +1034,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
     case TT_LAYOUT_DOC_AUTHOR:
       if (strlen(args[0]) > 0) {
         thencode(&(this->db->buff_enc), args[0], argenc);
-        this->doc_author = this->db->strstore(this->db->buff_enc.get_buffer());
+        this->doc_author = this->db->strstore(this->db->buff_enc.c_str());
       } else
         this->doc_author = "";
       this->def_doc_author = 2;  
@@ -1043,7 +1043,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
     case TT_LAYOUT_DOC_SUBJECT:
       if (strlen(args[0]) > 0) {
         thencode(&(this->db->buff_enc), args[0], argenc);
-        this->doc_subject = this->db->strstore(this->db->buff_enc.get_buffer());
+        this->doc_subject = this->db->strstore(this->db->buff_enc.c_str());
       } else
         this->doc_subject = "";
       this->def_doc_subject = 2;  
@@ -1052,7 +1052,7 @@ void thlayout::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
     case TT_LAYOUT_DOC_KEYWORDS:
       if (strlen(args[0]) > 0) {
         thencode(&(this->db->buff_enc), args[0], argenc);
-        this->doc_keywords = this->db->strstore(this->db->buff_enc.get_buffer());
+        this->doc_keywords = this->db->strstore(this->db->buff_enc.c_str());
       } else
         this->doc_keywords = "";
       this->def_doc_keywords = 2;  
@@ -1153,7 +1153,7 @@ void thlayout::self_print_library(std::ostream& out) {
   fmt::print(out, "\tplayout->set(thcmd_option_desc(TT_DATAOBJECT_NAME,1),oname,TT_UTF_8,0);\n");
   // decode title
   thdecode_c(&(this->db->buff_enc), this->get_title());
-  fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.c_str());
   fmt::print(out, "\tplayout->set(thcmd_option_desc(TT_DATAOBJECT_TITLE,1),oname,TT_UTF_8,0);\n");
 
 
@@ -1315,29 +1315,29 @@ void thlayout::self_print_library(std::ostream& out) {
 
   fmt::print(out, "\tplayout->def_origin_label = {};\n", this->def_origin_label);
   thdecode_c(&(this->db->buff_enc), this->olx);
-  fmt::print(out, "\tplayout->olx = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->olx = \"{}\";\n", this->db->buff_enc.c_str());
   thdecode_c(&(this->db->buff_enc), this->oly);
-  fmt::print(out, "\tplayout->oly = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->oly = \"{}\";\n", this->db->buff_enc.c_str());
 
   fmt::print(out, "\tplayout->def_doc_title = {};\n", this->def_doc_title);
   thdecode_c(&(this->db->buff_enc), this->doc_title);
-  fmt::print(out, "\tplayout->doc_title = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->doc_title = \"{}\";\n", this->db->buff_enc.c_str());
   
   fmt::print(out, "\tplayout->def_doc_comment = {};\n", this->def_doc_comment);
   thdecode_c(&(this->db->buff_enc), this->doc_comment);
-  fmt::print(out, "\tplayout->doc_comment = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->doc_comment = \"{}\";\n", this->db->buff_enc.c_str());
   
   fmt::print(out, "\tplayout->def_doc_author = {};\n", this->def_doc_author);
   thdecode_c(&(this->db->buff_enc), this->doc_author);
-  fmt::print(out, "\tplayout->doc_author = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->doc_author = \"{}\";\n", this->db->buff_enc.c_str());
 
   fmt::print(out, "\tplayout->def_doc_subject = {};\n", this->def_doc_author);
   thdecode_c(&(this->db->buff_enc), this->doc_subject);
-  fmt::print(out, "\tplayout->doc_subject = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->doc_subject = \"{}\";\n", this->db->buff_enc.c_str());
   
   fmt::print(out, "\tplayout->def_doc_keywords = {};\n", this->def_doc_keywords);
   thdecode_c(&(this->db->buff_enc), this->doc_keywords);
-  fmt::print(out, "\tplayout->doc_keywords = \"{}\";\n", this->db->buff_enc.get_buffer());
+  fmt::print(out, "\tplayout->doc_keywords = \"{}\";\n", this->db->buff_enc.c_str());
   
   fmt::print(out, "\tplayout->def_excl_pages = {};\n", this->def_excl_pages);
   fmt::print(out, "\tplayout->excl_pages = {};\n",(this->excl_pages ? "true" : "false"));
@@ -1345,7 +1345,7 @@ void thlayout::self_print_library(std::ostream& out) {
     fmt::print(out, "\tplayout->excl_list = NULL;\n");
   } else {
     thdecode_c(&(this->db->buff_enc), this->excl_list);
-    fmt::print(out, "\tplayout->excl_list = \"{}\";\n", this->db->buff_enc.get_buffer());
+    fmt::print(out, "\tplayout->excl_list = \"{}\";\n", this->db->buff_enc.c_str());
   }
 
   fmt::print(out, "\tplayout->def_font_setup = {};\n", this->def_font_setup);
@@ -1417,7 +1417,7 @@ void thlayout::self_print_library(std::ostream& out) {
           }
           fmt::print(out, ";\n");
         }
-        fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.get_buffer());
+        fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.c_str());
         fmt::print(out, "\tplayout->set(thcmd_option_desc(0,1),oname,TT_UTF_8,0);\n");
         break;
       case TT_LAYOUT_CODE_SYMBOL_ASSIGN:
@@ -1428,7 +1428,7 @@ void thlayout::self_print_library(std::ostream& out) {
       case TT_LAYOUT_CODE_SYMBOL_COLOR:
         if (ln->line != NULL) {
           thdecode_c(&(this->db->buff_enc), ln->line);
-          fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.get_buffer());
+          fmt::print(out, "\toname = \"{}\";\n", this->db->buff_enc.c_str());
         }
         if (ln->code != TT_LAYOUT_CODE_SYMBOL_DEFAULTS)
           fmt::print(out, "\tplayout->set(thcmd_option_desc(TT_LAYOUT_SYMBOL_DEFAULTS,0),NULL,TT_UTF_8,0);\n");
@@ -1699,7 +1699,7 @@ void thlayout::export_pdftex(FILE * o, thdb2dprj * /*prj*/, char mode) { // TODO
         	fprintf(o, "\\includeprefix={%s}\n", fix_path_slashes(last_path).c_str());
         }
         thdecode_utf2tex(&(this->db->buff_enc), ln->line);
-        fprintf(o, "%s\n", this->db->buff_enc.get_buffer());
+        fprintf(o, "%s\n", this->db->buff_enc.c_str());
       }
   }
   
@@ -1726,7 +1726,7 @@ void thlayout::export_mpost(FILE * o) {
         }
         anyline = true;
         thdecode(&(this->db->buff_enc), TT_ISO8859_2, ln->line);
-        fprintf(o, "%s\n", this->db->buff_enc.get_buffer());
+        fprintf(o, "%s\n", this->db->buff_enc.c_str());
       }
   }
   

--- a/src/therion-core/thline.cxx
+++ b/src/therion-core/thline.cxx
@@ -177,7 +177,7 @@ void thline::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long 
 
     case TT_LINE_TEXT:
       thencode(&(this->db->buff_enc), *args, argenc);
-      this->parse_text(this->db->buff_enc.get_buffer());
+      this->parse_text(this->db->buff_enc.c_str());
       break;
 
     case TT_LINE_SMOOTH:
@@ -269,7 +269,7 @@ void thline::self_print_properties(FILE * outf)
 }
 
 
-void thline::parse_type(char * ss)
+void thline::parse_type(const char * ss)
 {
   this->type = thmatch_token(ss,thtt_line_types);
   switch (this->type) {
@@ -309,7 +309,7 @@ void thline::parse_type(char * ss)
 }
 
 
-void thline::parse_subtype(char * ss)
+void thline::parse_subtype(const char * ss)
 {
 //  int prevcsubtype = this->csubtype;
   if (this->type == TT_LINE_TYPE_U) {
@@ -381,7 +381,7 @@ void thline::parse_subtype(char * ss)
 
 
 
-void thline::insert_line_point(int nargs, char ** args, double * nums)
+void thline::insert_line_point(int nargs, char const * const * args, double * nums)
 {
   // check number of parameters
   if ((nargs != 6) && (nargs != 2))
@@ -389,7 +389,7 @@ void thline::insert_line_point(int nargs, char ** args, double * nums)
 
   double cp1x, cp1y, cp2x, cp2y, x, y;
   int pidx = 0, sv;
-  char * invs = NULL;
+  const char * invs = NULL;
   bool invnum = false;
 
   if (nargs == 6) {
@@ -487,7 +487,7 @@ void thline::insert_line_point(int nargs, char ** args, double * nums)
 }
 
 
-void thline::insert_point_mark(char * ss)
+void thline::insert_point_mark(const char * ss)
 {
   if (!th_is_keyword(ss))
     throw thexception(fmt::format("mark not a key word -- {}",ss));
@@ -1206,7 +1206,7 @@ unsigned thline::export_path_mp(class thexpmapmpxs * out,
 }
 
 
-void thline::parse_border(char * ss) {
+void thline::parse_border(const char * ss) {
   int bd;
   if (this->type != TT_LINE_TYPE_SLOPE)
     throw thexception(fmt::format("-border not valid with type {}", thmatch_string(this->type,thtt_line_types)));
@@ -1240,7 +1240,7 @@ static const thstok thtt_line_gradient[] = {
 };
 
 
-void thline::parse_gradient(char * ss) {
+void thline::parse_gradient(const char * ss) {
   int gd;
   if (this->type != TT_LINE_TYPE_CONTOUR)
     throw thexception(fmt::format("-gradient not valid with type {}", thmatch_string(this->type,thtt_line_types)));
@@ -1268,7 +1268,7 @@ void thline::parse_gradient(char * ss) {
 }
 
 
-void thline::parse_direction(char * ss) {
+void thline::parse_direction(const char * ss) {
   int gd;
   if (this->type != TT_LINE_TYPE_SECTION)
     throw thexception(fmt::format("-direction not valid with type {}", thmatch_string(this->type,thtt_line_types)));
@@ -1305,7 +1305,7 @@ void thline::parse_direction(char * ss) {
 
 
 
-void thline::parse_head(char * ss) {
+void thline::parse_head(const char * ss) {
   int gd;
   if (this->type != TT_LINE_TYPE_ARROW)
     throw thexception(fmt::format("-direction not valid with type {}", thmatch_string(this->type,thtt_line_types)));
@@ -1330,7 +1330,7 @@ void thline::parse_head(char * ss) {
 }
 
 
-void thline::parse_adjust(char * ss) {
+void thline::parse_adjust(const char * ss) {
   if (this->last_point != NULL)
     this->last_point->adjust = thmatch_token(ss,thtt_line_adjusts);
   else
@@ -1343,7 +1343,7 @@ void thline::parse_adjust(char * ss) {
 }
 
 
-void thline::parse_size(int w, char * ss) {
+void thline::parse_size(int w, const char * ss) {
   int sv;
   double sz;
   if (this->last_point == NULL)
@@ -1386,7 +1386,7 @@ void thline::parse_size(int w, char * ss) {
 }
 
 
-void thline::parse_altitude(char * ss) {
+void thline::parse_altitude(const char * ss) {
 
   if (this->type != TT_LINE_TYPE_WALL)
     throw thexception(fmt::format("-altitude not valid with type {}", thmatch_string(this->type,thtt_line_types)));
@@ -1399,7 +1399,7 @@ void thline::parse_altitude(char * ss) {
   this->last_point->tags |= TT_LINEPT_TAG_ALTITUDE;
 }
 
-void thline::parse_text(char * ss) {
+void thline::parse_text(const char * ss) {
   if (this->type != TT_LINE_TYPE_LABEL)
     throw thexception(fmt::format("-text not valid with type {}", thmatch_string(this->type,thtt_line_types)));
   if (strlen(ss) > 0)
@@ -1438,7 +1438,7 @@ void thline::start_insert() {
 
 
 
-void thline::parse_height(char * ss) {
+void thline::parse_height(const char * ss) {
   switch (this->type) {
     case TT_LINE_TYPE_PIT:
       break;

--- a/src/therion-core/thline.h
+++ b/src/therion-core/thline.h
@@ -340,19 +340,19 @@ class thline : public th2ddataobject {
   class thdb2dlp * first_point,  ///< First line point.
     * last_point;  ///< Last line point.
 
-  void parse_type(char * ss);  ///< Parse line type.
-  void parse_subtype(char * ss);  ///< Parse line subtype.
-  void parse_border(char * ss);  ///< Parse line type.
-  void parse_size(int w, char * ss);  ///< Parse line size.
-  void parse_gradient(char * ss);  ///< Parse line subtype.
-  void parse_direction(char * ss);  ///< Parse line direction.
-  void parse_altitude(char * ss);  ///< Parse wall altitude
-  void parse_head(char * ss);  ///< Parse line head.
-  void parse_adjust(char * ss);  ///< Parse line head.
-  void parse_height(char * ss);  ///< Parse pit/chimney height.
-  void parse_text(char * ss);  ///< Parse line text.
-  void insert_line_point(int nargs, char ** args, double * nums = NULL);  ///< Insert line point.
-  void insert_point_mark(char * ss);  ///< Insert line point mark.
+  void parse_type(const char * ss);  ///< Parse line type.
+  void parse_subtype(const char * ss);  ///< Parse line subtype.
+  void parse_border(const char * ss);  ///< Parse line type.
+  void parse_size(int w, const char * ss);  ///< Parse line size.
+  void parse_gradient(const char * ss);  ///< Parse line subtype.
+  void parse_direction(const char * ss);  ///< Parse line direction.
+  void parse_altitude(const char * ss);  ///< Parse wall altitude
+  void parse_head(const char * ss);  ///< Parse line head.
+  void parse_adjust(const char * ss);  ///< Parse line head.
+  void parse_height(const char * ss);  ///< Parse pit/chimney height.
+  void parse_text(const char * ss);  ///< Parse line text.
+  void insert_line_point(int nargs, char const * const * args, double * nums = NULL);  ///< Insert line point.
+  void insert_point_mark(const char * ss);  ///< Insert line point mark.
 
   void preprocess();  ///< Reverse if necessary and close.
 

--- a/src/therion-core/thlogfile.cxx
+++ b/src/therion-core/thlogfile.cxx
@@ -102,7 +102,7 @@ void thlogfile::set_file_name(const char *fname)
 
 const char* thlogfile::get_file_name()
 {
-    return this->file_name;
+    return this->file_name.c_str();
 }
 
 void  thlogfile::set_logging(bool log_io)

--- a/src/therion-core/thlookup.cxx
+++ b/src/therion-core/thlookup.cxx
@@ -111,7 +111,7 @@ void thlookup::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
   const char * lkpindex;
   const char * lkpnname;
   char * tmpa[1];
-  thbuffer tmpb;
+  std::string tmpb;
 
   thcmd_option_desc defcod = this->get_default_cod(cod.id);
   switch (cod.id) {
@@ -228,7 +228,7 @@ void thlookup::postprocess_object_references() {
     thlookup_table_row * tr;
     thlookup_table_list::iterator tli;
     thobjectname on;
-    thbuffer tmp;
+    std::string tmp;
     for(tli = this->m_table.begin(); tli != this->m_table.end(); tli++) {
       tr = &(*tli);
       switch (this->m_type) {
@@ -488,7 +488,7 @@ void thlookup::export_color_legend(thlayout * layout) {
 void thlookup_parse_reference(const char * arg, int * type, const char ** index, const char ** nname) {
   // parse lookup type
   thmbuffer mbf;
-  thbuffer normname;
+  std::string normname;
   thsplit_strings(& mbf, arg, ':');
   if ((mbf.get_size() > 2) || (mbf.get_size() < 1))
     throw thexception(fmt::format("invalid lookup id -- {}", arg));

--- a/src/therion-core/thlookup.cxx
+++ b/src/therion-core/thlookup.cxx
@@ -135,7 +135,7 @@ void thlookup::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
 	case TT_LOOKUP_TITLE:
       if (strlen(args[0]) > 0) {
         thencode(&(this->db->buff_enc), args[0], argenc);
-        this->m_title = this->db->strstore(this->db->buff_enc.get_buffer());
+        this->m_title = this->db->strstore(this->db->buff_enc.c_str());
       } else
         this->m_title = "";
       break;
@@ -146,7 +146,7 @@ void thlookup::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
       if (this->m_type == TT_LAYOUT_CCRIT_UNKNOWN)
         throw thexception(fmt::format("invalid coloring criteria -- {}", args[0]));
       tmpb = lkpnname;
-      tmpa[0] = tmpb.get_buffer();
+      tmpa[0] = tmpb.data();
       args = tmpa;
       [[fallthrough]];
     default:
@@ -237,7 +237,7 @@ void thlookup::postprocess_object_references() {
         case TT_LAYOUT_CCRIT_SURVEY:
           if ((tr->m_ref == NULL) && (strlen(tr->m_valueString) > 0)) {
             tmp = tr->m_valueString;
-            thparse_objectname(on, &(thdb.buff_strings), tmp.get_buffer(), NULL);
+            thparse_objectname(on, &(thdb.buff_strings), tmp.data(), NULL);
             tr->m_ref = thdb.get_object(on, NULL);
             if (tr->m_ref == NULL) {
               thwarning(fmt::format("invalid reference -- {}", tr->m_valueString));
@@ -505,7 +505,7 @@ void thlookup_parse_reference(const char * arg, int * type, const char ** index,
     normname = "";
   normname += "_";
   normname += *index;
-  *nname = thdb.strstore(normname.get_buffer());
+  *nname = thdb.strstore(normname.c_str());
 }
 
 void thlookup::add_auto_item(class thdataobject * o, thlayout_color c) {

--- a/src/therion-core/thmapstat.cxx
+++ b/src/therion-core/thmapstat.cxx
@@ -309,8 +309,8 @@ void thmapstat_print_team(FILE * f, thmapstat_personmap & team_map, const char *
     				b += "<thsp>";
     				b += layout->units.format_i18n_length_units();
     		} else {
-          	  	    std::snprintf(c.get_buffer(),127,"%.0f",pd[i].crit);
-          	  	    b += c.get_buffer();
+          	  	    std::snprintf(c.data(),127,"%.0f",pd[i].crit);
+          	  	    b += c.c_str();
     		}
             b += ")";
           }
@@ -353,8 +353,8 @@ void thmapstat_print_copy(FILE * f, thmapstat_copyrightmap & copy_map, const cha
 			b += pd[i].data.date.get_str(TT_DATE_FMT_UTF8_Y);
 			if (show_lengths) {
 			  b += " (";
-			  std::snprintf(c.get_buffer(),127,"%.0f",pd[i].crit);
-			  b += c.get_buffer();
+			  std::snprintf(c.data(),127,"%.0f",pd[i].crit);
+			  b += c.c_str();
 			  b += ")";
 			}
             if (i < (maxcnt-1))
@@ -473,14 +473,14 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
   ldata->cavelengthtitle = "";
   if (clen > 0) {
     //b = "";  
-    //std::snprintf(b.get_buffer(),255,"%.0f",clen);
+    //std::snprintf(b.data(),255,"%.0f",clen);
 		b = layout->units.format_length(clen);
     b += "<thsp>";
     //b += thT("units m",layout->lang);
     b += layout->units.format_i18n_length_units();
     fprintf(f,"\\cavelengthtitle={%s}\n",utf2tex(thT("title cave length",layout->lang)).c_str());
-    fprintf(f,"\\cavelength={%s}\n",utf2tex(b.get_buffer()).c_str());
-    ldata->cavelength = thutf82xhtml(b.get_buffer());
+    fprintf(f,"\\cavelength={%s}\n",utf2tex(b.c_str()).c_str());
+    ldata->cavelength = thutf82xhtml(b.c_str());
     ldata->cavelengthtitle = thT("title cave length",layout->lang);
   }
   
@@ -489,23 +489,23 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
 
   if (!thisnan(z_top)) {
     //b = "";  
-    //std::snprintf(b.get_buffer(),255,"%.0f",z_top-z_bot);
+    //std::snprintf(b.data(),255,"%.0f",z_top-z_bot);
 	b = layout->units.format_length(z_top - z_bot);
     b += "<thsp>";
     //b += thT("units m",layout->lang);
     b += layout->units.format_i18n_length_units();
     fprintf(f,"\\cavedepthtitle={%s}\n",utf2tex(thT("title cave depth",layout->lang)).c_str());
-    fprintf(f,"\\cavedepth={%s}\n",utf2tex(b.get_buffer()).c_str());
-    ldata->cavedepth = thutf82xhtml(b.get_buffer());
+    fprintf(f,"\\cavedepth={%s}\n",utf2tex(b.c_str()).c_str());
+    ldata->cavedepth = thutf82xhtml(b.c_str());
     ldata->cavedepthtitle = thT("title cave depth",layout->lang);
 	b = layout->units.format_length(z_top);
     //b += "<thsp>";
     //b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\cavemaxz={%s}\n",utf2tex(b.get_buffer()).c_str());
+    fprintf(f,"\\cavemaxz={%s}\n",utf2tex(b.c_str()).c_str());
 	b = layout->units.format_length(z_bot);
     //b += "<thsp>";
     //b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\caveminz={%s}\n",utf2tex(b.get_buffer()).c_str());
+    fprintf(f,"\\caveminz={%s}\n",utf2tex(b.c_str()).c_str());
 
   }
   

--- a/src/therion-core/thobjectname.cxx
+++ b/src/therion-core/thobjectname.cxx
@@ -61,7 +61,7 @@ void thparse_objectname(thobjectname & ds, thmbuffer * sstore, char * src, thdat
     thdb.buff_tmp += src;
     if (psobj->stnsuff != NULL)
       thdb.buff_tmp += psobj->stnsuff;
-    src = thdb.buff_tmp.get_buffer();
+    src = thdb.buff_tmp.data();
   }
   ds.name = src;
   size_t snl = strlen(src), sni;

--- a/src/therion-core/thparse.cxx
+++ b/src/therion-core/thparse.cxx
@@ -103,7 +103,7 @@ void thsplit_word(thbuffer * dword, thbuffer * drest, const char * src)
       case 0:
         if (*s2 < 33) {
           state = 1;
-          dword->strncpy((char *)s1, idx - idx0);
+          dword->assign((char *)s1, idx - idx0);
         }
         break;
       case 1:
@@ -119,15 +119,15 @@ void thsplit_word(thbuffer * dword, thbuffer * drest, const char * src)
   
   switch (state) {
     case -1:
-      dword->strcpy("");
-      drest->strcpy("");
+      dword->assign("");
+      drest->assign("");
       break;
     case 0:
-      dword->strcpy((char *)s1);
-      drest->strcpy("");
+      dword->assign((char *)s1);
+      drest->assign("");
       break;
     case 1:
-      drest->strcpy("");
+      drest->assign("");
       break;
     default:
       idx = srcl;
@@ -136,7 +136,7 @@ void thsplit_word(thbuffer * dword, thbuffer * drest, const char * src)
         s2--;
         idx--;
       }
-      drest->strncpy((char *) s1, idx - idx0 + 1);
+      drest->assign((char *) s1, idx - idx0 + 1);
   }
 
 }
@@ -372,7 +372,7 @@ void thsplit_fpath(thbuffer * dest, const char * src)
     s--;
     len--;
   }
-  dest->strncpy(src, len);
+  dest->assign(src, len);
 }
 
 
@@ -550,7 +550,7 @@ void thdecode_c(thbuffer * dest, const char * src)
   unsigned num;
   dest->guarantee(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
     if ((*srcp < 32) || (*srcp > 127)) {
         *dstp = '"';
@@ -600,7 +600,7 @@ void thdecode_tcl(thbuffer * dest, const char * src)
   unsigned num;
   dest->guarantee(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
     if ((*srcp < 32) || (*srcp > 127) || (*srcp == '[') || (*srcp == '[') || (*srcp == '"')) {
         *dstp = '\\';
@@ -635,7 +635,7 @@ void thdecode_mp(thbuffer * dest, const char * src)
   unsigned char * srcp, * dstp;
   dest->guarantee(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
     if (*srcp < 32) {
         *dstp = ' ';
@@ -676,7 +676,7 @@ void thdecode_tex(thbuffer * dest, const char * src)
 //  unsigned num;
   dest->guarantee(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
     switch (*srcp) {
       case '%':
@@ -719,9 +719,9 @@ void thdecode_utf2tex(thbuffer * dest, const char * src)
   tmpb = src;
   size_t srcln = strlen(src), srcx = 0, tmpl;
   unsigned char * srcp, * dstp, * wsrcp, *tmpp;
-  dest->strcpy("");  // check buffer size
+  dest->assign("");  // check buffer size
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) tmpb.get_buffer();
+  dstp = (unsigned char*) tmpb.c_str();
   while (srcx < srcln) {
     switch (*srcp) {
       case '%':
@@ -760,7 +760,7 @@ void thdecode_utf2tex(thbuffer * dest, const char * src)
   // end destination string with 0
   srcx = 0;
   srcp = (unsigned char*) src;
-  wsrcp = (unsigned char*) tmpb.get_buffer();
+  wsrcp = (unsigned char*) tmpb.c_str();
   unsigned char single[2];
   bool isutf8;
   dstp = &(single[0]);
@@ -770,7 +770,7 @@ void thdecode_utf2tex(thbuffer * dest, const char * src)
   while(srcx < srcln) {
     if (*wsrcp == 0) {
       single[0] = *srcp;
-      dest->strcat((char*) dstp);
+      dest->append((char*) dstp);
       srcx++;
       srcp++;
       wsrcp++;
@@ -783,9 +783,9 @@ void thdecode_utf2tex(thbuffer * dest, const char * src)
         isutf8 = isutf8 || (*tmpp > 127);
       }
       if (isutf8) {
-        dest->strcat(utf2tex((char*) wsrcp).c_str());
+        dest->append(utf2tex((char*) wsrcp).c_str());
       } else {
-        dest->strcat((char*) wsrcp);
+        dest->append((char*) wsrcp);
       }
       srcx+=tmpl;
       srcp+=tmpl;
@@ -809,7 +809,7 @@ void thdecode_sql(thbuffer * dest, const char * src)
   }
   dest->guarantee(srcln * 8 + 3);  // check buffer size
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   *dstp = '\'';
   dstp++;
   while (srcx < srcln) {
@@ -858,7 +858,7 @@ void thdecode_arg(thbuffer * dest, const char * src)
   }  
   
   if (quickcpy) {
-    dest->strcpy(src);
+    dest->assign(src);
     return;
   }
   
@@ -866,7 +866,7 @@ void thdecode_arg(thbuffer * dest, const char * src)
   dest->guarantee(srcln * 8 + 3);  // check buffer size
   srcx = 0;
   srcp = (unsigned char*) src;
-  dstp = (unsigned char*) dest->get_buffer();
+  dstp = (unsigned char*) dest->c_str();
   *dstp = '"';
   dstp++;
   while (srcx < srcln) {
@@ -1120,7 +1120,7 @@ const char * thutf82xhtml(const char * src)
   bool inspec;
   char * res;
   tmp.guarantee(sl);
-  res = tmp.get_buffer();
+  res = tmp.data();
 
   inspec = false;
   for(sx = 0, dx = 0; sx < sl; sx++) {
@@ -1202,8 +1202,8 @@ void thparse_length(int & sv, double & dv, const char * src)
   static thbuffer plb;
   char * srcb;
   
-  plb.strcpy(src);  
-  srcb = plb.get_buffer();
+  plb.assign(src);  
+  srcb = plb.data();
     
   // first let's find units index
   bool has_units = false;

--- a/src/therion-core/thperson.cxx
+++ b/src/therion-core/thperson.cxx
@@ -45,7 +45,7 @@ void thperson::identify(thdatabase * dbp)
   dbp->buff_tmp = this->n2;
   dbp->buff_tmp += "/";
   dbp->buff_tmp += this->n1;
-  this->nn = dbp->strstore(dbp->buff_tmp.get_buffer(), true);
+  this->nn = dbp->strstore(dbp->buff_tmp.c_str(), true);
 }
 
 
@@ -55,7 +55,7 @@ thperson::thperson()
 }
 
 
-void thperson::parse(thdatabase * dbp, char * src)
+void thperson::parse(thdatabase * dbp, const char * src)
 {
   this->reset();
   bool has_sep = (strchr(src,'/') != NULL);

--- a/src/therion-core/thperson.h
+++ b/src/therion-core/thperson.h
@@ -59,7 +59,7 @@ class thperson {
    * Parse the person name.
    */
    
-  void parse(thdatabase * dbp, char * src);
+  void parse(thdatabase * dbp, const char * src);
   
   
   /**

--- a/src/therion-core/thpic.cxx
+++ b/src/therion-core/thpic.cxx
@@ -118,7 +118,7 @@ void thpic::init(const char * pfname, const char * incfnm)
   thprint("running convert\n");
 #endif
 
-  retcode = system(ccom.get_buffer());
+  retcode = system(ccom.c_str());
   if (retcode == EXIT_SUCCESS) {
     FILE * tmp;
     tmp = fopen(thpic_tmp,"r");
@@ -175,12 +175,12 @@ const char * thpic::convert(const char * type, const char * ext, const std::stri
   ccom += tmpf;
   if (isspc) ccom += "\"";
 
-  retcode = system(ccom.get_buffer());
+  retcode = system(ccom.c_str());
   if (retcode == EXIT_SUCCESS) {
     ccom = thtmp.get_file_name(tmpfn.c_str());
     size_t x, l;
     l = strlen(ccom);
-    for (x = 0; x < l; x++) if (ccom.get_buffer()[x] == '\\') ccom.get_buffer()[x] = '/';
+    for (x = 0; x < l; x++) if (ccom.c_str()[x] == '\\') ccom.data()[x] = '/';
     return (thdb.strstore(ccom));
   } else {
     return NULL;

--- a/src/therion-core/thpic.cxx
+++ b/src/therion-core/thpic.cxx
@@ -56,7 +56,7 @@ thpic::thpic() {
 
   if (thpic_tmp == NULL) {
     thdb.buff_tmp = thtmp.get_file_name("pic0000.txt");
-    thpic_tmp = thdb.strstore(thdb.buff_tmp);
+    thpic_tmp = thdb.strstore(thdb.buff_tmp.c_str());
   }
 }
 
@@ -179,9 +179,9 @@ const char * thpic::convert(const char * type, const char * ext, const std::stri
   if (retcode == EXIT_SUCCESS) {
     ccom = thtmp.get_file_name(tmpfn.c_str());
     size_t x, l;
-    l = strlen(ccom);
+    l = strlen(ccom.c_str());
     for (x = 0; x < l; x++) if (ccom.c_str()[x] == '\\') ccom.data()[x] = '/';
-    return (thdb.strstore(ccom));
+    return (thdb.strstore(ccom.c_str()));
   } else {
     return NULL;
   }

--- a/src/therion-core/thpoint.cxx
+++ b/src/therion-core/thpoint.cxx
@@ -155,7 +155,7 @@ void thpoint::set(thcmd_option_desc cod, char ** args, int argenc, unsigned long
 
     case TT_POINT_TEXT:
       thencode(&(this->db->buff_enc), *args, argenc);
-      this->parse_text(this->db->buff_enc.get_buffer());
+      this->parse_text(this->db->buff_enc.c_str());
       break;
 
     case TT_POINT_EXPLORED:
@@ -275,7 +275,7 @@ void thpoint::self_print_properties(FILE * outf)
 }
 
 
-void thpoint::parse_type(char * tstr)
+void thpoint::parse_type(const char * tstr)
 {
   this->type = thmatch_token(tstr, thtt_point_types);
   if (this->type == TT_POINT_TYPE_UNKNOWN)
@@ -294,7 +294,7 @@ void thpoint::parse_type(char * tstr)
 }
 
 
-void thpoint::parse_subtype(char * ststr)
+void thpoint::parse_subtype(const char * ststr)
 {
   if (this->type == TT_POINT_TYPE_UNKNOWN)
     throw thexception("point type must be specified before subtype");
@@ -341,7 +341,7 @@ void thpoint::parse_subtype(char * ststr)
     throw thexception("invalid point type - subtype combination");
 }
 
-void thpoint::parse_from(char * estr)
+void thpoint::parse_from(const char * estr)
 {
   thsplit_words(& this->db->db2d.mbf, estr);
   int npar = this->db->db2d.mbf.get_size();
@@ -387,7 +387,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
   int macroid = -1, omacroid = -1, cmark;
   const char * postprocess_label = NULL;
   this->db->buff_enc.guarantee(8128);
-//  char * buff = this->db->buff_enc.get_buffer();
+//  char * buff = this->db->buff_enc.data();
   double xrr = (thisnan(this->orient) ? out->rr : 0.0);
 
   if (this->scale_numeric < out->layout->min_symbol_scale) return(false);
@@ -604,9 +604,9 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
           //  sprintf(buff,"%.0f",this->xsize);
           fprintf(out->file,"%s",utf2tex(out->layout->units.format_human_length(this->xsize)).c_str());
         }
-        this->db->buff_enc.strcpy((this->tags & (TT_POINT_TAG_HEIGHT_PQ |
+        this->db->buff_enc.assign((this->tags & (TT_POINT_TAG_HEIGHT_PQ |
             TT_POINT_TAG_HEIGHT_NQ | TT_POINT_TAG_HEIGHT_UQ)) != 0 ? "?" : "" );
-        fprintf(out->file,"%s etex,",utf2tex(this->db->buff_enc.get_buffer()).c_str());
+        fprintf(out->file,"%s etex,",utf2tex(this->db->buff_enc.c_str()).c_str());
         postprocess_label = "p_label_mode_height";
       }
       postprocess = false;
@@ -971,7 +971,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
   return(false);
 }
 
-void thpoint::parse_align(char * tstr) {
+void thpoint::parse_align(const char * tstr) {
   switch (this->type) {
     case TT_POINT_TYPE_STATION:
       throw thexception(fmt::format("-align not valid with type {}", thmatch_string(this->type,thtt_point_types)));
@@ -983,7 +983,7 @@ void thpoint::parse_align(char * tstr) {
 }
 
 
-void thpoint::parse_text(char * ss) {
+void thpoint::parse_text(const char * ss) {
   switch (this->type) {
     case TT_POINT_TYPE_LABEL:
     case TT_POINT_TYPE_REMARK:
@@ -1001,7 +1001,7 @@ void thpoint::parse_text(char * ss) {
 }
 
 
-void thpoint::parse_explored(char * ss) {
+void thpoint::parse_explored(const char * ss) {
   switch (this->type) {
     case TT_POINT_TYPE_CONTINUATION:
       break;
@@ -1065,7 +1065,7 @@ void thpoint_parse_value(int & sv, double & dv, bool & qw, int & sign, char * st
 }
 
 
-void thpoint::parse_value(char * ss, bool is_dist) {
+void thpoint::parse_value(const char * ss, bool is_dist) {
   bool opt_ok = false;
   switch (this->type) {
     case TT_POINT_TYPE_EXTRA:

--- a/src/therion-core/thpoint.h
+++ b/src/therion-core/thpoint.h
@@ -498,19 +498,19 @@ class thpoint : public th2ddataobject {
 
   void start_insert() override;
 
-  void parse_type(char * tstr);  ///< Parse point type.
+  void parse_type(const char * tstr);  ///< Parse point type.
 
-  void parse_align(char * tstr);  ///< Parse point align.
+  void parse_align(const char * tstr);  ///< Parse point align.
 
-  void parse_subtype(char * ststr);  ///< Parse point subtype.
+  void parse_subtype(const char * ststr);  ///< Parse point subtype.
 
-  void parse_from(char * estr);  ///< Parse station extend.
+  void parse_from(const char * estr);  ///< Parse station extend.
 
-  void parse_text(char * ss);  ///< Parse point text.
+  void parse_text(const char * ss);  ///< Parse point text.
 
-  void parse_explored(char * ss);  ///< Parse explored length.
+  void parse_explored(const char * ss);  ///< Parse explored length.
 
-  void parse_value(char * ss, bool is_dist=false);  ///< Parse point value.
+  void parse_value(const char * ss, bool is_dist=false);  ///< Parse point value.
 
   void check_extra();
 

--- a/src/therion-core/thproj.cxx
+++ b/src/therion-core/thproj.cxx
@@ -332,7 +332,7 @@ void thcs2cs(int si, int ti,
 // set CA bundle path; supported since proj 7.2.0
 #ifdef THWIN32
 #if PROJ_VER >= 8
-  std::string ca_path = fmt::format("{}\\lib\\cacert.pem", thcfg.install_path.get_buffer());
+  std::string ca_path = fmt::format("{}\\lib\\cacert.pem", thcfg.install_path.c_str());
   proj_context_set_ca_bundle_path(PJ_DEFAULT_CTX, ca_path.c_str());
 #endif
 #endif

--- a/src/therion-core/thselector.cxx
+++ b/src/therion-core/thselector.cxx
@@ -234,10 +234,10 @@ void thselector_export_survey_tree_node (FILE * cf, unsigned long level, thdatao
       fprintf(cf," %s %s",ss->get_name(),ss->full_name);
       if (strlen(ss->get_title()) > 0) {
         thdecode_tex(&(thdb.buff_enc), ss->get_title());
-        fprintf(cf," \"%s\"",thdb.buff_enc.get_buffer());
+        fprintf(cf," \"%s\"",thdb.buff_enc.c_str());
         thdecode(&(thdb.buff_enc),TT_ASCII,ss->get_title());
-        thdecode_tex(&(thdb.buff_tmp), thdb.buff_enc.get_buffer());
-        fprintf(cf," \"%s\"",thdb.buff_tmp.get_buffer());
+        thdecode_tex(&(thdb.buff_tmp), thdb.buff_enc.c_str());
+        fprintf(cf," \"%s\"",thdb.buff_tmp.c_str());
       }
       else
         fprintf(cf," \"\" \"\"");
@@ -343,10 +343,10 @@ void thselector_export_map_tree_node (FILE * cf, unsigned long level, unsigned l
   fprintf(cf," %s %s%s%s",optr->get_name(),optr->get_name(), (strlen(optr->fsptr->full_name) > 0 ? "@" : ""), optr->fsptr->full_name);
   if (strlen(optr->get_title()) > 0) {
     thdecode_tex(&(thdb.buff_enc), optr->get_title());
-    fprintf(cf," \"%s\"",thdb.buff_enc.get_buffer());
+    fprintf(cf," \"%s\"",thdb.buff_enc.c_str());
     thdecode(&(thdb.buff_enc),TT_ASCII,optr->get_title());
-    thdecode_tex(&(thdb.buff_tmp), thdb.buff_enc.get_buffer());
-    fprintf(cf," \"%s\"\n",thdb.buff_tmp.get_buffer());
+    thdecode_tex(&(thdb.buff_tmp), thdb.buff_enc.c_str());
+    fprintf(cf," \"%s\"\n",thdb.buff_tmp.c_str());
   }
   else
     fprintf(cf," \"\" \"\"\n");

--- a/src/therion-core/thsurvey.cxx
+++ b/src/therion-core/thsurvey.cxx
@@ -164,9 +164,9 @@ void thsurvey::set(thcmd_option_desc cod, char ** args, int argenc, unsigned lon
       
     case TT_SURVEY_PERSON_RENAME:
       thencode(&(this->db->buff_enc), args[0], argenc);
-      tmpp1.parse(this->db, this->db->buff_enc.get_buffer());
+      tmpp1.parse(this->db, this->db->buff_enc.c_str());
       thencode(&(this->db->buff_enc), args[1], argenc);
-      tmpp2.parse(this->db, this->db->buff_enc.get_buffer());
+      tmpp2.parse(this->db, this->db->buff_enc.c_str());
       this->person_renames[tmpp1] = tmpp2;
       break;
 
@@ -195,7 +195,7 @@ void thsurvey::self_print_properties(FILE * outf)
   thdataobject::self_print_properties(outf);
   fprintf(outf,"thsurvey:\n");
   fprintf(outf,"\tfull name: \"%s\" (\"%s\")\n", this->full_name,
-    this->reverse_full_name.get_buffer());
+    this->reverse_full_name.c_str());
   if (this->decdef) {
     fprintf(outf,"\tdeclination:\n");
     nval = this->declin.get_size();
@@ -320,7 +320,7 @@ void thsurvey::full_name_reverse()
     if ((*c1 == '.') || ((i1 == fnln) && has_dot)) {
       has_dot = true;
       c3 = this->full_name + si;
-      c2 = this->reverse_full_name.get_buffer() + fnln - i1;
+      c2 = this->reverse_full_name.data() + fnln - i1;
       if (i1 < fnln) {
         c2--;
         *c2 = '.';

--- a/src/therion-core/thsurvey.h
+++ b/src/therion-core/thsurvey.h
@@ -233,7 +233,7 @@ class thsurvey : public thdataobject {
    * Return reverse full survey name.
    */
    
-   virtual const char * get_reverse_full_name() {return this->reverse_full_name;}
+   virtual const char * get_reverse_full_name() {return this->reverse_full_name.c_str();}
   
 
   /**

--- a/src/therion-core/thsvxctrl.cxx
+++ b/src/therion-core/thsvxctrl.cxx
@@ -391,7 +391,7 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
   fclose(svxf);
   
   // run survex
-  thbuffer svxcom;
+  std::string svxcom;
   int retcode;
   svxcom = "\"";
   svxcom += thini.get_path_cavern();
@@ -565,7 +565,7 @@ enum {THSVXLOGNUM_NONE, THSVXLOGNUM_LINE, THSVXLOGNUM_STATION};
 
 void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
 {
-  thbuffer tsbuff;
+  std::string tsbuff;
   thdb1ds * stp;
   std::string lnbuff;
   std::string numbuff;

--- a/src/therion-core/thsvxctrl.cxx
+++ b/src/therion-core/thsvxctrl.cxx
@@ -405,7 +405,7 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
 #else
 //    thprint("processing ... ");
 #endif
-  retcode = system(svxcom.get_buffer());
+  retcode = system(svxcom.c_str());
 
   this->transcript_log_file(dbp, thtmp.get_file_name("data.log"));
 
@@ -456,7 +456,7 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
 // #ifdef THDEBUG
 //   thprint("running 3dtopos\n");
 // #endif
-//   retcode = system(svxcom.get_buffer());
+//   retcode = system(svxcom.c_str());
 // 
 //   if (retcode != EXIT_SUCCESS)
 //     ththrow("3dtopos exit code -- %d", retcode);
@@ -469,12 +469,12 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
 // // #endif
 // //   svxcom += thtmp.get_file_name("data.*");
 // //   svxcom += " ";
-// //   svxcom += wdir.get_buffer();
+// //   svxcom += wdir.c_str();
 // // #ifdef THDEBUG
 // //   thprint("copying results\n");
 // // #endif
 // // 
-// //   retcode = system(svxcom.get_buffer());
+// //   retcode = system(svxcom.c_str());
 // // 
 // //   if (retcode != EXIT_SUCCESS)
 // //     ththrow("cp exit code -- %d", retcode);
@@ -491,7 +491,7 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
 //   unsigned long ss;
 //   size_t lnsize = 4096, pix = 0, ppx = 0, clns;
 //   svxcom.guarantee(lnsize);
-//   char * lnbuff = svxcom.get_buffer(),
+//   char * lnbuff = svxcom.data(),
 //     * p[4], * cps = lnbuff;
 //   posf.open(thtmp.get_file_name("data.pos"));
 //   if (!posf.is_open())
@@ -650,10 +650,10 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
               if (srcmi != this->src_map.end()) {
                 if (!fonline) {
                   fonline = true;
-                  tsbuff.strcat("\n");
+                  tsbuff.append("\n");
                 }
                 numbuff = fmt::format("{:2d}> input:{} -- {} [{}]\n",lnum,csn,srcmi->second->name,srcmi->second->line);
-                tsbuff.strcat(numbuff.c_str());
+                tsbuff.append(numbuff.c_str());
               }
               break;
             case THSVXLOGNUM_STATION:
@@ -661,18 +661,18 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
               if ((csn >= 0) && (csn < long(lsid))) {
                 if (fonline) {
                   numbuff = fmt::format("{:2d}> ",lnum);
-                  tsbuff.strcat(numbuff.c_str());
+                  tsbuff.append(numbuff.c_str());
                   fonline = false;
                 }
                 else {
-                  tsbuff.strcat(" -- ");
+                  tsbuff.append(" -- ");
                 }
                 numbuff = fmt::format("{} : ",(csn+1));
                 stp = & (dbp->db1d.station_vec[(unsigned int)csn]);
-                tsbuff.strcat(numbuff.c_str());
-                tsbuff.strcat(stp->name);
-                tsbuff.strcat("@");
-                tsbuff.strcat(stp->survey->get_full_name());
+                tsbuff.append(numbuff.c_str());
+                tsbuff.append(stp->name);
+                tsbuff.append("@");
+                tsbuff.append(stp->survey->get_full_name());
               }
               break;
             default:
@@ -688,11 +688,11 @@ void thsvxctrl::transcript_log_file(class thdatabase * dbp, const char * lfnm)
     }
     
     if (!fonline)
-        tsbuff.strcat("\n");
+        tsbuff.append("\n");
 
   }
   clf.close();
-  thlog(fmt::format("######################### transcription ########################\n{}",tsbuff.get_buffer()));
+  thlog(fmt::format("######################### transcription ########################\n{}",tsbuff.c_str()));
   thlog("#################### end of cavern log file ####################\n");
 }
 

--- a/src/therion-core/thsymbolset.cxx
+++ b/src/therion-core/thsymbolset.cxx
@@ -1772,7 +1772,7 @@ void export_all_symbols()
 #ifdef THDEBUG
     thprint("running metapost\n");
 #endif
-    retcode = system(com.get_buffer());
+    retcode = system(com.c_str());
     thsymbolset_log_log_file("data.log",
     "####################### metapost log file ########################\n",
     "#################### end of metapost log file ####################\n",true);

--- a/src/therion-core/thsymbolset.cxx
+++ b/src/therion-core/thsymbolset.cxx
@@ -1713,7 +1713,7 @@ void export_all_symbols()
     const auto tmp_handle = thtmp.switch_to_tmpdir();
 
     // run MP
-    thbuffer com;
+    std::string com;
 
     // vypise kodovania
     print_fonts_setup();

--- a/src/therion-core/thtmpdir.cxx
+++ b/src/therion-core/thtmpdir.cxx
@@ -98,14 +98,14 @@ void thtmpdir::create() try
     return;
 
   fs::path dir_path;
-  this->tmp_remove_script = thini.tmp_remove_script.get_buffer();
+  this->tmp_remove_script = thini.tmp_remove_script.c_str();
 
 #ifdef THDEBUG
   // the debugging temp directory
   dir_path = "thTMPDIR";
 #else
-  if (strlen(thini.tmp_path.get_buffer()) > 0) {
-    dir_path = thini.tmp_path.get_buffer();
+  if (!thini.tmp_path.empty()) {
+    dir_path = thini.tmp_path.c_str();
   } else if (this->debug) {
     dir_path = "thTMPDIR";
   } else {


### PR DESCRIPTION
**Context:** The `thbuffer` class has the semantics of a null-terminated `std::string`

**Summary of changes:** Make `thbuffer` more similar to `std::string`, and replace it with `std::string` where possible.

**Goal:** Make the codebase easier to read and modify for someone who's familiar with `std::string`

**Changes:**

- remove: `operator char* ()`
- rename: `strcpy` / `strncpy` → `assign`
- rename: `strcat` / `strncat` → `append`
- rename: `get_buffer` → `data` / `c_str`
- new method: `empty`
- make `buff` and `size` private
- replace 13 instances of `thbuffer` with `std::string`