### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,6 @@
 name: CMake
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   Ubuntu:


### PR DESCRIPTION
Potential fix for [https://github.com/therion/therion/security/code-scanning/30](https://github.com/therion/therion/security/code-scanning/30)

In general, the fix is to declare an explicit `permissions` block for the workflow or for individual jobs, granting only the scopes actually required. For a typical CI workflow that only checks out code and uploads artifacts, `contents: read` is sufficient and matches the minimal recommendation from the CodeQL message.

The best way to fix this workflow without changing its functionality is to add a root-level `permissions` block right after the `name` (or before `on`) in `.github/workflows/cmake.yml`, so it applies to all jobs. None of the steps need to write to the repository or interact with issues/PRs, so `contents: read` is enough. The `actions/upload-artifact` step uses the artifact service and does not require repository write permissions. No new imports or external packages are needed; this is purely a YAML configuration change within the workflow file.

Concretely, in `.github/workflows/cmake.yml`, add:

```yaml
permissions:
  contents: read
```

between line 1 (`name: CMake`) and line 2 (`on: [push, pull_request]`). No other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
