### PR TITLE
Various C++ improvements

### DIFF
--- a/loch/lxData.cxx
+++ b/loch/lxData.cxx
@@ -309,7 +309,7 @@ void lxData::Rebuild()
     sv.m_parent = sv_it->m_parent;
     sv.m_level = 0;
     sv.m_full_name = sv.m_name;
-    if (this->m_selected_surveys.size() == 0)
+    if (this->m_selected_surveys.empty())
     	sv.m_selected = true;
     else
     	sv.m_selected = (this->m_selected_surveys.find(sv.m_id) != this->m_selected_surveys.end());

--- a/loch/lxWX.h
+++ b/loch/lxWX.h
@@ -120,11 +120,11 @@ protected:
 	bool CheckValidator()	const
 	{
 		wxCHECK_MSG( m_validatorWindow,	FALSE,
-			_T("No	window associated	with validator") );
+			_T("No window associated with validator") );
 		wxCHECK_MSG( m_validatorWindow->IsKindOf(CLASSINFO(wxTextCtrl)), FALSE,
-			_T("wxNumberValidator is	only for wxTextCtrl's")	);
+			_T("wxNumberValidator is only for wxTextCtrl's")	);
 		wxCHECK_MSG( dynamic_cast<wxTextCtrl*>(m_validatorWindow)->IsSingleLine(),	FALSE,
-			_T("Multiline wxTextCtrl	not	allowed	yet")	);
+			_T("Multiline wxTextCtrl not allowed yet")	);
 
 		return TRUE;
 	}
@@ -155,7 +155,7 @@ protected:
 	bool CheckValidator()	const
 	{
 		wxCHECK_MSG( m_validatorWindow,	FALSE,
-			_T("No	window associated	with validator") );
+			_T("No window associated with validator") );
 		wxCHECK_MSG( m_validatorWindow->IsKindOf(CLASSINFO(wxRadioButton)), FALSE,
 			_T("wxRadioBtnValidator is only for wxRadioButtons")	);
 

--- a/src/common-utils/lxFile.h
+++ b/src/common-utils/lxFile.h
@@ -7,9 +7,9 @@
 #include <cstdint>
 #include <vector>
 
-typedef char * lxFileBuff;
+using lxFileBuff = char*;
 
-#define lxFileSizeT uint32_t
+using lxFileSizeT = uint32_t;
 
 #define lxassert(expr) if (!(expr)) std::exit(1);
 

--- a/src/therion-core/thdb1d.cxx
+++ b/src/therion-core/thdb1d.cxx
@@ -57,8 +57,10 @@
 
 #include <fmt/format.h>
 
-//#define THUSESVX
-//#define THDEBUG
+[[noreturn]] static void report_problem(const std::source_location loc = std::source_location::current())
+{
+  throw thexception(fmt::format("a software BUG is present ({}:{})", loc.file_name(), loc.line()));
+}
 
 thdb1d_tree_arrow::thdb1d_tree_arrow() : is_discovery(false), is_nosurvey(false), is_reversed(false),
   start_node(NULL), end_node(NULL), 
@@ -694,8 +696,8 @@ void thdb1d::scan_data()
     else
       thwarning("unable to determine magnetic declination used for undated surveys");
     thprint("undated surveys:\n");
-    for(auto usi = undated_surveys_set.begin(); usi != undated_surveys_set.end(); usi++) {
-      thprint(usi->c_str());
+    for (const auto& us : undated_surveys_set) {
+      thprint(us);
       thprint("\n");
     }
   }
@@ -1058,7 +1060,7 @@ void thdb1d::process_tree()
       
       // something is wrong
       if (n2 == NULL) {
-        throw thexception(fmt::format("a software BUG is present (" __FILE__ ":{})", __LINE__));
+        report_problem();
 //#ifdef THDEBUG
 //        thprint("warning -- not all stations connected to the network\n");
 //#endif
@@ -2430,7 +2432,7 @@ void thdb1d::close_loops()
 		));
 #endif
     if (froms->placed == 0)
