### PR TITLE
Install missing dependency nlohmann::json

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -121,6 +121,7 @@ jobs:
             mingw-w64-${{ matrix.config.arch }}-fmt
             mingw-w64-${{ matrix.config.arch }}-catch
             mingw-w64-${{ matrix.config.arch }}-imagemagick
+            mingw-w64-${{ matrix.config.arch }}-nlohmann-json
       - run: mkdir build && cd build && cmake -G "MSYS Makefiles" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_THBOOK=OFF ${{ matrix.config.args }} ..
       - run: cmake --build build -t therion loch utest -- -j 4
       - name: Set up the batteries

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -22,7 +22,24 @@ jobs:
         with:
           msystem: ${{ matrix.config.msystem }}
           update: true
-          install: make git python mingw-w64-${{ matrix.config.arch }}-freetype mingw-w64-${{ matrix.config.arch }}-cmake mingw-w64-${{ matrix.config.arch }}-proj mingw-w64-${{ matrix.config.arch }}-shapelib mingw-w64-${{ matrix.config.arch }}-vtk mingw-w64-${{ matrix.config.arch }}-wxwidgets3.2-gtk3 mingw-w64-${{ matrix.config.arch }}-wxwidgets3.2-msw mingw-w64-${{ matrix.config.arch }}-gcc mingw-w64-${{ matrix.config.arch }}-make mingw-w64-${{ matrix.config.arch }}-bwidget mingw-w64-${{ matrix.config.arch }}-fmt mingw-w64-${{ matrix.config.arch }}-catch mingw-w64-${{ matrix.config.arch }}-imagemagick
+          install: >
+            make
+            git
+            python
+            mingw-w64-${{ matrix.config.arch }}-freetype
+            mingw-w64-${{ matrix.config.arch }}-cmake
+            mingw-w64-${{ matrix.config.arch }}-proj
+            mingw-w64-${{ matrix.config.arch }}-shapelib
+            mingw-w64-${{ matrix.config.arch }}-vtk
+            mingw-w64-${{ matrix.config.arch }}-wxwidgets3.2-gtk3
+            mingw-w64-${{ matrix.config.arch }}-wxwidgets3.2-msw
+            mingw-w64-${{ matrix.config.arch }}-gcc
+            mingw-w64-${{ matrix.config.arch }}-make
+            mingw-w64-${{ matrix.config.arch }}-bwidget
+            mingw-w64-${{ matrix.config.arch }}-fmt
+            mingw-w64-${{ matrix.config.arch }}-catch
+            mingw-w64-${{ matrix.config.arch }}-imagemagick
+            mingw-w64-${{ matrix.config.arch }}-nlohmann-json
       - name: prevent git EOL conversion
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v6


### PR DESCRIPTION
Install missing dependency `nlohmann::json` required by VTK on Windows.