### PR TITLE
Cleanup includes in thchencdata/generate.pl

### DIFF
--- a/src/therion-core/th2ddataobject.cxx
+++ b/src/therion-core/th2ddataobject.cxx
@@ -29,6 +29,7 @@
 #include "thexception.h"
 #include "thsymbolset.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/tharea.cxx
+++ b/src/therion-core/tharea.cxx
@@ -31,6 +31,7 @@
 #include "thexpmap.h"
 #include "thline.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thattr.cxx
+++ b/src/therion-core/thattr.cxx
@@ -30,6 +30,7 @@
 #include "shapefil.h"
 #include "therion.h"
 #include "thchenc.h"
+#include "thparse.h"
 #include <cctype>
 #include <cmath>
 #include <cstring>

--- a/src/therion-core/thchenc.cxx
+++ b/src/therion-core/thchenc.cxx
@@ -29,6 +29,7 @@
 #include "thchencdata.cxx"
 #include "therion.h"
 #include "thexception.h"
+#include "thparse.h"
 
 
 void thencode(thbuffer * dest, const char * src, int srcenc)

--- a/src/therion-core/thconfig.cxx
+++ b/src/therion-core/thconfig.cxx
@@ -46,6 +46,7 @@
 #include "thsketch.h"
 #include "thcs.h"
 #include "thlog.h"
+#include "thparse.h"
 #ifdef THWIN32
 #include <windows.h>
 #endif

--- a/src/therion-core/thcs.cxx
+++ b/src/therion-core/thcs.cxx
@@ -30,6 +30,7 @@
 #include "thexception.h"
 #include "thproj.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thdata.cxx
+++ b/src/therion-core/thdata.cxx
@@ -34,6 +34,7 @@
 #include "thcsdata.h"
 #include "thdatareader.h"
 #include "thdatabase.h"
+#include "thparse.h"
 #include "therion.h"
 #include "icase.h"
 

--- a/src/therion-core/thdatabase.cxx
+++ b/src/therion-core/thdatabase.cxx
@@ -51,6 +51,7 @@
 #include "thendscrap.h"
 #include "thconfig.h"
 #include "thproj.h"
+#include "thparse.h"
 #include "therion.h"
 
 #include <fmt/ostream.h>

--- a/src/therion-core/thdataobject.cxx
+++ b/src/therion-core/thdataobject.cxx
@@ -35,6 +35,7 @@
 #include "thproj.h"
 #include "thcs.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thdatareader.cxx
+++ b/src/therion-core/thdatareader.cxx
@@ -30,6 +30,7 @@
 #include "thobjectsrc.h"
 #include "thdataobject.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thdb1d.cxx
+++ b/src/therion-core/thdb1d.cxx
@@ -52,6 +52,7 @@
 #include "thgeomagdata.h"
 #include "therion.h"
 #include "thlog.h"
+#include "thparse.h"
 #include "QuickHull.hpp"
 
 //#define THUSESVX

--- a/src/therion-core/thdb2d.cxx
+++ b/src/therion-core/thdb2d.cxx
@@ -46,6 +46,7 @@
 #include "thfilehandle.h"
 #include "therion.h"
 #include "thlog.h"
+#include "thparse.h"
 #include <list>
 #include <set>
 #include <iterator>

--- a/src/therion-core/thdb2dji.cxx
+++ b/src/therion-core/thdb2dji.cxx
@@ -28,6 +28,7 @@
 #include "thdb2dji.h"
 #include "thdatabase.h"
 #include "thexception.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thendscrap.cxx
+++ b/src/therion-core/thendscrap.cxx
@@ -28,6 +28,7 @@
 #include "thendscrap.h"
 #include "thexception.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thendsurvey.cxx
+++ b/src/therion-core/thendsurvey.cxx
@@ -28,6 +28,7 @@
 #include "thendsurvey.h"
 #include "thexception.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thexpdb.cxx
+++ b/src/therion-core/thexpdb.cxx
@@ -38,6 +38,7 @@
 #include "thchenc.h"
 #include <map>
 #include "thinfnan.h"