-      throw thexception(fmt::format("a software BUG is present (" __FILE__ ":{})", __LINE__));
+      report_problem();
     if (tos->placed == 0) {
       tos->placed += 1;
       if (cleg->reverse) {
@@ -2553,7 +2555,6 @@ void thdb1d::close_loops()
       ps->y = froms->y;
       ps->z = froms->z;
       if (ps->placed == 0) {
-//        ththrow("a software BUG is present (" __FILE__ ":{})", __LINE__);
         throw thexception(fmt::format("can not connect {}@{} to centerline network",
           this->station_vec[i].name,
           this->station_vec[i].survey->get_full_name()));

--- a/src/therion-core/thdouble.h
+++ b/src/therion-core/thdouble.h
@@ -19,20 +19,18 @@ struct thdouble
  * @param value value intended for printing
  * @return thdouble with precision set to 2
  */
-inline constexpr thdouble operator""_thd(long double value)
+constexpr thdouble operator""_thd(long double value)
 {
     return {static_cast<double>(value), 2};
 }
 
-namespace fmt
-{
 /**
  * @brief Extension for {fmt} for printing thdouble.
  * Will print floating point numbers in fixed format
  * and without trailing zeros.
  */
 template <>
-struct formatter<thdouble>: formatter<std::string> {
+struct fmt::formatter<thdouble>: formatter<std::string> {
     template <typename FormatContext>
     auto format(const thdouble& p, FormatContext& ctx) const {
         // fixed formatting with given precision
@@ -55,4 +53,3 @@ struct formatter<thdouble>: formatter<std::string> {
             ->formatter<std::string>::format(num, ctx);
     }
 };
-}

--- a/src/therion-core/thepsparse.cxx
+++ b/src/therion-core/thepsparse.cxx
@@ -1555,7 +1555,7 @@ void thgraphics2pdf() {
       patt.data.print_pdf(F,patt.name);
       F << "}" << tex_set_ref(tex_Pname(ALL_PATTERNS[patt.name]), "\\pdflastobj") << "\n";
   }
-  if (GRADIENTS.size() > 0) F << "% GRADIENTS:\n";
+  if (!GRADIENTS.empty()) F << "% GRADIENTS:\n";
   for (auto &g: GRADIENTS) {
       F << "\\immediate\\pdfobj {<< /Type /Pattern /PatternType 2 /Shading <<\n";
       F << fmt::format("/ShadingType {:d} /ColorSpace /Device{:s}\n", g.second.type == gradient_lin ? 2 : 3, g.second.c0.model == colormodel::grey ? "Gray" : (g.second.c0.model == colormodel::cmyk ? "CMYK" : "RGB"));

--- a/src/therion-core/thexpmap.cxx
+++ b/src/therion-core/thexpmap.cxx
@@ -129,7 +129,7 @@ void thexpmap_log_log_file(const char * logfpath, const char * on_title, const c
   while (!(lf.eof())) {
     std::getline(lf, lnbuff);
     if (mpbug && (!skip_this)) {
-      if (lnbuff.substr(0, 5) == "write") {
+      if (lnbuff.starts_with("write")) {
         skip_next = true;
         skip_this = true;
         peoln = false;
@@ -1522,7 +1522,7 @@ if (ENC_NEW.NFSS==0) {
   thsurface * surf;
   double surfscl = this->layout->scale * 11811.023622472446117783;
     
-  if (COLORLEGENDLIST.size() > 0) {
+  if (!COLORLEGENDLIST.empty()) {
     fprintf(plf,"# COLOR LEGEND\n");
     for (std::list<colorlegendrecord>::iterator cli = COLORLEGENDLIST.begin();
       cli != COLORLEGENDLIST.end(); cli++) {
@@ -2290,11 +2290,11 @@ if (ENC_NEW.NFSS==0) {
     if ((this->layout->m_lookup != NULL) && (strlen(this->layout->m_lookup->m_title) > 0)) {
       ldata.colorlegendtitle = this->layout->m_lookup->m_title;
     }
-    fprintf(tf,"\\colorlegendtitle={%s}\n", utf2tex(ldata.colorlegendtitle.c_str()).c_str());
+    fprintf(tf,"\\colorlegendtitle={%s}\n", utf2tex(ldata.colorlegendtitle).c_str());
   }
 
   // ak neni atlas, tak nastavi legendcavename
-  fprintf(tf,"\\cavename={%s}\n",ths2tex(tit.c_str(), this->layout->lang).c_str());
+  fprintf(tf,"\\cavename={%s}\n",ths2tex(tit, this->layout->lang).c_str());
   ldata.cavename = tit.c_str();
   ldata.comment = "";
 

--- a/src/therion-core/thexpuni.cxx
+++ b/src/therion-core/thexpuni.cxx
@@ -538,7 +538,7 @@ void thexpmap::export_kml(class thdb2dxm * maps, class thdb2dprj * prj)
           if (cmi->type == TT_MAPITEM_NORMAL) {
             scrap = dynamic_cast<thscrap*>(cmi->object);
             xu.parse_scrap(scrap);
-            if (xu.m_part_list.size() > 0) {
+            if (!xu.m_part_list.empty()) {
               fprintf(out,"<Polygon>\n");
               first_outer = true;
               std::list<thexpuni_part>::iterator it;
@@ -559,7 +559,7 @@ void thexpmap::export_kml(class thdb2dxm * maps, class thdb2dprj * prj)
                     ip->m_x, ip->m_y, scrap->z, x, y, z);
                   fprintf(out, "\t%.14f,%.14f,%.14f ", x / THPI * 180.0, y / THPI * 180.0, 0.0);
                 }
-                if (it->m_point_list.size() > 0) {
+                if (!it->m_point_list.empty()) {
                 	ip = it->m_point_list.begin();
                     thcs2cs(thcfg.outcs, TTCS_LONG_LAT,
                       ip->m_x, ip->m_y, scrap->z, x, y, z);
@@ -746,7 +746,7 @@ void thexpmap::export_dxf(class thdb2dxm * maps, class thdb2dprj * /*prj*/) // T
           if (cmi->type == TT_MAPITEM_NORMAL) {
             scrap = dynamic_cast<thscrap*>(cmi->object);
             xu.parse_scrap(scrap);
-            if (xu.m_part_list.size() > 0) {
+            if (!xu.m_part_list.empty()) {
               double x(0.0), y(0.0), z(0.0), px(0.0), py(0.0);
               bool inside;
               std::list<thexpuni_part>::iterator it;

--- a/src/therion-core/thinput.cxx
+++ b/src/therion-core/thinput.cxx
@@ -142,9 +142,9 @@ thinput::thinput()
   this->cmd_sensitivity = true;
   this->input_sensitivity = true;
   this->scan_search_path = false;
-  this->first_ptr = std::unique_ptr<ifile>(new ifile(nullptr));
+  this->first_ptr = std::make_unique<ifile>(nullptr);
   this->last_ptr = this->first_ptr.get();
-  this->lnbuffer = std::unique_ptr<char[]>(new char [thinput::max_line_size]);
+  this->lnbuffer = std::make_unique<char[]>(thinput::max_line_size);
   this->pifo = false;
   this->pifoid = nullptr;
   this->pifoproc = nullptr;
@@ -249,7 +249,7 @@ void thinput::open_file(const char * fname)
   while (ifptr->sh.is_open() && (ifptr->next_ptr != nullptr))
     ifptr = ifptr->next_ptr.get();
   if (ifptr->sh.is_open() && (ifptr->next_ptr == nullptr)) {
-    ifptr->next_ptr = std::unique_ptr<ifile>(new ifile(ifptr));
+    ifptr->next_ptr = std::make_unique<ifile>(ifptr);
     ifptr = ifptr->next_ptr.get();
   }
   
@@ -467,7 +467,7 @@ char * thinput::read_line()
         continue;
         
       // interpret commands
-      switch (thmatch_token(this->cmdbf.c_str(), thtt_input)) {
+      switch (thmatch_token(this->cmdbf, thtt_input)) {
       
         case TT_INPUT:
           if (this->input_sensitivity) {
@@ -606,11 +606,11 @@ int thinput::get_cif_encoding()
   return this->last_ptr->encoding;
 }
 
-void thinput::print_if_opened(void (* pifop)(char *), bool * printed) {
+void thinput::print_if_opened(std::function<void(char*)> pifop, bool * printed) {
   this->pifo = true;
   if (printed != nullptr)
     this->pifoid = printed;
-  this->pifoproc = pifop;
+  this->pifoproc = std::move(pifop);
 }
 
 

--- a/src/therion-core/thinput.h
+++ b/src/therion-core/thinput.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "thmbuffer.h"
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -54,7 +55,7 @@ private:
   thmbuffer search_path,  ///< Search paths.
     file_suffix,  ///< File suffixes.
     tmpmb;   ///< Temporary multi buffer.
-  void (* pifoproc)(char *);  ///< Function to call if file was opened.
+   std::function<void(char*)> pifoproc;  ///< Function to call if file was opened.
   std::string linebf,  ///< Line buffer.
     cmdbf,  ///< Command buffer.
     valuebf;  ///< Value buffer.
@@ -217,7 +218,7 @@ public:
   /**
    * Text to print some file was opened.
    */
-  void print_if_opened(void (* pifop)(char *), bool * printed);
+  void print_if_opened(std::function<void(char*)> pifop, bool * printed);
   
   /**
    * @brief Report if the file is missing.

--- a/src/therion-core/thlayout.cxx
+++ b/src/therion-core/thlayout.cxx
@@ -1717,7 +1717,6 @@ void thlayout::export_pdftex(FILE * o, thdb2dprj * /*prj*/, char mode) { // TODO
 
 void thlayout::export_mpost(FILE * o) {
 
-  bool anyline = false;
   const char * last_path = "";
   for (auto ln = lines.begin(); ln != lines.end(); ++ln) {
       if (ln->code == TT_LAYOUT_CODE_METAPOST) {
@@ -1725,15 +1724,10 @@ void thlayout::export_mpost(FILE * o) {
           last_path = ln->path;
           fprintf(o, "includeprefix := \"%s\";\n", fix_path_slashes(last_path).c_str());
         }
-        anyline = true;
         thdecode(&(this->db->buff_enc), TT_ISO8859_2, ln->line);
         fprintf(o, "%s\n", this->db->buff_enc.c_str());
       }
   }
-  
-  if (!anyline) {
-  }
-
 }
 
 

--- a/src/therion-core/thlookup.cxx
+++ b/src/therion-core/thlookup.cxx
@@ -445,7 +445,7 @@ void thlookup::export_color_legend(thlayout * layout) {
               clrec.name += tli->m_valueDate.get_str(TT_DATE_FMT_UTF8_Y);
             if (clrec.name.size() == 0)
               clrec.name = thT("not specified",layout->lang);
-            clrec.texname = utf2tex(clrec.name.c_str());
+            clrec.texname = utf2tex(clrec.name);
             break;
           default:
             clrec.texname = "";
@@ -474,7 +474,7 @@ void thlookup::export_color_legend(thlayout * layout) {
             }
             if (clrec.name.size() == 0)
               clrec.name = thT("not specified",layout->lang);
-            clrec.texname = utf2tex(clrec.name.c_str());
+            clrec.texname = utf2tex(clrec.name);
             break;
         }
       }

--- a/src/therion-core/thmapstat.cxx
+++ b/src/therion-core/thmapstat.cxx
@@ -295,7 +295,7 @@ void thmapstat_print_team(FILE * f, thmapstat_personmap & team_map, const char *
 			ditem.crit = pi->second.crit;
 		pd.push_back(ditem);
     }
-    if ((pd.size() > 0) && (max_items != 0)) {
+    if (!pd.empty() && (max_items != 0)) {
     	std::sort(pd.begin(), pd.end());
     	unsigned long maxcnt(pd.size());
     	if (max_items > 0)
@@ -343,7 +343,7 @@ void thmapstat_print_copy(FILE * f, thmapstat_copyrightmap & copy_map, const cha
 			ditem.crit = pi->second.crit;
 		pd.push_back(ditem);
     }
-    if ((pd.size() > 0) && (max_items != 0)) {
+    if (!pd.empty() && (max_items != 0)) {
         fprintf(f, "%s", utf2tex(teamstr).c_str());
     	std::sort(pd.begin(), pd.end());
     	unsigned long maxcnt(pd.size());
@@ -485,7 +485,7 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
     //b += thT("units m",layout->lang);
     b += layout->units.format_i18n_length_units();
     fprintf(f,"\\cavelengthtitle={%s}\n",utf2tex(thT("title cave length",layout->lang)).c_str());
-    fprintf(f,"\\cavelength={%s}\n",utf2tex(b.c_str()).c_str());
+    fprintf(f,"\\cavelength={%s}\n",utf2tex(b).c_str());
     ldata->cavelength = thutf82xhtml(b.c_str());
     ldata->cavelengthtitle = thT("title cave length",layout->lang);
   }
@@ -501,17 +501,17 @@ void thmapstat::export_pdftex(FILE * f, class thlayout * layout, legenddata * ld
     //b += thT("units m",layout->lang);
     b += layout->units.format_i18n_length_units();
     fprintf(f,"\\cavedepthtitle={%s}\n",utf2tex(thT("title cave depth",layout->lang)).c_str());
-    fprintf(f,"\\cavedepth={%s}\n",utf2tex(b.c_str()).c_str());
+    fprintf(f,"\\cavedepth={%s}\n",utf2tex(b).c_str());
     ldata->cavedepth = thutf82xhtml(b.c_str());
     ldata->cavedepthtitle = thT("title cave depth",layout->lang);
 	b = layout->units.format_length(z_top);
     //b += "<thsp>";
     //b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\cavemaxz={%s}\n",utf2tex(b.c_str()).c_str());
+    fprintf(f,"\\cavemaxz={%s}\n",utf2tex(b).c_str());
 	b = layout->units.format_length(z_bot);
     //b += "<thsp>";
     //b += layout->units.format_i18n_length_units();
-    fprintf(f,"\\caveminz={%s}\n",utf2tex(b.c_str()).c_str());
+    fprintf(f,"\\caveminz={%s}\n",utf2tex(b).c_str());
 
   }
   

--- a/src/therion-core/thpoint.cxx
+++ b/src/therion-core/thpoint.cxx
@@ -610,7 +610,7 @@ bool thpoint::export_mp(class thexpmapmpxs * out)
         }
         this->db->buff_enc.assign((this->tags & (TT_POINT_TAG_HEIGHT_PQ |
             TT_POINT_TAG_HEIGHT_NQ | TT_POINT_TAG_HEIGHT_UQ)) != 0 ? "?" : "" );
-        fprintf(out->file,"%s etex,",utf2tex(this->db->buff_enc.c_str()).c_str());
+        fprintf(out->file,"%s etex,",utf2tex(this->db->buff_enc).c_str());
         postprocess_label = "p_label_mode_height";
       }
       postprocess = false;

--- a/src/therion-core/thproj.cxx
+++ b/src/therion-core/thproj.cxx
@@ -475,7 +475,7 @@ int thcs_parse_gridhandling(const char * s) {
 }
 
 void thcs_log_transf_used() {
-  if (precise_transf.size() > 0) {
+  if (!precise_transf.empty()) {
     thlog("\n################# custom transformations used ##################\n");
     for (auto &j: precise_transf) {
       thlog(fmt::format("  [{} → {}] definition: [{}]\n", thcs_get_name(j.first.first), thcs_get_name(j.first.second), j.second));

--- a/src/therion-core/thscrap.cxx
+++ b/src/therion-core/thscrap.cxx
@@ -1478,11 +1478,11 @@ void thscrap::parse_sketch(char ** args, int /*argenc*/) // TODO unused paramete
   // X
   thparse_double(sv,sk.m_x,args[1]);
   if ((sv	!= TT_SV_NUMBER) &&	(sv	!= TT_SV_NAN))
-    throw thexception(fmt::format("invalid	number --	{}", args[1]));
+    throw thexception(fmt::format("invalid number -- {}", args[1]));
   // Y
   thparse_double(sv,sk.m_y,args[2]);
   if ((sv	!= TT_SV_NUMBER) &&	(sv	!= TT_SV_NAN))
-    throw thexception(fmt::format("invalid	number --	{}", args[2]));
+    throw thexception(fmt::format("invalid number -- {}", args[2]));
   this->sketch_list.push_back(std::move(sk));
 }
 

--- a/src/therion-core/thscrapis.cxx
+++ b/src/therion-core/thscrapis.cxx
@@ -140,7 +140,7 @@ void thscrapis::insert_outline_lnsegment(bool newsegment, thline * line,
   bool first_point = true;
   std::list <thscrapislns> :: iterator it;
   thscrapisolpt * cpt;
-  if (tmplist.size() == 0)
+  if (tmplist.empty())
     return;
   if (reverse) {
     it = tmplist.end();
@@ -238,9 +238,9 @@ struct int3df {
   bool m_single, m_dim, m_pos, m_dir, m_setdim;
   thvec2 m_pf, m_pt;
   thline2 m_lf, m_lt, m_ln;
-  double m_lnl;
+  double m_lnl{};
   lxVec m_posf, m_post, m_direction;
-  double m_upf, m_upt, m_dnf, m_dnt;
+  double m_upf{}, m_upt{}, m_dnf{}, m_dnt{};
 
   int3df() : m_single(true), m_dim(false), m_pos(false), m_dir(false), m_setdim(false) {}
   

--- a/src/therion-core/thsvxctrl.cxx
+++ b/src/therion-core/thsvxctrl.cxx
@@ -768,8 +768,6 @@ void thsvxctrl::load_err_file(class thdatabase * dbp, const char * lfnm) {
 //								thprint("LEG not found!!!\n");
 							}
 						}
-						else if (strcmp(b.get_buffer()[i-1],"=") == 0) {
-						}
 						prev_st = st;
 					}
 				}

--- a/src/therion-core/thsymbolset.cxx
+++ b/src/therion-core/thsymbolset.cxx
@@ -79,7 +79,7 @@ void thsymbolset_log_log_file(const char * logfpath, const char * on_title, cons
   while (!(lf.eof())) {
     std::getline(lf, lnbuff);
     if (mpbug && (!skip_this)) {
-      if (lnbuff.substr(0, 5) == "write") {
+      if (lnbuff.starts_with("write")) {
         skip_next = true;
         skip_this = true;
         peoln = false;


### PR DESCRIPTION
Fixed a variety of smaller issues, mostly reported by `SonarCloud`:
* Do not use method `size()` to check container emptiness.
* Do not use (unescaped) tabs in string literals.
* Use type aliases (`using`) instead of `#define` or `typedef` in `lxFile.h`.
* Replaced macros `__FILE__` and `__LINE__` with `std::source_location`.
* Removed redundant calls to `c_str()`.
* Constexpr functions do not need to be explicitly marked as `inline`.
* We do not need to open namespace `fmt` to introduce a new formatter.
* Use `std::string::starts_with()`.
* Use `std::make_unique<>()`.
* Replaced raw function pointer with `std::function`.
* Removed useless conditions in `thlayout.cxx` and `thsvxctrl.cxx`.
* Initialize member variables.