### PR TITLE
Refactor macros in thinfnan.h

### DIFF
--- a/src/therion-core/thdb1d.cxx
+++ b/src/therion-core/thdb1d.cxx
@@ -419,7 +419,7 @@ void thdb1d::scan_data()
                 lei->total_dy = (lei->direction ? 1.0 : -1.0) * lei->dy;
                 lei->total_dz = (lei->direction ? 1.0 : -1.0) * lei->dz;
                 lei->total_length = thdxyz2length(lei->total_dx,lei->total_dy,lei->total_dz);
-                lei->total_bearing = thdxyz2bearing(lei->total_dx,lei->total_dy,lei->total_dz);
+                lei->total_bearing = thdxyz2bearing(lei->total_dx,lei->total_dy);
                 lei->total_gradient = thdxyz2clino(lei->total_dx,lei->total_dy,lei->total_dz);
                 if (lei->infer_plumbs && (!lei->plumbed)) {
                   lei->plumbed = (lei->dx == 0.0) && (lei->dy == 0.0) && (lei->dz != 0.0);

--- a/src/therion-core/thexpdb.cxx
+++ b/src/therion-core/thexpdb.cxx
@@ -353,9 +353,9 @@ void thexpdb::export_sql_file(class thdatabase * dbp)
                   "%ld, %ld, %ld, %ld, %.3f, %.2f, %.2f, %.3f, %.2f, %.2f, %.3f, %.2f, %.2f);\n",
                   ++shotx, lei->from.id, lei->to.id, dp->id,
                   sql_double(lei->total_length), sql_double(lei->total_bearing), sql_double(lei->total_gradient),
-				  sql_double(thdxyz2length(adx, ady, adz)), sql_double(thdxyz2bearing(adx, ady, adz)), sql_double(thdxyz2clino(adx, ady, adz)),
+				  sql_double(thdxyz2length(adx, ady, adz)), sql_double(thdxyz2bearing(adx, ady)), sql_double(thdxyz2clino(adx, ady, adz)),
 				  sql_double(thdxyz2length(adx - lei->total_dx, ady - lei->total_dy, adz - lei->total_dz)),
-				  sql_double(thdxyz2bearing(adx - lei->total_dx, ady - lei->total_dy, adz - lei->total_dz)),
+				  sql_double(thdxyz2bearing(adx - lei->total_dx, ady - lei->total_dy)),
 				  sql_double(thdxyz2clino(adx - lei->total_dx, ady - lei->total_dy, adz - lei->total_dz))
                   );
                 if ((lei->flags & TT_LEGFLAG_SURFACE) != TT_LEGFLAG_NONE)

--- a/src/therion-core/thinfnan.cxx
+++ b/src/therion-core/thinfnan.cxx
@@ -52,3 +52,28 @@ bool thdefinitely_less_than(double a, double b, double epsilon)
 {
     return (b - a) > ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * epsilon);
 }
+
+double thnanpow2(double number)
+{
+    return (thisnan(number) ? 0.0 : number) * (thisnan(number) ? 0.0 : number);
+}
+
+double thdxyz2length(double dx, double dy, double dz)
+{
+    return sqrt(thnanpow2(dx) + thnanpow2(dy) + thnanpow2(dz));
+}
+
+double thdxyz2b(double dx, double dy)
+{
+    return 270 - (atan2(dy,dx) / THPI * 180.0 + 180);
+}
+
+double thdxyz2bearing(double dx, double dy)
+{
+    return thdxyz2b(dx,dy) < 0.0 ? thdxyz2b(dx,dy) + 360.0 : thdxyz2b(dx,dy);
+}
+
+double thdxyz2clino(double dx, double dy, double dz)
+{
+    return atan2(dz,sqrt(thnanpow2(dx) + thnanpow2(dy))) / THPI * 180.0;
+}

--- a/src/therion-core/thinfnan.h
+++ b/src/therion-core/thinfnan.h
@@ -26,8 +26,7 @@
  * --------------------------------------------------------------------
  */
  
-#ifndef thinfnan_h
-#define thinfnan_h
+#pragma once
 
 #include <cmath>
 #include <cfloat>
@@ -94,14 +93,10 @@ bool thessentially_equal(double a, double b, double epsilon);
 bool thdefinitely_greater_than(double a, double b, double epsilon);
 bool thdefinitely_less_than(double a, double b, double epsilon);
 
+inline constexpr double THPI = 3.1415926535898;
 
-// infnan.h
-#endif
-
-#define THPI 3.1415926535898
-#define thnanpow2(cislo) ((thisnan(cislo) ? 0.0 : cislo) * (thisnan(cislo) ? 0.0 : cislo))
-#define thdxyz2length(dx,dy,dz) (sqrt(thnanpow2(dx) + thnanpow2(dy) + thnanpow2(dz)))
-#define thdxyz2b(dx,dy,dz) (270 - (atan2(dy,dx) / THPI * 180.0 + 180))
-#define thdxyz2bearing(dx,dy,dz) (thdxyz2b(dx,dy,dz) < 0.0 ? thdxyz2b(dx,dy,dz) + 360.0 : thdxyz2b(dx,dy,dz))
-#define thdxyz2clino(dx,dy,dz) (atan2(dz,sqrt(thnanpow2(dx) + thnanpow2(dy))) / THPI * 180.0)
-
+double thnanpow2(double number);
+double thdxyz2length(double dx, double dy, double dz);
+double thdxyz2b(double dx, double dy);
+double thdxyz2bearing(double dx, double dy);
+double thdxyz2clino(double dx, double dy, double dz);


### PR DESCRIPTION
I have refactored some macros into normal functions, and `THPI` into a constexpr constant. Third argument of `thdxyz2bearing()` was unused so I have removed it, please check that.