### PR TITLE
THBook: including new ImageMagick dependency on Fedora instructions

### DIFF
--- a/thbook/ch06.tex
+++ b/thbook/ch06.tex
@@ -96,7 +96,7 @@ Installing dependencies on {\bf Ubuntu 26.04}:
   |zlib1g-dev|
 \par}
 
-Installing dependencies in {\bf Fedora 37}:
+Installing dependencies in {\bf Fedora 44}:
 
 {\rightskip 0pt plus 3cm
   |sudo dnf install|
@@ -106,6 +106,7 @@ Installing dependencies in {\bf Fedora 37}:
   |cmake|
   |fmt-devel|
   |g++|
+  |ImageMagick-c++-devel|
   |jbigkit-devel|
   |krb5-devel|
   |libidn2-devel|
@@ -549,7 +550,7 @@ XTherion starts. The file is commented; see the comments for details.
 \subchapter Limitations.
 
 \list
-*  scrap size = 
+*  scrap size =
 
    \MP\ in the default (`scaled') mode: $\approx 2.8 \times 2.8$ m in the output scale
 


### PR DESCRIPTION
Recently Therion started dependeing on ImageMagick.

This PR includes ImageMagick dependency on Fedora instructions.