### PR TITLE
Explicit exception for thparse_image("")

### DIFF
--- a/src/therion-core/thparse.cxx
+++ b/src/therion-core/thparse.cxx
@@ -946,6 +946,10 @@ void thparse_image(const char * fname, double & width, double & height, double &
   height = 0.0;
   dpi = 300.0;
 
+  if (!fname || !*fname) {
+    throw thexception("image file name is empty");
+  }
+
   try {
     const Magick::Image image(fname);
     const auto format = image.magick();


### PR DESCRIPTION
No implicit exception observed on Arch Linux and macOS, test hangs.