### PR TITLE
Refactor case insensitive comparators

### DIFF
--- a/src/common-utils/icase.cxx
+++ b/src/common-utils/icase.cxx
@@ -10,12 +10,12 @@ static auto lower_range(std::string_view s)
      return std::views::transform(s, [](const unsigned char c){ return std::tolower(c); });
 }
 
-bool icase_equals(std::string_view a, std::string_view b)
+bool icase_equal::operator()(std::string_view a, std::string_view b) const
 {
      return std::ranges::equal(lower_range(a), lower_range(b));
 }
 
-bool icase_less_than(std::string_view a, std::string_view b)
+bool icase_less::operator()(std::string_view a, std::string_view b) const
 {
      return std::ranges::lexicographical_compare(lower_range(a), lower_range(b));
 }

--- a/src/common-utils/icase.h
+++ b/src/common-utils/icase.h
@@ -3,11 +3,17 @@
 #include <string_view>
 
 /**
- * @brief Case insensitive comparison of two strings.
- */ 
-bool icase_equals(std::string_view a, std::string_view b);
+ * @brief Case insensitive equality comparator for strings.
+ */
+struct icase_equal
+{
+    bool operator()(std::string_view a, std::string_view b) const;
+};
 
 /**
- * @brief Case insensitive ordering of two strings.
- */ 
-bool icase_less_than(std::string_view a, std::string_view b);
+ * @brief Case insensitive ordering comparator for strings.
+ */
+struct icase_less
+{
+    bool operator()(std::string_view a, std::string_view b) const;
+};

--- a/src/common-utils/lxFile.cxx
+++ b/src/common-utils/lxFile.cxx
@@ -9,7 +9,6 @@
 #include <fstream>
 #include <filesystem>
 
-#include "icase.h"
 #include "lxMath.h"
 #include "img.h"
 
@@ -708,22 +707,9 @@ void lxFile::ImportPLT(const char * fn)
   stPtrPrev = 0;
   bool hasPT = false;
 
-  char * sname = new char [strlen(fn)+1];
-  int x, xx;
-  xx = 0;
-  for (x = (strlen(fn) - 1); x >= 0; x--) {
-    if ((fn[x] == '\\') || (fn[x] == '/')) {
-      xx = x + 1;
-      break;
-    }
-  }
-  for (x = xx; (x < int(strlen(fn))) && !icase_equals(&(fn[x]),".PLT"); x++) {
-    sname[x - xx] = fn[x];
-    sname[x - xx + 1] = 0;
-  }
+  const auto sname = fs::path(fn).stem().string();
   tmpSurvey = this->NewSurvey();
