### PR TITLE
Moved thcsdata build definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,6 @@ set_source_files_properties(
     ${CMAKE_BINARY_DIR}/thchencdata.h
     ${CMAKE_BINARY_DIR}/thchencdata.cxx
     ${CMAKE_BINARY_DIR}/thversion.h
-    ${CMAKE_BINARY_DIR}/thcsdata.h
-    ${CMAKE_BINARY_DIR}/thcsdata.cxx
     PROPERTIES GENERATED TRUE 
 )
 
@@ -84,19 +82,7 @@ macro(therion_make_files_lists LIST_NAME)
 endmacro()
 
 # copy files needed by some build steps
-therion_copy_files(thcsdata.tcl .clang-tidy)
-
-# generate thcsdata sources
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/thcsdata.h
-                          ${CMAKE_BINARY_DIR}/thcsdata.cxx
-                   COMMAND tclsh thcsdata.tcl ${PROJ_PREFIX}/share/proj
-                   DEPENDS ${CMAKE_BINARY_DIR}/thcsdata.tcl
-                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
-add_custom_target(generate_thcsdata DEPENDS
-    ${CMAKE_BINARY_DIR}/thcsdata.h
-    ${CMAKE_BINARY_DIR}/thcsdata.cxx
-)
+therion_copy_files(.clang-tidy)
 
 # generate version files
 add_custom_target(thversion python3 set_version.py ${CMAKE_BINARY_DIR}

--- a/cmake/TherionSources.cmake
+++ b/cmake/TherionSources.cmake
@@ -1,5 +1,4 @@
 set(THERION_SOURCES
-    ${CMAKE_BINARY_DIR}/thcsdata.cxx
     ${CMAKE_SOURCE_DIR}/src/therion-core/th2ddataobject.cxx
     ${CMAKE_SOURCE_DIR}/src/therion-core/tharea.cxx
     ${CMAKE_SOURCE_DIR}/src/therion-core/thattr.cxx

--- a/src/therion-core/CMakeLists.txt
+++ b/src/therion-core/CMakeLists.txt
@@ -1,6 +1,21 @@
-add_library(therion-core STATIC ${THERION_SOURCES})
+add_custom_command(
+    COMMAND
+        tclsh ${CMAKE_CURRENT_SOURCE_DIR}/thcsdata.tcl ${PROJ_PREFIX}/share/proj
+    OUTPUT
+        ${CMAKE_CURRENT_BINARY_DIR}/thcsdata.h
+        ${CMAKE_CURRENT_BINARY_DIR}/thcsdata.cxx
+    DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/thcsdata.tcl
+    WORKING_DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
 
-target_include_directories(therion-core PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(therion-core STATIC
+    ${THERION_SOURCES} 
+    ${CMAKE_CURRENT_BINARY_DIR}/thcsdata.cxx
+)
+
+target_include_directories(therion-core PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(therion-core SYSTEM PUBLIC ${CMAKE_SOURCE_DIR}/extern/stl_reader)
 target_link_libraries(therion-core PUBLIC
     therion-lang
@@ -18,5 +33,4 @@ target_compile_definitions(therion-core PUBLIC "TH${THPLATFORM}" $<$<BOOL:${ENAB
 add_dependencies(therion-core
     thversion
     generate_thchencdata
-    generate_thcsdata
 )

--- a/src/therion-core/thcsdata.tcl
+++ b/src/therion-core/thcsdata.tcl
@@ -229,8 +229,6 @@ puts $fid {/**
  
 #include "thstok.h"
  
-#include <map>
-
 /**
 * Add default CS transformations.
 */


### PR DESCRIPTION
I have moved build definition of `thcsdata` to `therion-core`. I was not able to create a separate library, because there are too many dependencies on `therion-core`.