### PR TITLE
fix: quote paths in therion.ini install code

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ loch:
  * added presentation animation mode and export
  * added walker mode
 
+infrastructure and compiler:
+ * fixed installation when the source or destination path contains spaces
+
 --------------------------------------------------------------------------------
 
 Therion 6.4.0 (2026-05-07):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ if (BUILD_THERION)
     install(TARGETS therion RUNTIME COMPONENT th-runtime)
     install(FILES therion.ini TYPE SYSCONF RENAME therion.ini.new COMPONENT th-runtime)
     install(CODE
-        "if (NOT EXISTS ${TH_PATH_INI}/therion.ini)
-            file(INSTALL ${CMAKE_CURRENT_SOURCE_DIR}/therion.ini DESTINATION ${TH_PATH_INI})
+        "if (NOT EXISTS \"${TH_PATH_INI}/therion.ini\")
+            file(INSTALL \"${CMAKE_CURRENT_SOURCE_DIR}/therion.ini\" DESTINATION \"${TH_PATH_INI}\")
         endif()"
         COMPONENT th-runtime)
 


### PR DESCRIPTION
## Problem

Installing Therion fails when the source directory path contains a space:

```
CMake Error at build/cmake_install.cmake:64 (file):
  file INSTALL cannot find "/Users/name/My Projects/Therion": No such file or
  directory
```

The `install(CODE ...)` block in `CMakeLists.txt` interpolates
`CMAKE_CURRENT_SOURCE_DIR` and `TH_PATH_INI` into generated CMake code without
quoting them:

```cmake
install(CODE
    "if (NOT EXISTS ${TH_PATH_INI}/therion.ini)
        file(INSTALL ${CMAKE_CURRENT_SOURCE_DIR}/therion.ini DESTINATION ${TH_PATH_INI})
    endif()"
    COMPONENT th-runtime)
```

Once expanded, the generated `cmake_install.cmake` contains an unquoted path, so
`file(INSTALL ...)` splits it into several arguments and aborts.

The neighbouring `install(FILES therion.ini ...)` call on the previous line is
unaffected, because CMake quotes the path itself when it generates the install
script. Only the hand-written code block is exposed.

The failure happens at the very end of a full build, which makes it more
annoying than its size suggests. Directories with spaces are common on macOS and
Windows.

## Fix

Quote both paths inside the generated code. Two lines.

## Reproduction

```bash
mkdir -p "/tmp/with space" && cd "/tmp/with space"
git clone https://github.com/therion/therion.git && cd therion
cmake -S . -B build -G Ninja -DUSE_BUNDLED_CATCH2=ON \
      -DBUILD_LOCH=OFF -DBUILD_XTHERION=OFF -DBUILD_THBOOK=OFF \
      -DCMAKE_INSTALL_PREFIX=/tmp/prefix
cmake --build build -t therion
cmake --install build      # fails before the fix, succeeds after
```

## Verification

Built from a source path containing a space and installed into a clean prefix,
on macOS 15 / arm64 with CMake and Ninja:

- before the change: install aborts at `cmake_install.cmake:64`, `therion.ini`
  is not installed;
- after the change: install completes with no errors and produces
  `bin/therion`, `etc/therion.ini`, and `etc/therion.ini.new`.

Also confirmed that a path without spaces behaves exactly as before.

`CHANGES` updated under `infrastructure and compiler`. No `thbook` change: this
is a build-system fix with no user-visible behaviour change.
