### PR TITLE
Deploy missing ImageMagick DLLs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -121,6 +121,7 @@ jobs:
             mingw-w64-${{ matrix.config.arch }}-fmt
             mingw-w64-${{ matrix.config.arch }}-catch
             mingw-w64-${{ matrix.config.arch }}-imagemagick
+            mingw-w64-${{ matrix.config.arch }}-libjxl
             mingw-w64-${{ matrix.config.arch }}-nlohmann-json
       - run: mkdir build && cd build && cmake -G "MSYS Makefiles" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBUILD_THBOOK=OFF ${{ matrix.config.args }} ..
       - run: cmake --build build -t therion loch utest -- -j 4

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -39,6 +39,7 @@ jobs:
             mingw-w64-${{ matrix.config.arch }}-fmt
             mingw-w64-${{ matrix.config.arch }}-catch
             mingw-w64-${{ matrix.config.arch }}-imagemagick
+            mingw-w64-${{ matrix.config.arch }}-libjxl
             mingw-w64-${{ matrix.config.arch }}-nlohmann-json
       - name: prevent git EOL conversion
         run: git config --global core.autocrlf input

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,12 +144,13 @@ if (BUILD_LOCH)
 endif()
 
 # deployment of DLL dependencies on Windows
-if (BUILD_THERION AND BUILD_LOCH AND WIN32)
+if (BUILD_THERION AND BUILD_LOCH AND MSYS)
     set(DLLS_DIR ${CMAKE_BINARY_DIR}/dependencies)
     add_custom_target(deploy 
         ${CMAKE_COMMAND} -D THERION=$<TARGET_FILE:therion>
                          -D LOCH=$<TARGET_FILE:loch>
                          -D DLLS_DIR=${DLLS_DIR}
+                         -D ImageMagick_VERSION=${ImageMagick_VERSION_STRING}
                          -P cmake/Deploy.cmake
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
     set_target_properties(deploy PROPERTIES ADDITIONAL_CLEAN_FILES ${DLLS_DIR})

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -7,6 +7,7 @@ string(REGEX MATCH "^[^-]+" ImageMagick_VERSION "${ImageMagick_VERSION}")
 set(ImageMagick_CODERS_PREFIX "$ENV{MSYSTEM_PREFIX}/lib/ImageMagick-${ImageMagick_VERSION}/modules-Q16HDRI/coders")
 set(ImageMagick_CODERS
     "${ImageMagick_CODERS_PREFIX}/gif.dll"
+    "${ImageMagick_CODERS_PREFIX}/heic.dll"
     "${ImageMagick_CODERS_PREFIX}/jpeg.dll"
     "${ImageMagick_CODERS_PREFIX}/jxl.dll"
     "${ImageMagick_CODERS_PREFIX}/png.dll"
@@ -14,6 +15,7 @@ set(ImageMagick_CODERS
 )
 set(ImageMagick_DESCRIPTORS
     "${ImageMagick_CODERS_PREFIX}/gif.la"
+    "${ImageMagick_CODERS_PREFIX}/heic.la"
     "${ImageMagick_CODERS_PREFIX}/jpeg.la"
     "${ImageMagick_CODERS_PREFIX}/jxl.la"
     "${ImageMagick_CODERS_PREFIX}/png.la"

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -12,6 +12,13 @@ set(ImageMagick_CODERS
     "${ImageMagick_CODERS_PREFIX}/png.dll"
     "${ImageMagick_CODERS_PREFIX}/webp.dll"
 )
+set(ImageMagick_DESCRIPTORS
+    "${ImageMagick_CODERS_PREFIX}/gif.la"
+    "${ImageMagick_CODERS_PREFIX}/jpeg.la"
+    "${ImageMagick_CODERS_PREFIX}/jxl.la"
+    "${ImageMagick_CODERS_PREFIX}/png.la"
+    "${ImageMagick_CODERS_PREFIX}/webp.la"
+)
 
 # silence warnings about normalizing paths
 cmake_policy(SET CMP0207 NEW)
@@ -27,7 +34,7 @@ file(GET_RUNTIME_DEPENDENCIES
 
 file(MAKE_DIRECTORY ${DLLS_DIR})
 
-foreach(DLL ${DLLS} ${ImageMagick_CODERS})
-    message("Copying dependency: ${DLL}")
-    file(COPY ${DLL} DESTINATION ${DLLS_DIR})
+foreach(DEP ${DLLS} ${ImageMagick_CODERS} ${ImageMagick_DESCRIPTORS})
+    message("Copying dependency: ${DEP}")
+    file(COPY ${DEP} DESTINATION ${DLLS_DIR})
 endforeach()

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -1,6 +1,24 @@
 # Find all DLL dependencies to deploy on Windows.
+
+# remove addendum release number from the ImageMagick version
+string(REGEX MATCH "^[^-]+" ImageMagick_VERSION "${ImageMagick_VERSION}")
+
+# list additional ImageMagick coders we want to deploy
+set(ImageMagick_CODERS_PREFIX "$ENV{MSYSTEM_PREFIX}/lib/ImageMagick-${ImageMagick_VERSION}/modules-Q16HDRI/coders")
+set(ImageMagick_CODERS
+    "${ImageMagick_CODERS_PREFIX}/gif.dll"
+    "${ImageMagick_CODERS_PREFIX}/jpeg.dll"
+    "${ImageMagick_CODERS_PREFIX}/jxl.dll"
+    "${ImageMagick_CODERS_PREFIX}/png.dll"
+    "${ImageMagick_CODERS_PREFIX}/webp.dll"
+)
+
+# silence warnings about normalizing paths
+cmake_policy(SET CMP0207 NEW)
+
 file(GET_RUNTIME_DEPENDENCIES
     EXECUTABLES ${THERION} ${LOCH}
+    LIBRARIES ${ImageMagick_CODERS}
     RESOLVED_DEPENDENCIES_VAR DLLS
     PRE_EXCLUDE_REGEXES "^api-ms-" "^ext-ms-"
     POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
@@ -9,7 +27,7 @@ file(GET_RUNTIME_DEPENDENCIES
 
 file(MAKE_DIRECTORY ${DLLS_DIR})
 
-foreach(DLL ${DLLS})
+foreach(DLL ${DLLS} ${ImageMagick_CODERS})
     message("Copying dependency: ${DLL}")
     file(COPY ${DLL} DESTINATION ${DLLS_DIR})
 endforeach()

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -85,7 +85,7 @@ int main(int argc, char * argv[]) {
     thexecute_cmd = argv[0];
 
     // initialize ImageMagick library
-    putenv(fmt::format("MAGICK_CODER_MODULE_PATH={}", std::filesystem::path(argv[0]).parent_path()).c_str());
+    putenv(fmt::format("MAGICK_CODER_MODULE_PATH={}", std::filesystem::path(argv[0]).parent_path().string()).c_str());
     Magick::InitializeMagick(*argv);
   
     // process command line

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -43,6 +43,7 @@
 
 #include <fmt/format.h>
 
+#include <filesystem>
 #include <fstream>
 
 extern const thstok thtt_texts [];
@@ -84,6 +85,7 @@ int main(int argc, char * argv[]) {
     thexecute_cmd = argv[0];
 
     // initialize ImageMagick library
+    putenv(fmt::format("MAGICK_CODER_MODULE_PATH={}", std::filesystem::path(argv[0]).parent_path()).c_str());
     Magick::InitializeMagick(*argv);
   
     // process command line

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -85,7 +85,9 @@ int main(int argc, char * argv[]) {
     thexecute_cmd = argv[0];
 
     // initialize ImageMagick library
+#ifdef THWIN32
     putenv(fmt::format("MAGICK_CODER_MODULE_PATH={}", std::filesystem::path(argv[0]).parent_path().string()).c_str());
+#endif
     Magick::InitializeMagick(*argv);
   
     // process command line

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -39,6 +39,8 @@
 #include "thdatabase.h"
 #include "thlog.h"
 
+#include <Magick++/Functions.h>
+
 #include <fmt/format.h>
 
 #include <fstream>
@@ -80,6 +82,9 @@ int main(int argc, char * argv[]) {
 
     // set some system parameters
     thexecute_cmd = argv[0];
+
+    // initialize ImageMagick library
+    Magick::InitializeMagick(*argv);
   
     // process command line
     thcmdln.process(argc, argv);

--- a/therion-main.cxx
+++ b/therion-main.cxx
@@ -86,7 +86,12 @@ int main(int argc, char * argv[]) {
 
     // initialize ImageMagick library
 #ifdef THWIN32
-    putenv(fmt::format("MAGICK_CODER_MODULE_PATH={}", std::filesystem::path(argv[0]).parent_path().string()).c_str());
+    // detect deployed ImageMagick DLLs
+    if (const auto exe_dir = std::filesystem::path(argv[0]).parent_path();
+        std::filesystem::exists(exe_dir / "jpeg.dll") && std::filesystem::exists(exe_dir / "jpeg.la"))
+    {
+      putenv(fmt::format("MAGICK_CODER_MODULE_PATH={}", exe_dir.string()).c_str());
+    }
 #endif
     Magick::InitializeMagick(*argv);
   


### PR DESCRIPTION
Install ImageMagick coders for image formats JPEG, JPEG XL, GIF, PNG, WebP, and HEIF.