+#include "thparse.h"
 #include "therion.h"
 
 thexpdb::thexpdb() {

--- a/src/therion-core/thexpmap.cxx
+++ b/src/therion-core/thexpmap.cxx
@@ -68,6 +68,7 @@
 #include "lxMath.h"
 #include "thsvg.h"
 #include "thlog.h"
+#include "thparse.h"
 #include "img.h"
 #include <filesystem>
 

--- a/src/therion-core/thexpmodel.cxx
+++ b/src/therion-core/thexpmodel.cxx
@@ -45,6 +45,7 @@
 #include "thtexfonts.h"
 #include "thlang.h"
 #include "thfilehandle.h"
+#include "thparse.h"
 #include "therion.h"
 #include <filesystem>
 

--- a/src/therion-core/thexport.cxx
+++ b/src/therion-core/thexport.cxx
@@ -31,6 +31,7 @@
 #include "thdatabase.h"
 #include "thexporter.h"
 #include "thcs.h"
+#include "thparse.h"
 #include "icase.h"
 #include <stdio.h>
 #include <algorithm>

--- a/src/therion-core/thexporter.cxx
+++ b/src/therion-core/thexporter.cxx
@@ -34,6 +34,7 @@
 #include "thexpdb.h"
 #include "thexpsys.h"
 #include "thexptable.h"
+#include "thparse.h"
 #include "therion.h"
 #include <stdio.h>
 

--- a/src/therion-core/thexpshp.cxx
+++ b/src/therion-core/thexpshp.cxx
@@ -44,6 +44,7 @@
 #include <time.h>
 #include "thcs.h"
 #include "thproj.h"
+#include "thparse.h"
 #include "therion.h"
 #include <filesystem>
 

--- a/src/therion-core/thexptable.cxx
+++ b/src/therion-core/thexptable.cxx
@@ -40,6 +40,7 @@
 #include "thproj.h"
 #include "thconfig.h"
 #include "thcs.h"
+#include "thparse.h"
 #include "therion.h"
 #include <filesystem>
 

--- a/src/therion-core/thexpuni.cxx
+++ b/src/therion-core/thexpuni.cxx
@@ -46,6 +46,7 @@
 #include "thproj.h"
 #include "thtexfonts.h"
 #include "thlang.h"
+#include "thparse.h"
 #include "therion.h"
 
 

--- a/src/therion-core/thgrade.cxx
+++ b/src/therion-core/thgrade.cxx
@@ -28,6 +28,7 @@
 #include "thgrade.h"
 #include "thdata.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/ostream.h>
 

--- a/src/therion-core/thimport.cxx
+++ b/src/therion-core/thimport.cxx
@@ -32,6 +32,7 @@
 #include "thdata.h"
 #include "thsurvey.h"
 #include "thdatabase.h"
+#include "thparse.h"
 #include "therion.h"
 #include "img.h"
 #include <string.h>

--- a/src/therion-core/thinit.cxx
+++ b/src/therion-core/thinit.cxx
@@ -38,6 +38,7 @@
 #include "thcsdata.h"
 #include "thproj.h"
 #include "thpdfdbg.h"
+#include "thparse.h"
 #include "icase.h"
 #include <filesystem>
 

--- a/src/therion-core/thinput.cxx
+++ b/src/therion-core/thinput.cxx
@@ -30,6 +30,7 @@
 #include "therion.h"
 #include "thexception.h"
 #include "thversion.h"
+#include "thparse.h"
 
 #include <algorithm>
 #include <array>

--- a/src/therion-core/thjoin.cxx
+++ b/src/therion-core/thjoin.cxx
@@ -28,6 +28,7 @@
 #include "thjoin.h"
 #include "thexception.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thlang.cxx
+++ b/src/therion-core/thlang.cxx
@@ -31,6 +31,7 @@
 #include "thconfig.h"
 #include "thdatabase.h"
 #include "thexception.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thlayout.cxx
+++ b/src/therion-core/thlayout.cxx
@@ -39,6 +39,7 @@
 #include "thconfig.h"
 #include "th2ddataobject.h"
 #include "thdatabase.h"
+#include "thparse.h"
 #include "therion.h"
 
 #include <fmt/ostream.h>

--- a/src/therion-core/thlayoutclr.cxx
+++ b/src/therion-core/thlayoutclr.cxx
@@ -29,6 +29,7 @@
 #include "thdatabase.h"
 #include "thexception.h"
 #include "thepsparse.h"
+#include "thparse.h"
 #include <cmath>
 #include <fmt/format.h>
 

--- a/src/therion-core/thline.cxx
+++ b/src/therion-core/thline.cxx
@@ -33,6 +33,7 @@
 #include "thtflength.h"
 #include "thscrap.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thlookup.cxx
+++ b/src/therion-core/thlookup.cxx
@@ -36,6 +36,7 @@
 #include "thlayout.h"
 #include "thtexfonts.h"
 #include "thdatabase.h"
+#include "thparse.h"
 #include "therion.h"
 #include <string.h>
 

--- a/src/therion-core/thmap.cxx
+++ b/src/therion-core/thmap.cxx
@@ -34,6 +34,7 @@
 #include "thtflength.h"
 #include "thconfig.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <cassert>
 #include <fmt/core.h>

--- a/src/therion-core/thmapstat.cxx
+++ b/src/therion-core/thmapstat.cxx
@@ -40,6 +40,7 @@
 #include "thproj.h"
 #include "thdb2dmi.h"
 #include "thdatabase.h"
+#include "thparse.h"
 #include <vector>
 #include <algorithm>
 #include <string.h>

--- a/src/therion-core/thobjectname.cxx
+++ b/src/therion-core/thobjectname.cxx
@@ -30,6 +30,7 @@
 #include "thdatabase.h"
 #include "thdataobject.h"
 #include "thsurvey.h"
+#include "thparse.h"
 
 #include <fmt/format.h>
 

--- a/src/therion-core/thparse.cxx
+++ b/src/therion-core/thparse.cxx
@@ -26,6 +26,8 @@
  * --------------------------------------------------------------------
  */
 
+#include "thparse.h"
+
 #include "therion.h"
 #include "thlang.h"
 #include "thtexfonts.h"

--- a/src/therion-core/thperson.cxx
+++ b/src/therion-core/thperson.cxx
@@ -28,6 +28,7 @@
 #include "thperson.h"
 #include "thdatabase.h"
 #include "thexception.h"
+#include "thparse.h"
 #include <string.h>
 
 #include <fmt/core.h>

--- a/src/therion-core/thpoint.cxx
+++ b/src/therion-core/thpoint.cxx
@@ -38,6 +38,7 @@
 #include "thobjectname.h"
 #include "therion.h"
 #include "thdataleg.h"
+#include "thparse.h"
 #include <string>
 #include <cstdio>
 

--- a/src/therion-core/thscan.cxx
+++ b/src/therion-core/thscan.cxx
@@ -38,6 +38,7 @@
 #include "thproj.h"
 #include "thtflength.h"
 #include "thtrans.h"
+#include "thparse.h"
 
 #include "stl_reader.h"
 

--- a/src/therion-core/thscrap.cxx
+++ b/src/therion-core/thscrap.cxx
@@ -40,6 +40,7 @@
 #include "thsketch.h"
 #include "thcsdata.h"
 #include "thdatabase.h"
+#include "thparse.h"
 #include "therion.h"
 
 #include <numbers>

--- a/src/therion-core/thscraplp.cxx
+++ b/src/therion-core/thscraplp.cxx
@@ -30,6 +30,7 @@
 #include "thexpmap.h"
 #include "thdatabase.h"
 #include "thdataleg.h"
+#include "thparse.h"
 #include "lxMath.h"
 
 thscraplp::thscraplp() {

--- a/src/therion-core/thselector.cxx
+++ b/src/therion-core/thselector.cxx
@@ -37,6 +37,7 @@
 #include <vector>
 #include "thchenc.h"
 #include "thmap.h"
+#include "thparse.h"
 #include "therion.h"
 
 thselector::thselector() {

--- a/src/therion-core/thsurface.cxx
+++ b/src/therion-core/thsurface.cxx
@@ -36,6 +36,7 @@
 #include "thdb1d.h"
 #include "thinfnan.h"
 #include "thproj.h"
+#include "thparse.h"
 #include "therion.h"
 #include <algorithm>
 #include <filesystem>

--- a/src/therion-core/thsurvey.cxx
+++ b/src/therion-core/thsurvey.cxx
@@ -32,6 +32,7 @@
 #include "thtfangle.h"
 #include "thinfnan.h"
 #include "thdatabase.h"
+#include "thparse.h"
 
 #include <fmt/core.h>
 

--- a/src/therion-core/thsvxctrl.cxx
+++ b/src/therion-core/thsvxctrl.cxx
@@ -39,6 +39,7 @@
 #include "thlogfile.h"
 #include "therion.h"
 #include "thlog.h"
+#include "thparse.h"
 #include "img.h"
 #include <math.h>
 #include <string>

--- a/src/therion-core/thsymbolset.cxx
+++ b/src/therion-core/thsymbolset.cxx
@@ -45,6 +45,7 @@
 #include "thdatabase.h"
 #include "therion.h"
 #include "thlog.h"
+#include "thparse.h"
 #include <fstream>
 
 thsymbolset::thsymbolset()

--- a/thchencdata/generate.pl
+++ b/thchencdata/generate.pl
@@ -100,7 +100,7 @@ $thtt_enum = "enum {\n$thtt_enum\t$ekey = $thtt_enum_val\n};\n";
 $thtt_encoding = "static const thstok thtt_encoding[] = {\n" .
   "$thtt_encoding_uc\t{\"$ENAME\",\t$ekey},\n" .
   "$thtt_encoding_lc\t{\"$ename\",\t$ekey},\n" .
-  "\t{NULL, TT_UNKNOWN_ENCODING}\n};\n";
+  "\t{nullptr, TT_UNKNOWN_ENCODING}\n};\n";
   
 # now let's generate encoding tables
 print "processing conversion tables: E$maxid, A$maxascii, U$maxunicode ... ";
@@ -161,7 +161,7 @@ print OUTPT <<ENDOUTPT;
 #ifndef thchencdata_cxx
 #define thchencdata_cxx
 
-#include <sys/types.h>
+#include <cstddef>
 
 
 /**
@@ -215,7 +215,7 @@ print OUTPT <<ENDOUTPT;
 #ifndef thchencdata_h
 #define thchencdata_h
 
-#include \"thparse.h\"
+#include \"thstok.h\"
 
 
 /**


### PR DESCRIPTION
I have started refactoring of thchencdata, but some files were relying on transitive includes, even thparse.cxx did not include thparse.h directly. I will move thchencdata in the next pull request.