### PR TITLE
Renamed thbuffer::guarantee() to resize()

### DIFF
--- a/src/therion-core/th2ddataobject.cxx
+++ b/src/therion-core/th2ddataobject.cxx
@@ -175,8 +175,8 @@ void th2dsplitTT(char * src, char ** type, char ** subtype)
   size_t sl, x, tl, stl;
   char * t, * st;
   sl = strlen(src);
-  sTTtype.guarantee(sl+1);
-  sTTsubtype.guarantee(sl+1);
+  sTTtype.resize(sl+1);
+  sTTsubtype.resize(sl+1);
   t = sTTtype.data();
   st = sTTsubtype.data();
   t[0] = 0;

--- a/src/therion-core/thattr.cxx
+++ b/src/therion-core/thattr.cxx
@@ -724,7 +724,7 @@ void thattr::export_html(const char * fname, const char * title, int /*encoding*
   const char * value;
   bool header_value;
   thbuffer valb;
-  valb.guarantee(128);
+  valb.resize(128);
   std::string value_plus;
   for(oi = this->m_obj_list.begin(); oi != this->m_obj_list.end(); ++oi) {
     fprintf(f,"<tr id=\"%s\">", oi->m_tree_node_id);

--- a/src/therion-core/thbuffer.cxx
+++ b/src/therion-core/thbuffer.cxx
@@ -130,7 +130,7 @@ thbuffer & thbuffer::operator+=(const char * src)
   return *this;
 }
 
-void thbuffer::guarantee(size_t bs)
+void thbuffer::resize(size_t bs)
 {
   if (this->size <= bs)
     this->enlarge(bs);

--- a/src/therion-core/thbuffer.h
+++ b/src/therion-core/thbuffer.h
@@ -113,12 +113,12 @@ class thbuffer {
   
 
   /**
-   * Guarantee buffer size.
+   * Resize buffer size.
    *
    * @param bs Minimal buffer size.  
    */
    
-  void guarantee(size_t bs);
+  void resize(size_t bs);
   
   
   /**

--- a/src/therion-core/thchenc.cxx
+++ b/src/therion-core/thchenc.cxx
@@ -45,7 +45,7 @@ void thencode(thbuffer * dest, const char * src, int srcenc)
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
   // check buffer size
-  dest->guarantee(srcln + srcln + srcln + srcln + srcln + srcln);
+  dest->resize(srcln + srcln + srcln + srcln + srcln + srcln);
   dstp = (unsigned char *) dest->c_str();
   srcp = (unsigned char *) src;
   
@@ -104,7 +104,7 @@ void thdecode(thbuffer * dest, int destenc, const char * src)
   
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
-  dest->guarantee(srcln);  // check buffer size
+  dest->resize(srcln);  // check buffer size
   dstp = (unsigned char*) dest->c_str();
   srcp = (unsigned char*) src;
   char32_t sch = 0;    

--- a/src/therion-core/thconfig.cxx
+++ b/src/therion-core/thconfig.cxx
@@ -162,7 +162,7 @@ thconfig::thconfig()
 #ifdef THWIN32
   thbuffer * tmpbf = &(this->bf1);
   // set search path according to Windows registers
-  tmpbf->guarantee(1024);
+  tmpbf->resize(1024);
   DWORD type = 0, length = 1024;
   HKEY key;
   bool loaded_ok = true;

--- a/src/therion-core/thdb2d.cxx
+++ b/src/therion-core/thdb2d.cxx
@@ -3624,7 +3624,7 @@ void thdb2d::process_areas_in_projection(thdb2dprj * prj)
   if (!af)
     throw thexception("can't open file data.1");
   double n[6] = {};
-  com.guarantee(256);
+  com.resize(256);
   std::unique_ptr<thline> cln;
   char * buff = com.data();
   ti = todo.begin();

--- a/src/therion-core/thexpmap.cxx
+++ b/src/therion-core/thexpmap.cxx
@@ -2133,7 +2133,7 @@ if (ENC_NEW.NFSS==0) {
             fprintf(plf,"\",\n");      
       
       thbuffer texb;
-      texb.guarantee(128);
+      texb.resize(128);
       thdecode(& texb,TT_ISO8859_2,(strlen(cmap->map->title) > 0 ? cmap->map->title : cmap->map->name));      
       thdecode_tex(& encb, texb.c_str());
       fprintf(plf,"\t\tN => '%s',\n",encb.c_str());
@@ -3070,7 +3070,7 @@ thexpmap_xmps thexpmap::export_mp(thexpmapmpxs * out, class thscrap * scrap,
                 lp->point->export_mp(out);
                 fprintf(out->file,",");
                 lp->export_nextcp_mp(out);
-                thdb.buff_enc.guarantee(4096);
+                thdb.buff_enc.resize(4096);
                 //sprintf(thdb.buff_enc.data(),"%.0f",lp->rsize - out->layout->goz);
                 fprintf(out->file,",btex \\thwallaltitude %s etex);\n",utf2tex(out->layout->units.format_length(lp->rsize - out->layout->goz)).c_str());
 //                fprintf(out->file,",\"%.0f\");\n",lp->rsize);
@@ -3212,7 +3212,7 @@ void thexpmap::export_pdf_set_colors(class thdb2dxm * maps, class thdb2dprj * /*
   // urobi altitude legendu
   long xalt;
   thbuffer tmpb;
-  tmpb.guarantee(2048);
+  tmpb.resize(2048);
   if (addleg && (maxz > minz) && (this->layout->color_crit == TT_LAYOUT_CCRIT_ALTITUDE)) {
     for (xalt = 5; xalt >= 0; xalt--) {
       curz = double(xalt) / 5.0 * (maxz - minz) + minz;

--- a/src/therion-core/thinit.cxx
+++ b/src/therion-core/thinit.cxx
@@ -307,7 +307,7 @@ void thinit::load()
 
 #ifdef THWIN32
   // set cavern path according to Windows registers
-  this->path_cavern.guarantee(1024);
+  this->path_cavern.resize(1024);
   thmbuffer mbf;
   thbuffer bf;
   DWORD type(0), length = 1024;

--- a/src/therion-core/thmapstat.cxx
+++ b/src/therion-core/thmapstat.cxx
@@ -434,8 +434,8 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
   bool show_count;
   show_count = false;
   double clen, z_top, z_bot;
-  c.guarantee(256);
-  b.guarantee(256);
+  c.resize(256);
+  b.resize(256);
 
   if (!thcfg.reproducible_output)
     fprintf(f,"\\thversion={%s}\n",utf2tex(THVERSION).c_str());

--- a/src/therion-core/thparse.cxx
+++ b/src/therion-core/thparse.cxx
@@ -550,7 +550,7 @@ void thdecode_c(thbuffer * dest, const char * src)
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
   unsigned num;
-  dest->guarantee(srcln * 8 + 1);  // check buffer size
+  dest->resize(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
   dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
@@ -600,7 +600,7 @@ void thdecode_tcl(thbuffer * dest, const char * src)
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
   unsigned num;
-  dest->guarantee(srcln * 8 + 1);  // check buffer size
+  dest->resize(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
   dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
@@ -635,7 +635,7 @@ void thdecode_mp(thbuffer * dest, const char * src)
 {
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
-  dest->guarantee(srcln * 8 + 1);  // check buffer size
+  dest->resize(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
   dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
@@ -676,7 +676,7 @@ void thdecode_tex(thbuffer * dest, const char * src)
   size_t srcln = strlen(src), srcx = 0;
   unsigned char * srcp, * dstp;
 //  unsigned num;
-  dest->guarantee(srcln * 8 + 1);  // check buffer size
+  dest->resize(srcln * 8 + 1);  // check buffer size
   srcp = (unsigned char*) src;
   dstp = (unsigned char*) dest->c_str();
   while (srcx < srcln) {
@@ -809,7 +809,7 @@ void thdecode_sql(thbuffer * dest, const char * src)
     *dest = "NULL";
     return;
   }
-  dest->guarantee(srcln * 8 + 3);  // check buffer size
+  dest->resize(srcln * 8 + 3);  // check buffer size
   srcp = (unsigned char*) src;
   dstp = (unsigned char*) dest->c_str();
   *dstp = '\'';
@@ -865,7 +865,7 @@ void thdecode_arg(thbuffer * dest, const char * src)
   }
   
   // zaciatocna uvodzovka
-  dest->guarantee(srcln * 8 + 3);  // check buffer size
+  dest->resize(srcln * 8 + 3);  // check buffer size
   srcx = 0;
   srcp = (unsigned char*) src;
   dstp = (unsigned char*) dest->c_str();
@@ -1121,7 +1121,7 @@ const char * thutf82xhtml(const char * src)
   size_t sx, dx, sl = strlen(src);
   bool inspec;
   char * res;
-  tmp.guarantee(sl);
+  tmp.resize(sl);
   res = tmp.data();
 
   inspec = false;

--- a/src/therion-core/thpoint.cxx
+++ b/src/therion-core/thpoint.cxx
@@ -387,7 +387,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
   std::string attr_text;
   int macroid = -1, omacroid = -1, cmark;
   const char * postprocess_label = NULL;
-  this->db->buff_enc.guarantee(8128);
+  this->db->buff_enc.resize(8128);
 //  char * buff = this->db->buff_enc.data();
   double xrr = (thisnan(this->orient) ? out->rr : 0.0);
 

--- a/src/therion-core/thsvxctrl.cxx
+++ b/src/therion-core/thsvxctrl.cxx
@@ -489,7 +489,7 @@ void thsvxctrl::process_survey_data(class thdatabase * dbp)
 //   double sx, sy, sz;
 //   unsigned long ss;
 //   size_t lnsize = 4096, pix = 0, ppx = 0, clns;
-//   svxcom.guarantee(lnsize);
+//   svxcom.resize(lnsize);
 //   char * lnbuff = svxcom.data(),
 //     * p[4], * cps = lnbuff;
 //   posf.open(thtmp.get_file_name("data.pos"));


### PR DESCRIPTION
Renamed `thbuffer::guarantee()` to `resize()` to bring thbuffer's API closer to `std::string`.