### PR TITLE
Silence Clang 22 warning

### DIFF
--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -17,3 +17,9 @@ else()
     )
     target_compile_options(disable-warnings INTERFACE -w)
 endif()
+
+# silence Clang warning: '__COUNTER__' is a C2y extension
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+    target_compile_options(enable-warnings INTERFACE -Wno-c2y-extensions)
+endif()


### PR DESCRIPTION
Silence Clang 22 warning `'__COUNTER__' is a C2y extension`.