-  tmpSurvey->m_namePtr = this->m_surveysData.AppendStr(sname);
-  delete [] sname;
+  tmpSurvey->m_namePtr = this->m_surveysData.AppendStr(sname.c_str());
 
   std::string line;
   while (!input.eof()) {
@@ -839,22 +825,9 @@ void lxFile::Import3D(const char * fn)
   stPtrLRUDPrev = NULL;
   bool hasPT = false;
 
-  char * sname = new char [strlen(fn)+1];
-  int x, xx;
-  xx = 0;
-  for (x = (strlen(fn) - 1); x >= 0; x--) {
-    if ((fn[x] == '\\') || (fn[x] == '/')) {
-      xx = x + 1;
-      break;
-    }
-  }
-  for (x = xx; (x < int(strlen(fn))) && !icase_equals(&(fn[x]),".PLT"); x++) {
-    sname[x - xx] = fn[x];
-    sname[x - xx + 1] = 0;
-  }
+  const auto sname = fs::path(fn).stem().string();
   tmpSurvey = this->NewSurvey();
-  tmpSurvey->m_namePtr = this->m_surveysData.AppendStr(sname);
-  delete [] sname;
+  tmpSurvey->m_namePtr = this->m_surveysData.AppendStr(sname.c_str());
 
   std::map<std::string, lxFileStation*> label_map;
   std::map<std::string, lxFileStation*>::iterator lmi;

--- a/src/therion-core/thdata.cxx
+++ b/src/therion-core/thdata.cxx
@@ -1764,9 +1764,9 @@ void thdata::insert_data_leg(int nargs, char ** args)
         break;
         
       case TT_DATALEG_DIRECTION:
-        if (icase_equals(args[carg],"b"))
+        if (icase_equal{}(args[carg], "b"))
           this->cd_leg->direction = false;
-        else if (!icase_equals(args[carg], "f"))
+        else if (!icase_equal{}(args[carg], "f"))
           throw thexception(fmt::format("invalid survey direction -- {}", args[carg]));
         break;
         

--- a/src/therion-core/thexport.cxx
+++ b/src/therion-core/thexport.cxx
@@ -253,7 +253,7 @@ void thexport::register_output(std::string fnm) {
 
 void thexport::set_format_by_extension(std::string_view extension, const int cformat)
 {
-  if (icase_equals(std::filesystem::path(this->outpt).extension().string(), extension)) {
+  if (icase_equal{}(std::filesystem::path(this->outpt).extension().string(), extension)) {
     this->format = cformat;
   }
 }

--- a/src/therion-core/thimport.cxx
+++ b/src/therion-core/thimport.cxx
@@ -224,13 +224,13 @@ void thimport::set_file_name(char * fnm)
   this->fname = this->db->strstore(impf_path_str.c_str());
 
   const auto ext = impf_path.extension().string();
-  for (const auto& [str, type] : {std::tuple{".3d", TT_IMPORT_FMT_3D}, 
-                                  std::tuple{".plt", TT_IMPORT_FMT_PLT}, 
-                                  std::tuple{".xyz", TT_IMPORT_FMT_XYZ}}) {
-    if (icase_equals(ext, str)) {
-      this->format = type;
-      return;
-    }
+  static const std::map<std::string, int, icase_less> extensions{
+    {".3d", TT_IMPORT_FMT_3D},
+    {".plt", TT_IMPORT_FMT_PLT},
+    {".xyz", TT_IMPORT_FMT_XYZ}};
+  if (auto it = extensions.find(ext); it != extensions.end())
+  {
+    this->format = it->second;
   }
 }
 

--- a/src/therion-core/thinit.cxx
+++ b/src/therion-core/thinit.cxx
@@ -279,7 +279,7 @@ void thinit::check_font_path(const char * fname, int index) {
   }
 
   // checkne ci TTF
-  if ((l > 3) && icase_equals(&(buff[l-4]), ".ttf")) ENC_NEW.t1_convert = 0;
+  if ((l > 3) && icase_equal{}(&(buff[l-4]), ".ttf")) ENC_NEW.t1_convert = 0;
 
   font_src[index] = pfull.c_str();
   font_dst[index] = pshort.c_str();

--- a/src/therion-core/thparse.cxx
+++ b/src/therion-core/thparse.cxx
@@ -47,18 +47,16 @@
 
 thmbuffer thparse_mbuff;
 
-template <typename Equality, typename Ordering>
-int binary_search_token(std::string_view token, std::span<const thstok> tab, Equality equality, Ordering ordering)
+template <typename Comparator>
+int binary_search_token(std::string_view token, std::span<const thstok> tab, Comparator cmp)
 {
   if (tab.empty())
     throw thexception(fmt::format("empty lookup table when searching for token '{}'", token));
 
-  // comparator between thstok and string_view
-  auto compare_thstok = [&ordering](const thstok& a, std::string_view b){ return ordering(a.s, b); };
   // binary search, we leave out the last item
-  auto it = std::lower_bound(tab.begin(), std::prev(tab.end()), token, compare_thstok);
-  // if bound was found we also need to compare for equality
-  if (it != std::prev(tab.end()) && equality(token, it->s))
+  auto it = std::ranges::lower_bound(tab.begin(), std::prev(tab.end()), token, cmp, &thstok::s);
+  // if bound was found we also need to use comparator to determine equality
+  if (it != std::prev(tab.end()) && !cmp(token, it->s))
     return it->tok;
   // last item contains default value
   return tab.back().tok;
@@ -66,13 +64,13 @@ int binary_search_token(std::string_view token, std::span<const thstok> tab, Equ
 
 int thmatch_token(std::string_view token, std::span<const thstok> tab)
 {
-  return binary_search_token(token, tab, std::equal_to<std::string_view>(), std::less<std::string_view>());
+  return binary_search_token(token, tab, std::less<>{});
 }
 
 
 int thcasematch_token(std::string_view token, std::span<const thstok> tab)
 {
-  return binary_search_token(token, tab, icase_equals, icase_less_than);
+  return binary_search_token(token, tab, icase_less{});
 }
 
 

--- a/tests/utest-str.cxx
+++ b/tests/utest-str.cxx
@@ -11,29 +11,30 @@
 
 using namespace std::string_literals;
 
-TEST_CASE("icase_equals")
+TEST_CASE("icase_equal")
 {
+    const icase_equal comparator;
+    REQUIRE(comparator("", ""));
+    REQUIRE(comparator("hello", "hello"));
+    REQUIRE(comparator("hello", "HELLO"s));
+    REQUIRE(comparator("hElLo"s, "HELLO"));
+    REQUIRE(comparator("HeLlo"s, "hello"s));
 
-    REQUIRE(icase_equals("", ""));
-    REQUIRE(icase_equals("hello", "hello"));
-    REQUIRE(icase_equals("hello", "HELLO"s));
-    REQUIRE(icase_equals("hElLo"s, "HELLO"));
-    REQUIRE(icase_equals("HeLlo"s, "hello"s));
-
-    REQUIRE_FALSE(icase_equals("hello", "world"));
-    REQUIRE_FALSE(icase_equals("hello", "world!"));
-    REQUIRE_FALSE(icase_equals("hello"s, "WORLD"s));
+    REQUIRE_FALSE(comparator("hello", "world"));
+    REQUIRE_FALSE(comparator("hello", "world!"));
+    REQUIRE_FALSE(comparator("hello"s, "WORLD"s));
 }
 
-TEST_CASE("icase_less_than")
+TEST_CASE("icase_less")
 {
-    REQUIRE(icase_less_than("hello", "world"));
-    REQUIRE(icase_less_than("hello", "World"));
-    REQUIRE(icase_less_than("Hello", "world"));
-    REQUIRE(icase_less_than("Hello", "World"));
-    REQUIRE_FALSE(icase_less_than("hello", "aworld"s));
-    REQUIRE_FALSE(icase_less_than("hello"s, "HELLO"));
-    REQUIRE_FALSE(icase_less_than("HELLO"s, "hello"s));
+    const icase_less comparator;
+    REQUIRE(comparator("hello", "world"));
+    REQUIRE(comparator("hello", "World"));
+    REQUIRE(comparator("Hello", "world"));
+    REQUIRE(comparator("Hello", "World"));
+    REQUIRE_FALSE(comparator("hello", "aworld"s));
+    REQUIRE_FALSE(comparator("hello"s, "HELLO"));
+    REQUIRE_FALSE(comparator("HELLO"s, "hello"s));
 }
 
 TEST_CASE("thstok")


### PR DESCRIPTION
I have recently simplified implementation of the case insensitive comparison functions, but we can do better. We can refactor them into comparators compatible with the STL, to make it easier to use them with standard containers and algorithms.

Please check the simplifications in `lxFile.cxx`, I think we don't need to compare the file extension there.