### PR TITLE
Refactored macro thassert into a function

### DIFF
--- a/src/therion-core/therion.cxx
+++ b/src/therion-core/therion.cxx
@@ -182,3 +182,11 @@ void thexit(int exit_code)
   if (exit_code == EXIT_FAILURE) thcfg.xth_save();
   exit(exit_code);
 }
+
+void thassert(const bool cond, const std::source_location loc)
+{
+  if (!cond) {
+    thprint2err(fmt::format("{}{} ({}:{}): assertion failed ", (thtext_inline ? "\n" : ""), thexecute_cmd, loc.file_name(), loc.line()));
+    std::exit(EXIT_FAILURE);
+  }
+}

--- a/src/therion-core/therion.h
+++ b/src/therion-core/therion.h
@@ -30,11 +30,11 @@
  * --------------------------------------------------------------------
  */
  
-#ifndef therion_h
-#define therion_h
+#pragma once
 
-#include <stdlib.h>
 #include <fmt/format.h>
+
+#include <source_location>
 
 #ifdef THDEBUG
 #define thprint_error_src() thprint2err(fmt::format("{}{} (" __FILE__ ":{}): error -- ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__))
@@ -130,8 +130,11 @@ extern int therion_exit_state;
 void thprint_environment();
 void thprint_xtherion();
 
-#define thassert(expr) {if (!(expr)) {thprint2err(fmt::format("{}{} (" __FILE__ ":{}): assertion failed ", (thtext_inline ? "\n" : ""), thexecute_cmd, __LINE__));exit(EXIT_FAILURE);}}
-
-#endif
-
-
+/**
+ * Assert condition.
+ *
+ * If the condition is false, prints error message and exits the program.
+ * @param cond Condition to check.
+ * @param loc Source location for better debugging.
+ */
+void thassert(bool cond, std::source_location loc = std::source_location::current());

--- a/src/therion-core/thpic.cxx
+++ b/src/therion-core/thpic.cxx
@@ -73,7 +73,7 @@ void thpic::init(const char * pfname, const char * incfnm)
 
   std::error_code ec;
   auto pict_path = fs::current_path(ec);
-  thassert(!ec)
+  thassert(!ec);
 
   if (incfnm != NULL) {
     if (fs::path(incfnm).is_absolute())

--- a/src/therion-core/thscan.cxx
+++ b/src/therion-core/thscan.cxx
@@ -313,7 +313,7 @@ void thscan::parse_data_source(char ** args) {
 
   std::error_code ec;
   auto pict_path = fs::current_path(ec);
-  thassert(!ec)
+  thassert(!ec);
 
   if (fs::path(thdb.csrc.name).is_absolute())
 	  pict_path = thdb.csrc.name;

--- a/src/therion-core/thsurface.cxx
+++ b/src/therion-core/thsurface.cxx
@@ -213,7 +213,7 @@ void thsurface::parse_picture(char ** args)
 
   std::error_code ec;
   auto pict_path = fs::current_path(ec);
-  thassert(!ec)
+  thassert(!ec);
 
   if (fs::path(thdb.csrc.name).is_absolute())
 	  pict_path = thdb.csrc.name;


### PR DESCRIPTION
Macros are evil, let's use C++20 `std::source_location` instead.