### PR TITLE
Removed macOS 14

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, macos-15, macos-26]
+        os: [macos-15, macos-26]
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:


### PR DESCRIPTION
macOS 14 will soon be deprecated on GitHub Actions, let's remove it.