### PR TITLE
Improving 'point -from' and removing unsupported 'point -extend'

### DIFF
--- a/thbook/ch02.tex
+++ b/thbook/ch02.tex
@@ -944,12 +944,23 @@ Point is a command for drawing a point map symbol.
   * |dist <distance>| =  if the point type is extra, specifies the distance to the nearest
     station (or station specified using |-from| option. If not specified,
     appropriate value from LRUD data is used.
-  * |from <station>| =  if the point type is extra, specifies reference station.
+  * |from <station>| = specifies a reference station.
+    This option is primarily intended for points of type |extra|. If omitted,
+    Therion uses the nearest station, and if |-dist| is not specified,
+    an appropriate value from LRUD data is used.
+
+    If the point type is |station| and the scrap projection is extended
+    elevation, this option specifies the neighbouring survey station that
+    should be used as origin (from station) when placing the station point on the 
+    extended centreline. This is useful at junctions, where the same survey station may
+    be reached by more than one shot and the cartographer needs to choose which branch
+    the point should follow. If |-from| is not given, Therion falls back to
+    the nearest matching branch in the scrap.
+
+    Therion accepts this option also for other point types, but it has no
+    defined effect there.
   * |name <reference>| = if the point type is station, this
     option gives the reference to the real survey station.
-  * |extend [prev[ious] <station>]| = if the point type is station and scrap
-    projection is extended elevation, you can
-    adjust the extension of the centreline using this option.
   * |scrap <reference>| = if the point type is section, this is a
     reference to a cross-section scrap.
   * |explored <length>| = if the point type is continuation, you can specify


### PR DESCRIPTION
With AI help I found out that:

'-extend' is not supported by current Therion. Trying to compile the following file:

```
encoding utf-8
scrap teste
point 10 20 station -extend previous A1
endscrap
```

results in the following error:

`therion: error -- point_extend.th2 [3] -- unknown option -- -extend`

'-from' inherited its function.