### PR TITLE
Fixed compatibility with new fmt 12.2.0

### DIFF
--- a/src/therion-core/th2ddataobject.cxx
+++ b/src/therion-core/th2ddataobject.cxx
@@ -31,7 +31,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 th2ddataobject::th2ddataobject()
 {

--- a/src/therion-core/tharea.cxx
+++ b/src/therion-core/tharea.cxx
@@ -33,7 +33,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 tharea::tharea()
 {

--- a/src/therion-core/thconfig.cxx
+++ b/src/therion-core/thconfig.cxx
@@ -51,7 +51,7 @@
 #include <windows.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 
 enum {

--- a/src/therion-core/thcs.cxx
+++ b/src/therion-core/thcs.cxx
@@ -32,7 +32,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <map>
 #include <string>

--- a/src/therion-core/thdataobject.cxx
+++ b/src/therion-core/thdataobject.cxx
@@ -37,7 +37,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thdataobject::thdataobject()
 {

--- a/src/therion-core/thdatareader.cxx
+++ b/src/therion-core/thdatareader.cxx
@@ -32,7 +32,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 unsigned long thdatareader_get_opos(bool inlineid, bool cfgid)
 {

--- a/src/therion-core/thdate.cxx
+++ b/src/therion-core/thdate.cxx
@@ -28,7 +28,7 @@
 #include "thdate.h"
 #include "thexception.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <time.h>
 #include <locale.h>

--- a/src/therion-core/thdb2dji.cxx
+++ b/src/therion-core/thdb2dji.cxx
@@ -30,7 +30,7 @@
 #include "thexception.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thdb2dji::thdb2dji()
 {

--- a/src/therion-core/thendscrap.cxx
+++ b/src/therion-core/thendscrap.cxx
@@ -30,7 +30,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thendscrap::thendscrap()
 {

--- a/src/therion-core/thendsurvey.cxx
+++ b/src/therion-core/thendsurvey.cxx
@@ -30,7 +30,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thendsurvey::thendsurvey()
 {

--- a/src/therion-core/thepsparse.cxx
+++ b/src/therion-core/thepsparse.cxx
@@ -39,7 +39,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cmath>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include "thepsparse.h"

--- a/src/therion-core/thexception.cxx
+++ b/src/therion-core/thexception.cxx
@@ -1,6 +1,6 @@
 #include "thexception.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thexception::thexception(const std::string& msg)
     : std::runtime_error(msg)

--- a/src/therion-core/thjoin.cxx
+++ b/src/therion-core/thjoin.cxx
@@ -30,7 +30,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thjoin::thjoin()
 {

--- a/src/therion-core/thlang.cxx
+++ b/src/therion-core/thlang.cxx
@@ -33,7 +33,7 @@
 #include "thexception.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <map>
 

--- a/src/therion-core/thline.cxx
+++ b/src/therion-core/thline.cxx
@@ -35,7 +35,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <numbers>
 

--- a/src/therion-core/thlocale.cxx
+++ b/src/therion-core/thlocale.cxx
@@ -4,7 +4,7 @@
 #include "thlang.h"
 #include "thinit.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LCBUFFNUM 10
 #define LCBUFFLEN 1024

--- a/src/therion-core/thmap.cxx
+++ b/src/therion-core/thmap.cxx
@@ -36,7 +36,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thmap::thmap()
 {

--- a/src/therion-core/thpdf.cxx
+++ b/src/therion-core/thpdf.cxx
@@ -41,7 +41,7 @@
 #include <cmath>
 #include <regex>
 #include <numbers>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "thpdfdbg.h"
 #include "thconfig.h"

--- a/src/therion-core/thpdfdbg.cxx
+++ b/src/therion-core/thpdfdbg.cxx
@@ -26,7 +26,7 @@
  */
  
 #include <string>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "thpdfdbg.h"
 #include "thpdfdata.h"

--- a/src/therion-core/thperson.cxx
+++ b/src/therion-core/thperson.cxx
@@ -31,7 +31,7 @@
 #include "thparse.h"
 #include <string.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 void thperson::reset()
 {

--- a/src/therion-core/thsurvey.cxx
+++ b/src/therion-core/thsurvey.cxx
@@ -34,7 +34,7 @@
 #include "thdatabase.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thsurvey::thsurvey()
 {

--- a/src/therion-core/thsvg.cxx
+++ b/src/therion-core/thsvg.cxx
@@ -39,7 +39,7 @@
 #include <cfloat>
 #include <cmath>
 #include <numbers>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include "thepsparse.h"

--- a/src/therion-core/thtexfonts.cxx
+++ b/src/therion-core/thtexfonts.cxx
@@ -38,7 +38,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cmath>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "thtexfonts.h"
 #include "thtexenc.h"

--- a/src/therion-core/thtf.cxx
+++ b/src/therion-core/thtf.cxx
@@ -29,7 +29,7 @@
 #include "thexception.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 void thtf::parse_scale(char * sstr)
 {

--- a/src/therion-core/thtflength.cxx
+++ b/src/therion-core/thtflength.cxx
@@ -30,7 +30,7 @@
 #include "thexception.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 thtflength::thtflength() : thtf(TT_TFU_M) {}
 

--- a/src/therion-core/thtfpwf.cxx
+++ b/src/therion-core/thtfpwf.cxx
@@ -30,7 +30,7 @@
 #include "thinfnan.h"
 #include "thparse.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 

--- a/src/therion-core/thtmpdir.cxx
+++ b/src/therion-core/thtmpdir.cxx
@@ -29,7 +29,7 @@
 #include "therion.h"
 #include "thinit.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstdlib>
 #include <filesystem>


### PR DESCRIPTION
Header `fmt/core.h` no longer pulls in `fmt::format`, we need to replace it with `fmt/format.h`.